### PR TITLE
Namespace support

### DIFF
--- a/.github/workflows/beeai-build.yml
+++ b/.github/workflows/beeai-build.yml
@@ -14,6 +14,7 @@ on:
     branches:
       - main
       - tekton-pod-cleanup
+      - namespace-support
     paths:
       - 'beeai/**'
   pull_request:

--- a/beeai/internal/controller/agentbuild_controller.go
+++ b/beeai/internal/controller/agentbuild_controller.go
@@ -320,7 +320,7 @@ func (r *AgentBuildReconciler) createPipelineRun(ctx context.Context, agentBuild
 		ObjectMeta: metav1.ObjectMeta{
 
 			Name:      pipelineRunName,
-			Namespace: "default",
+			Namespace: agentBuild.Namespace,
 		},
 		Spec: tektonv1.PipelineRunSpec{
 			PipelineSpec: &tektonv1.PipelineSpec{

--- a/beeai/internal/controller/agentbuild_controller.go
+++ b/beeai/internal/controller/agentbuild_controller.go
@@ -294,7 +294,7 @@ func (r *AgentBuildReconciler) createPipelineRun(ctx context.Context, agentBuild
 			"pipelineRunName", agentBuild.Status.PipelineRunName)
 		return ctrl.Result{}, err
 	}
-	logger.Info("createPipelineRun", "created push secret", pushRepoSecret)
+	logger.Info("- createPipelineRun", "created push secret", pushRepoSecret)
 
 	pipelineRunName := fmt.Sprintf("%s-%s", agentBuild.Name, generateShortUID())
 	pv, err := r.createPersistentVolume(ctx, agentBuild, pipelineRunName, "5Gi", "ReadWriteOnce", "/mnt/data")


### PR DESCRIPTION
Currently Tekton pipeline always runs in a default NS. Remove hardcoded NS assignment and instead use the namespace of the AgentBuild CR.