### PR TITLE
add pod grace period to be able to debug pod failure

### DIFF
--- a/platform-operator/config/rbac/role.yaml
+++ b/platform-operator/config/rbac/role.yaml
@@ -10,8 +10,6 @@ rules:
   - configmaps
   - secrets
   - services
-  - persistentvolumeclaims
-  - pods
   verbs:
   - create
   - delete
@@ -36,7 +34,6 @@ rules:
   - kagenti.operator.dev
   resources:
   - components
-  - platforms
   verbs:
   - create
   - delete
@@ -49,33 +46,13 @@ rules:
   - kagenti.operator.dev
   resources:
   - components/finalizers
-  - platforms/finalizers
   verbs:
   - update
 - apiGroups:
   - kagenti.operator.dev
   resources:
   - components/status
-  - platforms/status
   verbs:
   - get
   - patch
   - update
-- apiGroups:
-  - tekton.dev
-  resources:
-  - pipelineruns
-  - pipelines
-  - clustertasks
-  - customruns
-  - stepactions
-  - taskruns
-  - tasks
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch   

--- a/platform-operator/config/samples/agent-component.yaml
+++ b/platform-operator/config/samples/agent-component.yaml
@@ -89,9 +89,18 @@ spec:
       serviceType: "ClusterIP"
 
     env:
+#      - name: LLM_MODEL
+#        value: "llama3.2:3b-instruct-fp16"
+#      - name: LLM_URL
+#        value: "http://llm-service:11434"
+      - name: HOST
+        value: "0.0.0.0"  
+      - name: LLM_API_BASE
+        value: "http://host.docker.internal:11434/v1"
+      - name: LLM_API_KEY
+        value: "dummy"  
       - name: LLM_MODEL
-        value: "llama3.2:70b"
-      - name: LLM_URL
-        value: "http://llm-service:11434"
+        value: "llama3.2:3b-instruct-fp16"
+
 
  

--- a/platform-operator/internal/deployer/kubernetes/kubernetes.go
+++ b/platform-operator/internal/deployer/kubernetes/kubernetes.go
@@ -180,7 +180,7 @@ func (d *KubernetesDeployer) createDeployment(ctx context.Context, component *pl
 		kubeSpec.ImageSpec.Image,
 		kubeSpec.ImageSpec.ImageTag,
 	)
-
+	gracePeriodSeconds := int64(300)
 	deployment := &appsv1.Deployment{
 
 		ObjectMeta: metav1.ObjectMeta{
@@ -211,6 +211,7 @@ func (d *KubernetesDeployer) createDeployment(ctx context.Context, component *pl
 							Ports:           containerPorts,
 						},
 					},
+					TerminationGracePeriodSeconds: &gracePeriodSeconds,
 				},
 			},
 		},


### PR DESCRIPTION
Agent pod fails during deployment. Add grace period to be able to interrigate the pod status.
## Summary

## Related issue(s)

Fixes #
