### PR TITLE
:bug: Remove redundant -svc suffix from Agent service names

### DIFF
--- a/kagenti-operator/internal/controller/agent_controller.go
+++ b/kagenti-operator/internal/controller/agent_controller.go
@@ -522,7 +522,7 @@ func hasVolumeMounts(podSpec *corev1.PodSpec, volumeMountName string) bool {
 }
 
 func (r *AgentReconciler) reconcileAgentService(ctx context.Context, agent *agentv1alpha1.Agent) (ctrl.Result, error) {
-	serviceName := agent.Name + "-svc"
+	serviceName := agent.Name
 	service := &corev1.Service{}
 
 	err := r.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: agent.Namespace}, service)
@@ -568,7 +568,7 @@ func (r *AgentReconciler) createServiceForAgent(agent *agentv1alpha1.Agent) *cor
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        agent.Name + "-svc",
+			Name:        agent.Name,
 			Namespace:   agent.Namespace,
 			Labels:      labels,
 			Annotations: agent.Annotations,


### PR DESCRIPTION

## Summary

This PR updates the Kagenti operator to create Agent Services using the Agent name directly, removing the redundant -svc suffix.

Current (incorrect)
```
metadata:
  name: weather-agent-svc

```
Expected (correct)
```
metadata:
  name: weather-agent
```

**Why This Change**

- Matches common Kubernetes conventions (resource name = service name)

- Simplifies service discovery and DNS:

- Before: weather-agent-svc.team1.svc.cluster.local

- After: weather-agent.team1.svc.cluster.local

- Reduces configuration complexity for users

- Eliminates unnecessary suffix with no added value

## Related issue(s)

Fixes #139 
