### PR TITLE
🐛 Prevent Component from trying to own a CRD

### DIFF
--- a/platform-operator/config/samples/components-example.yaml
+++ b/platform-operator/config/samples/components-example.yaml
@@ -37,8 +37,11 @@ spec:
       manifest:
         github:
            repository: https://github.com/kagenti/kagenti
-           path: kagenti/installer/src/resources/phoenix.yaml
+           path: kagenti/installer/app/resources/phoenix.yaml
            revision: main
+           authSecretRef:
+             name: github-token-secret
+
     env:
 ---
 


### PR DESCRIPTION
When a component deploys from a yaml assembly, some objects can actually be CRDs. To support garbage collection the Component tries to set ownership of objects it applies to k8s. If the object happens to be a CRD, setting of ownership fails since the Component is a namespaced object. 
Modify code to skip CRDs when assigning ownership. 

## Summary

## Related issue(s)

Fixes #
