### PR TITLE
fix: update alpine image to avoid dockerhub rate limiting

### DIFF
--- a/beeai/internal/controller/agentbuild_controller.go
+++ b/beeai/internal/controller/agentbuild_controller.go
@@ -383,7 +383,7 @@ func (r *AgentBuildReconciler) createPipelineRun(ctx context.Context, agentBuild
 								Steps: []tektonv1.Step{
 									{
 										Name:  "check-dir",
-										Image: "alpine:latest",
+										Image: "public.ecr.aws/docker/library/alpine:latest",
 										Command: []string{
 											"sh", "-c",
 										},


### PR DESCRIPTION
update alpine image to avoid dockerhub rate limiting