### PR TITLE
❇️ create rbac per component

### DIFF
--- a/charts/platform-operator/templates/crd/kagenti.operator.dev_components.yaml
+++ b/charts/platform-operator/templates/crd/kagenti.operator.dev_components.yaml
@@ -15,15 +15,17 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     - jsonPath: .spec.suspend
       name: Suspend
       type: boolean
     - jsonPath: .status.conditions[?(@.type=='Ready')].status
-      name: READY
+      name: Ready
+      priority: 1
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      priority: 2
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/charts/platform-operator/templates/rbac/role.yaml
+++ b/charts/platform-operator/templates/rbac/role.yaml
@@ -47,6 +47,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: 
+  - clusterroles
+  - clusterrolebindings
+  - roles
+  - rolebindings
+  - serviceaccounts
+  verbs: ["*"]  
 - apiGroups:
   - apps
   resources:

--- a/platform-operator/api/v1alpha1/component_types.go
+++ b/platform-operator/api/v1alpha1/component_types.go
@@ -436,9 +436,9 @@ type ComponentDeploymentStatus struct {
 	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
 }
 
-// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
-//+kubebuilder:printcolumn:name="Suspend",type=boolean,JSONPath=`.spec.suspend`
-//+kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
+// +kubebuilder:printcolumn:name="Suspend",type="boolean",JSONPath=".spec.suspend",priority=0
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status",priority=1
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",priority=2
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 

--- a/platform-operator/cmd/main.go
+++ b/platform-operator/cmd/main.go
@@ -229,6 +229,7 @@ func main() {
 			HelmDeployer: helm.NewHelmDeployer(mgr.GetClient(), ctrl.Log.WithName("deployers").WithName("HelmDeployer"), mgr.GetScheme()),
 			OLMDeployer:  olm.NewOLMDeployer(mgr.GetClient(), ctrl.Log.WithName("deployers").WithName("OLMDeployer"), mgr.GetScheme()),
 		},
+		RBACManager: kubernetes.NewRBACManager(mgr.GetClient(), mgr.GetScheme()),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Component")
 		os.Exit(1)

--- a/platform-operator/config/crd/bases/kagenti.operator.dev_components.yaml
+++ b/platform-operator/config/crd/bases/kagenti.operator.dev_components.yaml
@@ -15,15 +15,17 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     - jsonPath: .spec.suspend
       name: Suspend
       type: boolean
     - jsonPath: .status.conditions[?(@.type=='Ready')].status
-      name: READY
+      name: Ready
+      priority: 1
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      priority: 2
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/platform-operator/config/samples/agent.yaml
+++ b/platform-operator/config/samples/agent.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kagenti
+---
+apiVersion: kagenti.operator.dev/v1alpha1
+kind: Component
+metadata:
+  name: research-agent
+  namespace: kagenti
+
+spec:
+  description: "A research agent for information gathering"
+  suspend: false
+  agent:
+    # Optional build specification for building from source
+    build:
+      mode: dev
+      pipeline:
+        parameters:
+          - name: github-token-secret
+            value: "github-credentials"  
+          - name: repo-url
+            value: "github.com/kagenti/agent-examples.git"
+          - name: revision
+            value: "main"
+          - name: subfolder-path
+            value: "acp/acp_ollama_researcher"
+          - name: image
+            value: "registry.cr-system.svc.cluster.local:5000/beai-research-agent:latest"
+      cleanupAfterBuild: true
+ 
+  deployer:
+    name: "my-agent-deployment"
+    namespace: kagenti 
+    deployAfterBuild: true
+    kubernetes:
+      imageSpec:
+        image: "beai-research-agent"
+        imageTag: "latest"
+        imageRegistry: "registry.cr-system.svc.cluster.local:5000"
+        imagePullPolicy: "IfNotPresent"
+      containerPorts:
+        - name: "http"
+          containerPort: 8090
+          protocol: "TCP"
+      servicePorts:
+        - name: "http"
+          port: 8008
+          targetPort: 8090
+          protocol: "TCP"   
+      resources:
+        limits:
+          cpu: "1"
+          memory: "2Gi"
+        requests:
+          cpu: "500m"
+          memory: "1Gi"
+      serviceType: "ClusterIP"
+
+    env:
+      - name: HOST
+        value: "0.0.0.0"  
+      - name: LLM_API_BASE
+        value: "http://host.docker.internal:11434/v1"
+      - name: LLM_API_KEY
+        value: "dummy"  
+      - name: LLM_MODEL
+        value: "llama3.2:3b-instruct-fp16"
+

--- a/platform-operator/internal/controller/component_controller.go
+++ b/platform-operator/internal/controller/component_controller.go
@@ -35,6 +35,7 @@ import (
 	platformv1alpha1 "github.com/kagenti/operator/platform/api/v1alpha1"
 	"github.com/kagenti/operator/platform/internal/builder"
 	"github.com/kagenti/operator/platform/internal/deployer"
+	"github.com/kagenti/operator/platform/internal/deployer/kubernetes"
 )
 
 // ComponentReconciler reconciles a Component object
@@ -44,12 +45,10 @@ type ComponentReconciler struct {
 	Log             logr.Logger
 	Builder         builder.Builder
 	DeployerFactory *deployer.DeployerFactory
+	RBACManager     *kubernetes.RBACManager
 }
 
 const componentFinalizer = "kagenti.operator.dev/finalizer"
-
-// +kubebuilder:printcolumn:name="Suspend",type=boolean,JSONPath=`.spec.suspend`
-// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 
 //+kubebuilder:rbac:groups="",resources=pods;services;configmaps;secrets;serviceaccounts;persistentvolumeclaims;namespaces,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=deployments;replicasets;statefulsets;daemonsets,verbs=get;list;watch;create;update;patch;delete

--- a/platform-operator/internal/deployer/kubernetes/rbac-manager.go
+++ b/platform-operator/internal/deployer/kubernetes/rbac-manager.go
@@ -1,0 +1,228 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	platformv1alpha1 "github.com/kagenti/operator/platform/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	//	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type RBACManager struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+type RBACConfig struct {
+	ServiceAccountName string
+	ClusterRoleName    string
+	BindingName        string
+	Namespace          string
+	Rules              []rbacv1.PolicyRule
+	Labels             map[string]string
+	Annotations        map[string]string
+	OwnerReference     *metav1.OwnerReference
+}
+
+func NewRBACManager(client client.Client, scheme *runtime.Scheme) *RBACManager {
+	return &RBACManager{
+		Client: client,
+		Scheme: scheme,
+	}
+}
+
+func (r *RBACManager) CreateRBACObjects(ctx context.Context, config *RBACConfig, component *platformv1alpha1.Component) error {
+	logger := log.FromContext(ctx)
+	logger.Info("Creating RBAC objects", "serviceAccount", config.ServiceAccountName, "clusterRole", config.ClusterRoleName)
+	if err := r.createServiceAccount(ctx, config, component); err != nil {
+		return fmt.Errorf("Unable to create ServiceAccount: %w", err)
+	}
+	if err := r.createClusterRole(ctx, config, component); err != nil {
+		return fmt.Errorf("Unable to create ClusterRole: %w", err)
+	}
+	if err := r.createClusterRoleBinding(ctx, config, component); err != nil {
+		return fmt.Errorf("Unable to create ClusterRoleBinding: %w", err)
+	}
+	logger.Info("Successfully created all RBAC objects [ServiceAccount, ClusterRole, ClusterRoleBinding]")
+	return nil
+}
+
+func (r *RBACManager) createServiceAccount(ctx context.Context, config *RBACConfig, component *platformv1alpha1.Component) error {
+	logger := log.FromContext(ctx)
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        config.ServiceAccountName,
+			Namespace:   config.Namespace,
+			Labels:      config.Labels,
+			Annotations: config.Annotations,
+		},
+	}
+	if err := controllerutil.SetOwnerReference(component, serviceAccount, r.Scheme); err != nil {
+		return fmt.Errorf("Unable to set owner reference for ServiceAccount: %w", err)
+	}
+	// Try to get existing ServiceAccount
+	existing := &corev1.ServiceAccount{}
+	err := r.Get(ctx, types.NamespacedName{Name: config.ServiceAccountName, Namespace: config.Namespace}, existing)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("Creating ServiceAccount", "name", config.ServiceAccountName, "namespace", config.Namespace)
+			if err := r.Create(ctx, serviceAccount); err != nil {
+				return fmt.Errorf("Unable to create ServiceAccount: %w", err)
+			}
+			logger.Info("ServiceAccount created successfully")
+		} else {
+			return fmt.Errorf("Unable to get ServiceAccount: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *RBACManager) createClusterRole(ctx context.Context, config *RBACConfig, component *platformv1alpha1.Component) error {
+	logger := log.FromContext(ctx)
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        config.ClusterRoleName,
+			Labels:      config.Labels,
+			Annotations: config.Annotations,
+		},
+		Rules: config.Rules,
+	}
+	// Set owner reference if provided (Note: ClusterRole is cluster-scoped, so owner must also be cluster-scoped)
+	if config.OwnerReference != nil && config.OwnerReference.APIVersion != "" {
+		if err := controllerutil.SetOwnerReference(component, clusterRole, r.Scheme); err != nil {
+			logger.Info("Warning: Could not set owner reference for ClusterRole (may be due to scope mismatch)", "error", err)
+		}
+	}
+	// Try to get existing ClusterRole
+	existing := &rbacv1.ClusterRole{}
+	err := r.Get(ctx, types.NamespacedName{Name: config.ClusterRoleName}, existing)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Create new ClusterRole
+			logger.Info("Creating ClusterRole", "name", config.ClusterRoleName)
+			if err := r.Create(ctx, clusterRole); err != nil {
+				return fmt.Errorf("Unable to create ClusterRole: %w", err)
+			}
+			logger.Info("ClusterRole created successfully")
+		} else {
+			return fmt.Errorf("Unable to get ClusterRole: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *RBACManager) createClusterRoleBinding(ctx context.Context, config *RBACConfig, component *platformv1alpha1.Component) error {
+	logger := log.FromContext(ctx)
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        config.BindingName,
+			Labels:      config.Labels,
+			Annotations: config.Annotations,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      config.ServiceAccountName,
+				Namespace: config.Namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     config.ClusterRoleName,
+		},
+	}
+	// Set owner reference if provided (Note: ClusterRoleBinding is cluster-scoped)
+	//	if config.OwnerReference != nil && config.OwnerReference.APIVersion != "" {
+	//		if err := controllerutil.SetOwnerReference(config.OwnerReference, clusterRoleBinding, r.Scheme); err != nil {
+	//			logger.Info("Warning: Could not set owner reference for ClusterRoleBinding (may be due to scope mismatch)", "error", err)
+	//		}
+	//	}
+	existing := &rbacv1.ClusterRoleBinding{}
+	err := r.Get(ctx, types.NamespacedName{Name: config.BindingName}, existing)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Create new ClusterRoleBinding
+			logger.Info("Creating ClusterRoleBinding", "name", config.BindingName)
+			if err := r.Create(ctx, clusterRoleBinding); err != nil {
+				return fmt.Errorf("failed to create ClusterRoleBinding: %w", err)
+			}
+			logger.Info("ClusterRoleBinding created successfully")
+		} else {
+			return fmt.Errorf("Unable to get ClusterRoleBinding: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *RBACManager) DeleteRBACObjects(ctx context.Context, config *RBACConfig) error {
+	logger := log.FromContext(ctx)
+	logger.Info("Deleting RBAC objects", "serviceAccount", config.ServiceAccountName, "clusterRole", config.ClusterRoleName)
+
+	if err := r.deleteClusterRoleBinding(ctx, config.BindingName); err != nil {
+		return fmt.Errorf("Unable to delete ClusterRoleBinding: %w", err)
+	}
+	if err := r.deleteServiceAccount(ctx, config.ServiceAccountName, config.Namespace); err != nil {
+		return fmt.Errorf("Unable to delete ServiceAccount: %w", err)
+	}
+
+	logger.Info("Successfully deleted all RBAC objects [ServiceAccount, ClusterRoleBinding]")
+	return nil
+}
+
+func (r *RBACManager) deleteServiceAccount(ctx context.Context, name, namespace string) error {
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	err := r.Delete(ctx, serviceAccount)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+func (r *RBACManager) deleteClusterRoleBinding(ctx context.Context, name string) error {
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	err := r.Delete(ctx, clusterRoleBinding)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+func GetComponentRBACConfig(namespace, serviceAccountName string, labels map[string]string) *RBACConfig {
+	return &RBACConfig{
+		ServiceAccountName: serviceAccountName,
+		ClusterRoleName:    fmt.Sprintf("%s", serviceAccountName),
+		BindingName:        fmt.Sprintf("%s", serviceAccountName),
+		Namespace:          namespace,
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods", "pods/log", "configmaps", "secrets"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+		},
+		Labels: labels,
+	}
+}

--- a/platform-operator/scripts/cleanup.sh
+++ b/platform-operator/scripts/cleanup.sh
@@ -1,0 +1,5 @@
+helm uninstall kagenti-platform-operator -n kagenti-system
+kubectl delete certificate serving-cert -n kagenti-system
+kubectl delete secret serving-cert -n kagenti-system --ignore-not-found
+kubectl delete certificate metrics-certs -n kagenti-system
+kubectl delete secret metrics-certs -n kagenti-system --ignore-not-found


### PR DESCRIPTION
## Summary
This PR implements automatic RBAC object creation for each Component custom resource instance. When a Component is created, the controller now provisions the necessary Kubernetes RBAC objects to ensure proper permissions for the component's workloads.

###What's Added
For each Component CR, the following RBAC objects are automatically created:

- ServiceAccount - Provides identity for the component's pods

- ClusterRole - Defines the permissions the component needs

- ClusterRoleBinding - Links the ServiceAccount to the ClusterRole

Also modified Deployment to assign the new ServiceAccount to agent/tool pod.

## Related issue(s)

Fixes #
