### PR TITLE
🐛  fixes buildah permissions in OCP

### DIFF
--- a/kagenti-operator/cmd/main.go
+++ b/kagenti-operator/cmd/main.go
@@ -234,8 +234,9 @@ func main() {
 			mgr.GetClient(),
 			mgr.GetLogger(),
 			mgr.GetScheme(),
-			tekton.NewPipelineComposer(mgr.GetClient(), mgr.GetLogger()),
+			tekton.NewPipelineComposer(mgr.GetClient(), mgr.GetLogger(), distType),
 			tekton.NewWorkspaceManager(mgr.GetClient(), mgr.GetScheme(), mgr.GetLogger()),
+			distType,
 		),
 		Recorder: mgr.GetEventRecorderFor("agentbuild-controller"),
 	}).SetupWithManager(mgr); err != nil {

--- a/kagenti-operator/internal/builder/tekton/pipeline-composer.go
+++ b/kagenti-operator/internal/builder/tekton/pipeline-composer.go
@@ -23,11 +23,13 @@ import (
 
 	"github.com/go-logr/logr"
 	agentv1alpha1 "github.com/kagenti/operator/api/v1alpha1"
+	"github.com/kagenti/operator/internal/distribution"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -51,14 +53,16 @@ type StepDefinition struct {
 
 // PipelineComposer handles composition of pipelines from individual steps
 type PipelineComposer struct {
-	client client.Client
-	Logger logr.Logger
+	client       client.Client
+	Logger       logr.Logger
+	Distribution distribution.Type
 }
 
-func NewPipelineComposer(c client.Client, log logr.Logger) *PipelineComposer {
+func NewPipelineComposer(c client.Client, log logr.Logger, dist distribution.Type) *PipelineComposer {
 	return &PipelineComposer{
-		client: c,
-		Logger: log,
+		client:       c,
+		Logger:       log,
+		Distribution: dist,
 	}
 }
 
@@ -218,13 +222,16 @@ func (pc *PipelineComposer) createPipelineTasks(steps map[string]*StepDefinition
 		// Convert parameters to Tekton Params (for passing to task)
 		taskParams := pc.convertToTektonParams(stepDefinition.Parameters)
 
+		// Sanitize step security contexts to ensure OpenShift compatibility
+		sanitizedSteps := pc.sanitizeSteps(stepDefinition.TaskSpec.Steps)
+
 		// Create task with embedded spec using EmbeddedTask
 		task := tektonv1.PipelineTask{
 			Name: stepDefinition.Name,
 			TaskSpec: &tektonv1.EmbeddedTask{
 				TaskSpec: tektonv1.TaskSpec{
 					Params:     pc.getTaskParams(stepDefinition.Parameters),
-					Steps:      stepDefinition.TaskSpec.Steps,
+					Steps:      sanitizedSteps,
 					Workspaces: stepDefinition.TaskSpec.Workspaces,
 					Volumes:    stepDefinition.TaskSpec.Volumes,
 					Results:    stepDefinition.TaskSpec.Results,
@@ -445,4 +452,44 @@ func (pc *PipelineComposer) collectPipelineParams(agentBuild *agentv1alpha1.Agen
 	}
 
 	return params
+}
+
+// sanitizeSteps removes or adjusts security contexts from task steps to ensure
+// compatibility with OpenShift's restricted SCC. This removes SETUID/SETGID
+// capabilities and explicit runAsUser settings that conflict with OpenShift's
+// namespace-allocated UID ranges.
+func (pc *PipelineComposer) sanitizeSteps(steps []tektonv1.Step) []tektonv1.Step {
+	sanitizedSteps := make([]tektonv1.Step, len(steps))
+	for i, step := range steps {
+		sanitizedSteps[i] = step
+
+		// Build a clean security context that's compatible with OpenShift's restricted SCC
+		sanitizedSteps[i].SecurityContext = pc.buildStepSecurityContext()
+	}
+	return sanitizedSteps
+}
+
+// buildStepSecurityContext creates a security context for task steps that is
+// compatible with OpenShift's restricted SCC. It removes SETUID/SETGID capabilities
+// and omits runAsUser on OpenShift to allow the SCC to assign a UID.
+func (pc *PipelineComposer) buildStepSecurityContext() *corev1.SecurityContext {
+	secCtx := &corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.To(false),
+		Privileged:               ptr.To(false),
+		RunAsNonRoot:             ptr.To(true),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
+
+	// On vanilla Kubernetes, set explicit runAsUser
+	// On OpenShift, omit to let SCC assign from namespace range
+	if pc.Distribution != distribution.OpenShift {
+		secCtx.RunAsUser = ptr.To(int64(1000))
+	}
+
+	return secCtx
 }

--- a/kagenti-operator/internal/builder/tekton/tekton.go
+++ b/kagenti-operator/internal/builder/tekton/tekton.go
@@ -25,6 +25,8 @@ import (
 	"github.com/go-logr/logr"
 	agentv1alpha1 "github.com/kagenti/operator/api/v1alpha1"
 	"github.com/kagenti/operator/internal/builder"
+	"github.com/kagenti/operator/internal/distribution"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -32,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -44,15 +47,17 @@ type TektonBuilder struct {
 	Log              logr.Logger
 	PipelineComposer *PipelineComposer
 	WorkspaceManager *WorkspaceManager
+	Distribution     distribution.Type
 }
 
-func NewTektonBuilder(client client.Client, log logr.Logger, scheme *runtime.Scheme, composer *PipelineComposer, workspaceMgr *WorkspaceManager) *TektonBuilder {
+func NewTektonBuilder(client client.Client, log logr.Logger, scheme *runtime.Scheme, composer *PipelineComposer, workspaceMgr *WorkspaceManager, dist distribution.Type) *TektonBuilder {
 	return &TektonBuilder{
 		Client:           client,
 		Scheme:           scheme,
 		Log:              log,
 		PipelineComposer: composer,
 		WorkspaceManager: workspaceMgr,
+		Distribution:     dist,
 	}
 }
 func (b *TektonBuilder) Build(ctx context.Context, agentBuild *agentv1alpha1.AgentBuild) error {
@@ -192,6 +197,9 @@ func (b *TektonBuilder) createPipelineRun(ctx context.Context, agentBuild *agent
 	} else {
 		fmt.Println("PipelineSpec:::" + string(pp))
 	}
+	// Build security context for task pods
+	podSecurityContext := b.buildPodSecurityContext()
+
 	pipelineRun := &tektonv1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pipelineRunName,
@@ -205,6 +213,11 @@ func (b *TektonBuilder) createPipelineRun(ctx context.Context, agentBuild *agent
 			PipelineSpec: pipelineSpec,
 			Workspaces:   b.WorkspaceManager.GetWorkspaceBindings(agentBuild),
 			Params:       pipelineParams,
+			TaskRunTemplate: tektonv1.PipelineTaskRunTemplate{
+				PodTemplate: &pod.Template{
+					SecurityContext: podSecurityContext,
+				},
+			},
 		},
 	}
 
@@ -386,6 +399,27 @@ func (b *TektonBuilder) extractBuiltImage(pipelineRun *tektonv1.PipelineRun) str
 	}
 
 	return ""
+}
+
+// buildPodSecurityContext creates a security context appropriate for the Kubernetes distribution.
+// On OpenShift, it omits runAsUser to allow the SCC admission controller to assign a UID
+// from the namespace's allocated range. On vanilla Kubernetes, it sets runAsUser: 1000.
+func (b *TektonBuilder) buildPodSecurityContext() *corev1.PodSecurityContext {
+	podSecCtx := &corev1.PodSecurityContext{
+		RunAsNonRoot: ptr.To(true),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+
+	// On OpenShift, omit runAsUser and fsGroup to let SCC admission controller
+	// assign appropriate values from the namespace's allocated range
+	if b.Distribution != distribution.OpenShift {
+		podSecCtx.RunAsUser = ptr.To(int64(1000))
+		podSecCtx.FSGroup = ptr.To(int64(1000))
+	}
+
+	return podSecCtx
 }
 
 func (b *TektonBuilder) GetStatus(ctx context.Context, agent *agentv1alpha1.AgentBuild) (agentv1alpha1.AgentBuildStatus, error) {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

  Better support for buildah build task in OpenShift
  
  1. Removes all capabilities from task steps (including SETUID/SETGID) by dropping ALL capabilities
  2. Omits runAsUser on OpenShift to let the SCC admission controller assign a UID from the namespace's allocated range
  3. Sets secure defaults (runAsNonRoot: true, allowPrivilegeEscalation: false, etc.)

  This applies to both:
  - Pod-level security context (via TaskRunTemplate.PodTemplate in the PipelineRun)
  - Container-level security context (via sanitized steps in each task)

## Related issue(s)

Fixes #154 
