### PR TITLE
:sparkles: Remove sidecar injection logic from Agent controller

### DIFF
--- a/kagenti-operator/internal/controller/agent_controller.go
+++ b/kagenti-operator/internal/controller/agent_controller.go
@@ -508,16 +508,6 @@ func (r *AgentReconciler) createDeploymentForAgent(ctx context.Context, agent *a
 	}, nil
 }
 
-func (r *AgentReconciler) containerExists(podTemplateSpec *corev1.PodTemplateSpec, containerName string) bool {
-	for _, container := range podTemplateSpec.Spec.Containers {
-		if container.Name == containerName {
-			return true
-		}
-	}
-
-	return false
-}
-
 func (r *AgentReconciler) volumeExists(podTemplateSpec *corev1.PodTemplateSpec, volumeName string) bool {
 
 	for _, vol := range podTemplateSpec.Spec.Volumes {


### PR DESCRIPTION
# Description

This PR removes sidecar injection code from the Agent controller in kagenti-operator. Sidecar injection is now handled by the mutating admission webhook in kagenti-extensions( see Related issue  kagenti/kagenti-extensions#2 )

## Context

As part of the effort to consolidate duplicate sidecar injection logic, we've moved all injection functionality to a centralized webhook in kagenti-extensions. The Agent controller no longer needs to inject sidecars during reconciliation, as this is now handled automatically at admission time via the webhook.

Fixes #118 
