### PR TITLE
✨ update CI to inject correct release version in values.yaml

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -56,10 +56,9 @@ jobs:
       run: |
         chartVersion=$(echo ${{ github.ref_name }} | cut -c 2-)
         chartPackageName="kagenti-platform-operator-chart-${chartVersion}.tgz"
-        cd ${{ env.CHARTS_PATH }}/platform-operator 
+        cd ${{ env.CHARTS_PATH }}/platform-operator
+        sed -i "s/__PLACEHOLDER__/${chartVersion}/g" values.yaml
         helm package . --destination . --version ${chartVersion} --app-version ${chartVersion}
-        ls -l # List files to check the generated filename
-        echo "Chart version: ${chartVersion}" 
         helm push "./${chartPackageName}" oci://${{ env.REGISTRY }}/${{ env.REPO }}        
     
      

--- a/charts/platform-operator/values.yaml
+++ b/charts/platform-operator/values.yaml
@@ -4,7 +4,7 @@ controllerManager:
   container:
     image:
       repository: ghcr.io/kagenti/kagenti-operator/platform-operator
-      tag: 0.2.0-alpha.3
+      tag: __PLACEHOLDER__
     args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Chart had an hardcoded version which when using the chart as dependency in the main Kagenti chart forces to provide two versions (one for the chart, one for the operator tag), which creates potential inconsistencies. This PR ensure that the chart values have the correct tag value from the start, and only chart version should be provided.
