### PR TITLE
:bug: Migrate Kaniko Executor to Strimzi Version

### DIFF
--- a/charts/platform-operator/templates/tekton/kaniko-build-step-external.yaml
+++ b/charts/platform-operator/templates/tekton/kaniko-build-step-external.yaml
@@ -28,7 +28,7 @@ data:
         default: "quay-registry-secret"
     steps:
       - name: docker-build
-        image: gcr.io/kaniko-project/executor:v1.9.1
+        image: quay.io/strimzi/kaniko-executor:0.48.0
         args:
           - --dockerfile=$(params.DOCKERFILE)
           - --context=$(workspaces.source.path)/$(params.subfolder-path)

--- a/charts/platform-operator/templates/tekton/kaniko-build-step-local.yaml
+++ b/charts/platform-operator/templates/tekton/kaniko-build-step-local.yaml
@@ -24,7 +24,7 @@ data:
         description: Path to the subfolder to use as build context
     steps:
       - name: docker-build
-        image: gcr.io/kaniko-project/executor:v1.9.1
+        image: quay.io/strimzi/kaniko-executor:0.48.0
         args:
           - --dockerfile=$(params.DOCKERFILE)
           - --context=$(workspaces.source.path)/$(params.subfolder-path)

--- a/charts/platform-operator/templates/tekton/kaniko-build-step.yaml
+++ b/charts/platform-operator/templates/tekton/kaniko-build-step.yaml
@@ -29,7 +29,7 @@ data:
         default: "ghcr-token"
     steps:
       - name: docker-build
-        image: gcr.io/kaniko-project/executor:v1.9.1
+        image: quay.io/strimzi/kaniko-executor:0.48.0
         args:
           - --dockerfile=$(params.DOCKERFILE)
           - --context=$(workspaces.source.path)/$(params.subfolder-path)

--- a/platform-operator/config/tekton/kaniko-build-step.yaml
+++ b/platform-operator/config/tekton/kaniko-build-step.yaml
@@ -29,7 +29,7 @@ data:
         default: "ghcr-token"
     steps:
       - name: docker-build
-        image: gcr.io/kaniko-project/executor:v1.9.1
+        image: quay.io/strimzi/kaniko-executor:0.48.0
         args:
           - --dockerfile=$(params.DOCKERFILE)
           - --context=$(workspaces.source.path)/$(params.subfolder-path)


### PR DESCRIPTION
## Summary
This PR replaces deprecated Kaniko executor image from gcr.io with an alternative due the the GCR shutdown and Kaniko project archival.

## Problem
 As of **October 8, 2025**
- Google Container Registry (gcr.io) has been shut down
- The original Kaniko project (`gcr.io/kaniko-project/executor`) has been archived
- All Tekton pipelines using Kaniko executor (build step) container image are currently failing

## Solution
Migrated to the Strimzi maintained Kaniko fork: `quay.io/strimzi/kaniko-executor:0.48.0` 

## Related issue(s)

Fixes #98 
