### PR TITLE
fix: update proactive restart demo defaults to match Helm conventions

### DIFF
--- a/kagenti-operator/demos/agentcard-proactive-restart/run-demo-commands.sh
+++ b/kagenti-operator/demos/agentcard-proactive-restart/run-demo-commands.sh
@@ -12,8 +12,8 @@ set -euo pipefail
 NAMESPACE="${NAMESPACE:-agents}"
 AGENTCARD="${AGENTCARD:-weather-agent-card}"
 DEPLOYMENT="${DEPLOYMENT:-weather-agent}"
-OPERATOR_NS="${OPERATOR_NS:-agentcard-system}"
-OPERATOR_DEPLOY="${OPERATOR_DEPLOY:-agentcard-operator}"
+OPERATOR_NS="${OPERATOR_NS:-kagenti-system}"
+OPERATOR_DEPLOY="${OPERATOR_DEPLOY:-kagenti-controller-manager}"
 
 # Capture the live operator args so we can restore them exactly after the demo.
 ORIGINAL_ARGS_JSON=$(kubectl get deployment "$OPERATOR_DEPLOY" -n "$OPERATOR_NS" \

--- a/kagenti-operator/demos/agentcard-proactive-restart/teardown-demo.sh
+++ b/kagenti-operator/demos/agentcard-proactive-restart/teardown-demo.sh
@@ -6,8 +6,8 @@
 
 set -euo pipefail
 
-OPERATOR_NS="${OPERATOR_NS:-agentcard-system}"
-OPERATOR_DEPLOY="${OPERATOR_DEPLOY:-agentcard-operator}"
+OPERATOR_NS="${OPERATOR_NS:-kagenti-system}"
+OPERATOR_DEPLOY="${OPERATOR_DEPLOY:-kagenti-controller-manager}"
 
 echo "=== AgentCard Proactive Restart Demo Teardown ==="
 echo ""


### PR DESCRIPTION
## Summary
- Update `OPERATOR_NS` default from `agentcard-system` to `kagenti-system`
- Update `OPERATOR_DEPLOY` default from `agentcard-operator` to `kagenti-controller-manager`
- Applied to both `run-demo-commands.sh` and `teardown-demo.sh`

Fixes #223

## Test plan
- [ ] Run `demos/agentcard-proactive-restart/run-demo-commands.sh` after a Helm-based install without env var overrides
- [ ] Verify `teardown-demo.sh` restores the operator correctly

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>