### PR TITLE
:bug: Add kagenti-operator image build and enable CRD deployment

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,8 +15,27 @@ builds:
     goarch: ppc64le
   env:
   - CGO_ENABLED=0
+
+# ADD: kagenti-operator build configuration
+- id: "kagenti-operator"
+  dir: kagenti-operator
+  main: ./cmd
+  binary: ./bin/kagenti-operator-manager
+  goos:
+  - linux
+  - darwin
+  goarch:
+  - amd64
+  - arm64
+  ignore:
+  - goos: darwin
+    goarch: ppc64le
+  env:
+  - CGO_ENABLED=0
+
 archives:
-- ids: [platform-operator]
+- ids: [platform-operator, kagenti-operator]
+
 kos:
   - id: "platform-operator-ko"
     repositories:
@@ -24,6 +43,24 @@ kos:
     working_dir: platform-operator
     main: ./cmd
     build: platform-operator
+    tags:
+      - '{{.Version}}'
+      - latest
+    bare: true
+    preserve_import_paths: false
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    env:
+      - CGO_ENABLED=0
+
+  # ADD: kagenti-operator container image build
+  - id: "kagenti-operator-ko"
+    repositories:
+    - ghcr.io/kagenti/kagenti-operator/kagenti-operator
+    working_dir: kagenti-operator
+    main: ./cmd
+    build: kagenti-operator
     tags:
       - '{{.Version}}'
       - latest

--- a/kagenti-operator/config/default/kustomization.yaml
+++ b/kagenti-operator/config/default/kustomization.yaml
@@ -15,7 +15,7 @@ namePrefix: kagenti-operator-
 #    someName: someValue
 
 resources:
-#- ../crd
+- ../crd
 - ../rbac
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in


### PR DESCRIPTION
Add missing kagenti-operator build configuration to GoReleaser:
- Add kagenti-operator build target (bin/kagenti-operator-manager)
- Add kagenti-operator-ko kos configuration for ghcr.io publishing
- Configure multi-platform support (linux/amd64, linux/arm64)
- Update archives to include both operators

Enable CRD deployment in kagenti-operator kustomization:
- Uncomment ../crd resource to include Agent CRDs
- Enables Agent, AgentBuild, and AgentCard CRDs installation
- Required for operator-based agent deployment workflow

This enables both operator images to be published to ghcr.io:
  - ghcr.io/kagenti/kagenti-operator/platform-operator
  - ghcr.io/kagenti/kagenti-operator/kagenti-operator

## Summary

Add missing kagenti-operator build configuration to GoReleaser

## Related issue(s)

issue #78

