### PR TITLE
🌱 remove fix-permissions init container

### DIFF
--- a/platform-operator/internal/deployer/kubernetes/kubernetes.go
+++ b/platform-operator/internal/deployer/kubernetes/kubernetes.go
@@ -304,16 +304,6 @@ func (d *KubernetesDeployer) createDeployment(ctx context.Context, component *pl
 		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: component.Name,
-			InitContainers: []corev1.Container{
-				{
-					Name:    "fix-permissions",
-					Image:   "busybox:1.36",
-					Command: []string{"sh", "-c", "chmod 0755 /opt"},
-					VolumeMounts: []corev1.VolumeMount{
-						SVIDMount,
-					},
-				},
-			},
 			Containers: []corev1.Container{
 				{
 					Name:            component.Name,


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Th `fix-permissions` initContainer that does chmod 0755 /opt   does NOT work in OpenShift:
```
$ k logs -n team1 a2a-currency-converter-74c7cc85bc-f275w fix-permissions 
chmod: /opt: Operation not permitted
```

The operator not to inject that init container, and I was able to successfully register in Keycloak in OCP:

```
k logs -n team1 a2a-currency-converter-554fb5c7dc-pwzkf kagenti-client-registration 
waiting for SVID
Created Keycloak client "spiffe://localtest.me/ns/team1/sa/a2a-currency-converter": 5ef7d55a-bb36-4eed-bb6a-e8657098752e
Writing secret for client ID: "spiffe://localtest.me/ns/team1/sa/a2a-currency-converter" (internal client ID: "5ef7d55a-bb36-4eed-bb6a-e8657098752e") to file: "/shared/secret.txt"
Successfully retrieved secret for client "a2a-currency-converter".
Secret written to file: "/shared/secret.txt"
Client registration complete. 
```

I tested the same code in kind, and it worked there as well without such init container:

```
(base) $ kubectx 
kind-kagenti
(base) $ k logs -n team1 a2a-contact-extractor-5dbbf7dc64-628jz kagenti-client-registration 
waiting for SVID
Created Keycloak client "spiffe://localtest.me/ns/team1/sa/a2a-contact-extractor": 605cdce0-e83b-4ccb-941a-47048ecebdea
Writing secret for client ID: "spiffe://localtest.me/ns/team1/sa/a2a-contact-extractor" (internal client ID: "605cdce0-e83b-4ccb-941a-47048ecebdea") to file: "/shared/secret.txt"
Successfully retrieved secret for client "a2a-contact-extractor".
Secret written to file: "/shared/secret.txt"
Client registration complete.
```

I tested this patch on a fresh kagenti installed with the old installer on kind:

```
(base) $ kubectl get deployment -n team1 a2a-contact-extractor -o jsonpath='{range .spec.template.spec.initContainers[*]}{@.name}{"\n"}{end}{range .spec.template.spec.containers[*]}{@.name}{"\n"}{end}'
a2a-contact-extractor
spiffe-helper
kagenti-client-registration

(base) $ kubectl logs -n team1 a2a-contact-extractor-869855457b-hkx2q kagenti-client-registration 
waiting for SVID
Created Keycloak client "spiffe://localtest.me/ns/team1/sa/a2a-contact-extractor": 6632c235-48d5-4ee6-8fb4-cc96cf8e36cd
Writing secret for client ID: "spiffe://localtest.me/ns/team1/sa/a2a-contact-extractor" (internal client ID: "6632c235-48d5-4ee6-8fb4-cc96cf8e36cd") to file: "/shared/secret.txt"
Successfully retrieved secret for client "a2a-contact-extractor".
Secret written to file: "/shared/secret.txt"
Client registration complete.
```
