### PR TITLE
🐛 update go in CI to 1.23 to support updated goreleaser

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -25,10 +25,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: v1.22
-
-    - name: Tidy Go Modules
-      run: go mod tidy
+        go-version: v1.23
     
     - name: Delete non-semver tags
       run: 'git tag -d $(git tag -l | grep -v "^v")'


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

After updating gorelaser CI started failing. It looks like go 1.23 is required by goreleaser-action@v6
