### PR TITLE
:bug: Fixes regression which prevented disabling of sidecar injection

### DIFF
--- a/charts/platform-operator/values.yaml
+++ b/charts/platform-operator/values.yaml
@@ -10,6 +10,8 @@ controllerManager:
       - "--metrics-bind-address=:8443"
       - "--health-probe-bind-address=:8081"
       - "--webhook-cert-path=/tmp/k8s-webhook-server/serving-certs"
+      # uncomment to disable identity sidecar injection
+      # - "--enable-client-registration=false"
     cmd: /ko-app/cmd
     resources:
       limits:


### PR DESCRIPTION
## Summary
This PR fixes regression which does not allow to disable identity sidecar injection even though `--enable-client-registration=false`

## Related issue(s)

Fixes #132 
