### PR TITLE
:bug: fix typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 This repository contains Kubernetes operators for managing AI agents. Currently, it includes an operator for BeeAI agents and will eventually include one for Llama-based agent deployments.
 ## Platform Operator
-Thee Platform operator, located in [platform-operator/](platform-operator/) directory, simplifies the deployment of complex applications by managing collections of components through two key Custom Resources: Platform and Component. 
-* **`Comoponent`**: The Component CR represents an individual deployable unit within a platform, with each component being exactly one of three types: Agent (AI/ML applications), Tool (utilities and supporting services), or Infrastructure (databases and foundational services). The Component controller manages the complete lifecycle from build execution through deployment, while the component starts in a suspended state until activated by the Platform controller based on dependency requirements and execution order.
+The Platform operator, located in [platform-operator/](platform-operator/) directory, simplifies the deployment of complex applications by managing collections of components through two key Custom Resources: Platform and Component.
+* **`Component`**: The Component CR represents an individual deployable unit within a platform, with each component being exactly one of three types: Agent (AI/ML applications), Tool (utilities and supporting services), or Infrastructure (databases and foundational services). The Component controller manages the complete lifecycle from build execution through deployment, while the component starts in a suspended state until activated by the Platform controller based on dependency requirements and execution order.
 
-* **`Platform`**: The Platform CR serves as a high-level orchestrator that manages collections of related Component CRs as a cohesive application unit. It defines the execution order and dependency relationships between components, ensuring that infrastructure components are deployed before the applications that depend on them. 
+* **`Platform`**: The Platform CR serves as a high-level orchestrator that manages collections of related Component CRs as a cohesive application unit. It defines the execution order and dependency relationships between components, ensuring that infrastructure components are deployed before the applications that depend on them.
 
-For detailed information about the Platform operator, including its proposal, design, CRD definitions, and implementation details, please refer to the [README.md](platform-operator/READEM.md) in the `platoform-operator` directory.
+For detailed information about the Platform operator, including its proposal, design, CRD definitions, and implementation details, please refer to the [README.md](platform-operator/README.md) in the `platoform-operator` directory.
 
 ## BeeAI Operator
 
@@ -21,4 +21,3 @@ For detailed information about the BeeAI operator, including its proposal, desig
 For installation and usage instructions for the BeeAI operator, please refer to the [INSTALL.md](beeai/INSTALL.md) in the `beeai` directory.
 
 ## Llama Operator
-


### PR DESCRIPTION
## Summary

Fixes a couple of typos in the readme. Also my editor seems to have found and deleted some trailing whitespace.