### PR TITLE
:bug: Fixes buildah step permissions and adds buildpacks CNB_PLATFORM_API version.

### DIFF
--- a/charts/kagenti-operator/templates/tekton/buildah-build-step.yaml
+++ b/charts/kagenti-operator/templates/tekton/buildah-build-step.yaml
@@ -24,7 +24,7 @@ data:
       - name: registry-secret
         type: string
         description: Name of the secret containing registry credentials
-        default: "ghcr-token"  
+        default: "ghcr-secret"  
     workspaces:
       - name: source
     
@@ -35,6 +35,15 @@ data:
     steps:
       - name: build-image
         image: quay.io/buildah/stable:latest
+        env:
+          - name: STORAGE_DRIVER
+            value: vfs
+          - name: BUILDAH_ISOLATION
+            value: chroot
+          - name: XDG_RUNTIME_DIR
+            value: /tmp/run
+          - name: HOME
+            value: /tmp/home
         script: |
           #!/bin/bash
           set -e
@@ -46,16 +55,20 @@ data:
           # Configure rootless buildah with vfs storage driver
           export BUILDAH_ISOLATION=chroot
           export STORAGE_DRIVER=vfs
-          
+
+          AUTH="/workspace/.docker/config.json" 
+
           buildah build \
             --file $(params.DOCKERFILE) \
             --tag $(params.image) \
             --tls-verify=$(params.SKIP_TLS_VERIFY) \
             --layers \
+            --authfile $AUTH \
             .
           
           buildah push \
             --tls-verify=$(params.SKIP_TLS_VERIFY) \
+            --authfile $AUTH \
             $(params.image)
           
           echo -n "$(params.image)" > $(results.IMAGE_URL.path)
@@ -67,11 +80,23 @@ data:
              - SETUID
              - SETGID
         volumeMounts:
+          - name: varlibcontainers
+            mountPath: /var/lib/containers
+          - name: run
+            mountPath: /tmp/run
+          - name: homedir
+            mountPath: /tmp/home        
           - name: docker-config
-            mountPath: /root/.docker
+            mountPath: /workspace/.docker
             readOnly: true
     
     volumes:
+      - name: varlibcontainers
+        emptyDir: {}
+      - name: run
+        emptyDir: {}
+      - name: homedir
+        emptyDir: {}    
       - name: docker-config
         secret:
           secretName: $(params.registry-secret)

--- a/charts/kagenti-operator/templates/tekton/buildpack-step.yaml
+++ b/charts/kagenti-operator/templates/tekton/buildpack-step.yaml
@@ -31,6 +31,10 @@ data:
         type: string
         description: Command to start the application
         default: "python __main__.py"  # Change to your actual start command
+      - name: CNB_PLATFORM_API
+        type: string
+        default: "0.13"
+        description: Cloud Native Buildpacks Platform API version        
     steps:
       - name: setup-build-files
         image: busybox
@@ -86,6 +90,8 @@ data:
         env:
           - name: DOCKER_CONFIG
             value: /kaniko/.docker
+          - name: CNB_PLATFORM_API
+            value: $(params.CNB_PLATFORM_API) 
         volumeMounts:
           - name: layers-dir
             mountPath: /layers


### PR DESCRIPTION
## Summary
This PR fixes permission related issues which occur when building container image from source that contains either Dockerfile or Containerfile. 

It also introduces a required tekton buildpacks step property CNB_PLATFORM_API with default version 0.13.  

## Related issue(s)

Fixes #130 
