### PR TITLE
📖 Add migration plan for AgentCard controller to support Deployments/StatefulSets 

### DIFF
--- a/docs/plans/migrate-agentcard-controller-to-workloads.md
+++ b/docs/plans/migrate-agentcard-controller-to-workloads.md
@@ -8,7 +8,7 @@
 
 This document outlines the migration of the AgentCard controller from watching and reconciling based on the custom `Agent` CRD to watching standard Kubernetes workloads (Deployments and StatefulSets) that are identified by specific labels.
 
-This migration aligns with the Kagenti UI migration documented in [kagenti/docs/plans/migrate-agent-crd-to-workloads.md](../../../kagenti/docs/plans/migrate-agent-crd-to-workloads.md), where agents are now deployed directly as Deployments/StatefulSets rather than through the Agent CRD.
+This migration aligns with the Kagenti UI migration documented in [kagenti/docs/plans/migrate-agent-crd-to-workloads.md](https://github.com/kagenti/kagenti/blob/main/docs/plans/migrate-agent-crd-to-workloads.md), where agents are now deployed directly as Deployments/StatefulSets rather than through the Agent CRD.
 
 **Goals:**
 - Support agents deployed as Deployments and StatefulSets
@@ -1373,7 +1373,7 @@ To revert to the previous version:
 
 ## References
 
-- [Kagenti UI Migration Plan](../../../kagenti/docs/plans/migrate-agent-crd-to-workloads.md)
+- [Kagenti UI Migration Plan](https://github.com/kagenti/kagenti/blob/main/docs/plans/migrate-agent-crd-to-workloads.md)
 - [Kubernetes Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
 - [Kubernetes StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/)
 - [Controller Runtime Watches](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/builder)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR adds a migration plan for updating the AgentCard controller to work with standard Kubernetes workloads (Deployments and StatefulSets) instead of the custom Agent CRD.

  Key Changes

  - Introduces targetRef field using duck typing pattern (similar to Gateway API) for explicit workload references
  - Replaces ambiguous label-based selector with direct apiVersion/kind/name reference
  - Uses unstructured.Unstructured to support any workload type without code changes

  Example
```
  spec:
    targetRef:
      apiVersion: apps/v1
      kind: Deployment
      name: my-agent
 ```     

  Why targetRef?

  - Explicit: References exactly one workload by name
  - Extensible: Supports any workload type (Deployment, StatefulSet, Job) without code changes
  - Follows K8s conventions: Aligns with Gateway API's PolicyTargetReference pattern

  Backward Compatibility

  - Deprecated selector field remains supported
  - Existing AgentCards are automatically migrated to use targetRef
  - Legacy Agent CRD support via --enable-legacy-agent-crd flag

  This aligns with the Kagenti UI migration where agents are deployed directly as Deployments/StatefulSets rather than through the Agent CRD.

## Related issue(s)

Fixes #163

🤖 Assisted by [Claude Code](https://claude.com/claude-code)