### PR TITLE
:book: User guide for the kagenti operator

### DIFF
--- a/kagenti-operator/GETTING_STARTED.md
+++ b/kagenti-operator/GETTING_STARTED.md
@@ -551,7 +551,7 @@ kubectl describe pod -n team1 -l toolhive-basename=weather-tool
 kubectl get svc weather-agent -n team1
 
 # Test connectivity from within the cluster using a temporary curl pod
-kubectl run test-curl --image=curlimages/curl:latest --rm -i --restart=Never -n team1 -- \
+kubectl run test-curl --image=curlimages/curl:8.1.2 --rm -i --restart=Never -n team1 -- \
   curl -v http://weather-agent.team1.svc.cluster.local:8000/health
 
 # Check if agent can reach MCP server


### PR DESCRIPTION
## Summary
This PR adds a comprehensive getting started guide for deploying and testing AI agents and tools with the Kagenti platform.

**What's included:**

- Deploy agents from existing images or build from source

- Deploy MCP servers for agent tool integration

- End-to-end testing with weather query example

- Status checking and troubleshooting commands

**Prerequisites:**

- Kagenti platform installed

- Ollama running locally with llama3.2:3b-instruct-fp16 model

**Key sections:**

- Quick agent deployment from existing image

- Optional: Build agent from GitHub source

- Deploy MCP server (weather-tool)

- Test end-to-end flow with JSON-RPC request

- Monitoring and troubleshooting

The guide covers both Kagenti Operator (Agent, AgentBuild) and Stacklok ToolHive Operator (MCPServer) custom resources.

Fixes #138 