### PR TITLE
🐛 Fetch tekton steps from cm in kagenti-system

### DIFF
--- a/platform-operator/internal/builder/tekton/pipeline-composer.go
+++ b/platform-operator/internal/builder/tekton/pipeline-composer.go
@@ -112,7 +112,7 @@ func (pc *PipelineComposer) loadSteps(ctx context.Context, component *platformv1
 		configMap := &corev1.ConfigMap{}
 		err := pc.client.Get(ctx, types.NamespacedName{
 			Name:      stepSpec.ConfigMap,
-			Namespace: component.Namespace,
+			Namespace: "kagenti-system",
 		}, configMap)
 
 		if err != nil {

--- a/platform-operator/internal/webhook/v1alpha1/component_webhook.go
+++ b/platform-operator/internal/webhook/v1alpha1/component_webhook.go
@@ -128,7 +128,7 @@ func (d *ComponentCustomDefaulter) processPipelineConfig(ctx context.Context, co
 	}
 
 	// Load pipeline template from ConfigMap
-	template, err := d.getPipelineTemplate(ctx, mode, component.Namespace)
+	template, err := d.getPipelineTemplate(ctx, mode, "kagenti-system")
 	if err != nil {
 		return fmt.Errorf("failed to get pipeline template for mode %s: %w", mode, err)
 	}


### PR DESCRIPTION
Allow Component CR to run in the same namespace as agent or tool. Modified tekton component to fetch tekton steps defined in configMaps from kagenti-system namespace.

## Summary

## Related issue(s)

Fixes #
