### PR TITLE
🐛 Fix service name mismatch in AgentCard controller

### DIFF
--- a/kagenti-operator/internal/agentcard/fetcher.go
+++ b/kagenti-operator/internal/agentcard/fetcher.go
@@ -117,9 +117,9 @@ func (f *DefaultFetcher) fetchA2ACard(ctx context.Context, serviceURL string) (*
 }
 
 // GetServiceURL constructs the service URL for an agent
-// Following the pattern from agent_controller.go where services are named <agent-name>-svc
+// Following the pattern from agent_controller.go where services are named <agent-name>
 func GetServiceURL(agentName, namespace string, port int32) string {
 	// Use cluster DNS for service discovery
 	// Format: http://<service-name>.<namespace>.svc.cluster.local:<port>
-	return fmt.Sprintf("http://%s-svc.%s.svc.cluster.local:%d", agentName, namespace, port)
+	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", agentName, namespace, port)
 }

--- a/kagenti-operator/internal/controller/agent_controller.go
+++ b/kagenti-operator/internal/controller/agent_controller.go
@@ -597,7 +597,7 @@ func (r *AgentReconciler) handleDeletion(ctx context.Context, agent *agentv1alph
 		}
 
 		service := &corev1.Service{}
-		serviceName := agent.Name + "-svc"
+		serviceName := agent.Name
 		err = r.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: agent.Namespace}, service)
 		if err == nil {
 			logger.Info("Deleting service for Agent", "serviceName", serviceName)

--- a/kagenti-operator/internal/controller/agentcard_controller.go
+++ b/kagenti-operator/internal/controller/agentcard_controller.go
@@ -196,8 +196,8 @@ func (r *AgentCardReconciler) getAgentProtocol(agent *agentv1alpha1.Agent) strin
 
 // getAgentService retrieves the Service for an Agent
 func (r *AgentCardReconciler) getAgentService(ctx context.Context, agent *agentv1alpha1.Agent) (*corev1.Service, error) {
-	// Service name follows the pattern: <agent-name>-svc
-	serviceName := agent.Name + "-svc"
+	// Service name follows the pattern: <agent-name>
+	serviceName := agent.Name
 	service := &corev1.Service{}
 
 	err := r.Get(ctx, types.NamespacedName{

--- a/kagenti-operator/internal/controller/agentcard_controller_test.go
+++ b/kagenti-operator/internal/controller/agentcard_controller_test.go
@@ -48,7 +48,7 @@ var _ = Describe("AgentCard Controller", func() {
 		const (
 			agentName     = "test-card-agent"
 			agentCardName = "test-agentcard"
-			serviceName   = "test-card-agent-svc"
+			serviceName   = "test-card-agent"
 			namespace     = "default"
 		)
 
@@ -207,7 +207,7 @@ var _ = Describe("AgentCard Controller", func() {
 			}).Should(BeTrue())
 
 			By("verifying the URL was overridden with the service URL")
-			expectedURL := "http://test-card-agent-svc.default.svc.cluster.local:8000"
+			expectedURL := "http://test-card-agent.default.svc.cluster.local:8000"
 			Expect(agentCard.Status.Card.URL).To(Equal(expectedURL))
 
 			By("verifying other card data was preserved")


### PR DESCRIPTION
## Summary

This is a follow-up to PR #143 which removed the "-svc" suffix from service creation in reconcileAgentService(). However, other parts of the codebase still used the old naming convention, causing AgentCard sync to fail with:

  "Service \"<agent-name>-svc\" not found"

This fix removes the "-svc" suffix from the remaining locations:
- agentcard_controller.go: getAgentService()
- agent_controller.go: handleDeletion()
- agentcard/fetcher.go: GetServiceURL()
- agentcard_controller_test.go: test expectations

## Related issue(s)

https://github.com/kagenti/kagenti-operator/pull/143

