### PR TITLE
:bug: Remove namespace template from operator deployment

### DIFF
--- a/charts/kagenti-operator/templates/manager/manager.yaml
+++ b/charts/kagenti-operator/templates/manager/manager.yaml
@@ -1,11 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-    {{- include "chart.labels" . | nindent 4 }}
-  name: {{ .Release.Namespace }}
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
## Summary
This PR fixes an issue that prevents the installer from installing the operator. The kagenti-operator chart manager.yaml was creating `kagenti-system` namespace causing conflict. This namespace is managed by the installer which adds labels required for the platform to work correctly.

The fix is to remove the namespace template from kagenti-operator manager.yaml

## Related issue(s)

Fixes #
