### PR TITLE
🐛 The latest version of operator chart is using old crds

### DIFF
--- a/charts/platform-operator/templates/crd/kagenti.operator.dev_components.yaml
+++ b/charts/platform-operator/templates/crd/kagenti.operator.dev_components.yaml
@@ -114,6 +114,8 @@ spec:
                           This will be used to fetch the pipeline template from ConfigMap
                         enum:
                         - dev
+                        - dev-local
+                        - dev-external
                         - preprod
                         - prod
                         - custom
@@ -10848,6 +10850,8 @@ spec:
                           This will be used to fetch the pipeline template from ConfigMap
                         enum:
                         - dev
+                        - dev-local
+                        - dev-external
                         - preprod
                         - prod
                         - custom


### PR DESCRIPTION
## Summary
Recent version of the operator has API changes. There are new crds with these changes however the platform-operator chart was not updated and causes UI failure when deploying agent and tools.

## Related issue(s)

Fixes #72 
