### PR TITLE
✨ Add env variables to client registration container

### DIFF
--- a/platform-operator/internal/deployer/kubernetes/kubernetes.go
+++ b/platform-operator/internal/deployer/kubernetes/kubernetes.go
@@ -431,7 +431,8 @@ func (d *KubernetesDeployer) createDeployment(ctx context.Context, component *pl
 							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "environments",
 							},
-							Key: "KEYCLOAK_TOKEN_EXCHANGE_ENABLED",
+							Key:      "KEYCLOAK_TOKEN_EXCHANGE_ENABLED",
+							Optional: ptr.To(true),
 						},
 					},
 				},
@@ -442,7 +443,8 @@ func (d *KubernetesDeployer) createDeployment(ctx context.Context, component *pl
 							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "environments",
 							},
-							Key: "KEYCLOAK_CLIENT_REGISTRATION_ENABLED",
+							Key:      "KEYCLOAK_CLIENT_REGISTRATION_ENABLED",
+							Optional: ptr.To(true),
 						},
 					},
 				},


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Adds two new env variables to the client-registration containers in the platform-operator. These two env variables should be set in the `environments` ConfigMap. 
- `KEYCLOAK_TOKEN_EXCHANGE_ENABLED`
- `KEYCLOAK_CLIENT_REGISTRATION_ENABLED`

Both of these are optional, but the client registration script in the kagenti/kagenti repository has been modified to default these values to true: https://github.com/kagenti/kagenti/pull/399/files#diff-14172c6e9fe6472ea3d35bb2435e41f082b5268c4a4de1620b503fee2db6522b 

## Related issue(s)
https://github.com/kagenti/kagenti/pull/399 

Fixes #135 
