### PR TITLE
Enable pulling images from private repos

### DIFF
--- a/platform-operator/internal/deployer/kubernetes/kubernetes.go
+++ b/platform-operator/internal/deployer/kubernetes/kubernetes.go
@@ -345,6 +345,11 @@ func (d *KubernetesDeployer) createDeployment(ctx context.Context, component *pl
 						},
 					},
 					TerminationGracePeriodSeconds: &gracePeriodSeconds,
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{
+							Name: "ghcr-secret",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

This PR adds support for deploying containers from private image repos (in github) by allowing the injection of imagePullSecrets into Kubernetes Deployment specs.

Changes:
Updated `kubernetes.go` to accept and attach `imagePullSecrets` to the PodSpec.

## Related issue(s)

Fixes #55 
