### PR TITLE
:sparkles: Replace SPIRE HostPath with CSI driver

### DIFF
--- a/platform-operator/internal/deployer/kubernetes/kubernetes.go
+++ b/platform-operator/internal/deployer/kubernetes/kubernetes.go
@@ -329,7 +329,7 @@ func (d *KubernetesDeployer) createDeployment(ctx context.Context, component *pl
 							MountPath: "/etc/spiffe-helper",
 						},
 						{
-							Name:      "spire-agent-socket",
+							Name:      "spiffe-workload-api",
 							MountPath: "/spiffe-workload-api",
 						},
 						SVIDMount,
@@ -424,10 +424,11 @@ func (d *KubernetesDeployer) createDeployment(ctx context.Context, component *pl
 						},
 					},
 					{
-						Name: "spire-agent-socket",
+						Name: "spiffe-workload-api",
 						VolumeSource: corev1.VolumeSource{
-							HostPath: &corev1.HostPathVolumeSource{
-								Path: "/run/spire/agent-sockets",
+							CSI: &corev1.CSIVolumeSource{
+								Driver:   "csi.spiffe.io",
+								ReadOnly: func() *bool { b := true; return &b }(),
 							},
 						},
 					},


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Replacing SPIRE HostPath with CSI driver better suites deployment on OCP

## Related issue(s)

Fixes # https://github.com/kagenti/kagenti/issues/338
