### PR TITLE
🌱 Add a working dev-build script.

### DIFF
--- a/scripts/dev-build.sh
+++ b/scripts/dev-build.sh
@@ -1,9 +1,27 @@
 #!/bin/bash
 
-#TAG=$(date +%Y%m%d%H%M%S)
-#docker build . --tag local/kagenti-operator:${TAG} --load
-#kind load docker-image --name agent-platform local/kagenti-operator:${TAG}
-#kubectl -n kagenti-system set image deployment/kagenti-operator kagenti-ui-container=local/kagenti-ui:${TAG}
-#kubectl rollout status -n kagenti-system deployment/kagenti-ui
-#kubectl get -n kagenti-system pod -l app.kubernetes.io/instance=kagenti-operator
+set -e
+
+cd "$(dirname "$0")/../kagenti-operator"
+
+TAG=$(date +%Y%m%d%H%M%S)
+echo "Building kagenti-operator:${TAG}..."
+docker build . --tag local/kagenti-operator:${TAG} --load
+
+echo "Loading image into kind cluster..."
+kind load --name kagenti docker-image local/kagenti-operator:${TAG}
+
+echo "Updating deployment..."
+kubectl -n kagenti-system set image deployment/kagenti-controller-manager manager=local/kagenti-operator:${TAG}
+
+# Local Dockerfile builds to /manager, but production images (built with ko) use /ko-app/cmd.
+# Override the command for local dev. See: docs/identity-binding-quickstart.md
+kubectl -n kagenti-system patch deployment kagenti-controller-manager \
+  --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/command", "value": ["/manager"]}]'
+
+echo "Waiting for rollout..."
+kubectl rollout status -n kagenti-system deployment/kagenti-controller-manager
+
+echo "Current pods:"
+kubectl get pods -n kagenti-system -l control-plane=controller-manager
 


### PR DESCRIPTION
## Summary

The dev-build script had been commented out, due to incompatibility with recent changes to the project.

Here I've added an updated script which:

1. builds relative to the script's location, so you don't need to track down a Docker file.
2. Includes a patch necessary for building and deploying against production builds of kagenti-operator.

It should be useful to folks who have installed Kagenti using the --dev environment.

example output:

```
kagenti-operator on  dev-build-script:main [$⇡] on ☁️  (us-west-2) on ☁️  mofoster@redhat.com
❯ bash scripts/dev-build.sh
Building kagenti-operator:20260202115542...
[+] Building 17.5s (17/17) FINISHED                                                                                                                             docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                            0.0s
 => => transferring dockerfile: 1.30kB                                                                                                                                          0.0s
 => [internal] load metadata for gcr.io/distroless/static:nonroot                                                                                                               0.4s
 => [internal] load metadata for docker.io/library/golang:1.23                                                                                                                  0.8s
 => [internal] load .dockerignore                                                                                                                                               0.0s
 => => transferring context: 160B                                                                                                                                               0.0s
 => [builder 1/9] FROM docker.io/library/golang:1.23@sha256:60deed95d3888cc5e4d9ff8a10c54e5edc008c6ae3fba6187be6fb592e19e8c0                                                    0.0s
 => => resolve docker.io/library/golang:1.23@sha256:60deed95d3888cc5e4d9ff8a10c54e5edc008c6ae3fba6187be6fb592e19e8c0                                                            0.0s
 => CACHED [stage-1 1/3] FROM gcr.io/distroless/static:nonroot@sha256:f9f84bd968430d7d35e8e6d55c40efb0b980829ec42920a49e60e65eac0d83fc                                          0.0s
 => => resolve gcr.io/distroless/static:nonroot@sha256:f9f84bd968430d7d35e8e6d55c40efb0b980829ec42920a49e60e65eac0d83fc                                                         0.0s
 => [internal] load build context                                                                                                                                               0.0s
 => => transferring context: 109.31kB                                                                                                                                           0.0s
 => CACHED [builder 2/9] WORKDIR /workspace                                                                                                                                     0.0s
 => CACHED [builder 3/9] COPY go.mod go.mod                                                                                                                                     0.0s
 => CACHED [builder 4/9] COPY go.sum go.sum                                                                                                                                     0.0s
 => CACHED [builder 5/9] RUN go mod download                                                                                                                                    0.0s
 => [builder 6/9] COPY cmd/main.go cmd/main.go                                                                                                                                  0.0s
 => [builder 7/9] COPY api/ api/                                                                                                                                                0.0s
 => [builder 8/9] COPY internal/ internal/                                                                                                                                      0.0s
 => [builder 9/9] RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -o manager cmd/main.go                                                                                 15.0s
 => [stage-1 2/3] COPY --from=builder /workspace/manager .                                                                                                                      0.1s
 => exporting to image                                                                                                                                                          1.4s
 => => exporting layers                                                                                                                                                         1.2s
 => => exporting manifest sha256:181b3b2675231b642f76bbdc2046841ae1c39245bccc8481a093630e2a723d52                                                                               0.0s
 => => exporting config sha256:f8906e486394564426f2b6021980aef1785634a96d54f0221acfe98f15a815b4                                                                                 0.0s
 => => exporting attestation manifest sha256:07d4e7fdb472ef27c3329a9258b3697b3ef292aa0d69d1e5e272b880ad70d8c7                                                                   0.0s
 => => exporting manifest list sha256:b5339c4e16b1a4c992ce3e790b2c3fe47642a3e7a3442cbdee0516f4d1041caf                                                                          0.0s
 => => naming to docker.io/local/kagenti-operator:20260202115542                                                                                                                0.0s
 => => unpacking to docker.io/local/kagenti-operator:20260202115542                                                                                                             0.2s
Loading image into kind cluster...
Image: "local/kagenti-operator:20260202115542" with ID "sha256:b5339c4e16b1a4c992ce3e790b2c3fe47642a3e7a3442cbdee0516f4d1041caf" not yet present on node "kagenti-control-plane", loading...
Updating deployment...
deployment.apps/kagenti-controller-manager image updated
deployment.apps/kagenti-controller-manager patched (no change)
Waiting for rollout...
Waiting for deployment "kagenti-controller-manager" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "kagenti-controller-manager" rollout to finish: 1 old replicas are pending termination...
deployment "kagenti-controller-manager" successfully rolled out
Current pods:
NAME                                          READY   STATUS        RESTARTS   AGE
kagenti-controller-manager-86768fc64c-94ndw   1/1     Terminating   0          14m
kagenti-controller-manager-9c5c97b49-tv2mj    1/1     Running       0          13s


```