### PR TITLE
fix(rbac): Add missing agentruntimes permissions to ClusterRole

### DIFF
--- a/charts/kagenti-operator/templates/rbac/role.yaml
+++ b/charts/kagenti-operator/templates/rbac/role.yaml
@@ -121,6 +121,32 @@ rules:
   - patch
   - update
 - apiGroups:
+  - agent.kagenti.dev
+  resources:
+  - agentruntimes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - agent.kagenti.dev
+  resources:
+  - agentruntimes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - agent.kagenti.dev
+  resources:
+  - agentruntimes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingresses


### PR DESCRIPTION
## Problem

The kagenti-operator is deployed with insufficient RBAC permissions, causing continuous errors in production:

```
agentruntimes.agent.kagenti.dev is forbidden: User "system:serviceaccount:kagenti-operator-system:controller-manager" 
cannot list resource "agentruntimes" in API group "agent.kagenti.dev" at the cluster scope
```

### Logs showing the issue:

```
W0327 18:56:01.604062       1 reflector.go:569] failed to list *v1alpha1.AgentRuntime: agentruntimes.agent.kagenti.dev is forbidden
E0327 18:56:01.604188       1 reflector.go:166] "Unhandled Error" err="Failed to watch *v1alpha1.AgentRuntime: agentruntimes.agent.kagenti.dev is forbidden"
```

This error repeats continuously (exponential backoff), filling operator logs and preventing the AgentRuntimeReconciler from functioning.

## Root Cause

**Mismatch between code and Helm chart:**

1. **Code declares required RBAC** in [internal/controller/agentruntime_controller.go:66-69](https://github.com/kagenti/kagenti-operator/blob/main/kagenti-operator/internal/controller/agentruntime_controller.go#L66-L69):
   ```go
   // +kubebuilder:rbac:groups=agent.kagenti.dev,resources=agentruntimes,verbs=get;list;watch;create;update;patch;delete
   // +kubebuilder:rbac:groups=agent.kagenti.dev,resources=agentruntimes/status,verbs=get;update;patch
   // +kubebuilder:rbac:groups=agent.kagenti.dev,resources=agentruntimes/finalizers,verbs=update
   ```

2. **Controller is always registered** in [cmd/main.go:323-330](https://github.com/kagenti/kagenti-operator/blob/main/kagenti-operator/cmd/main.go#L323-L330)

3. **Helm chart ClusterRole is missing these permissions** in [charts/kagenti-operator/templates/rbac/role.yaml](https://github.com/kagenti/kagenti-operator/blob/main/charts/kagenti-operator/templates/rbac/role.yaml)

## Solution

Add the missing `agentruntimes` permissions to the ClusterRole Helm template to match the controller's kubebuilder RBAC annotations.

### Changes:
- Added `agentruntimes` resource permissions (get, list, watch, create, update, patch, delete)
- Added `agentruntimes/status` subresource permissions (get, update, patch)
- Added `agentruntimes/finalizers` subresource permissions (update)

## Impact

**Before fix:**
- ❌ Permission errors fill operator logs
- ❌ AgentRuntime controller cannot reconcile
- ❌ Per-workload identity configuration non-functional
- ❌ Per-workload observability overrides non-functional

**After fix:**
- ✅ Permission errors eliminated
- ✅ AgentRuntime controller can list/watch/reconcile CRDs
- ✅ Per-workload configuration features functional
- ✅ Clean operator logs

## Testing

Deployed operator with this fix in kind cluster:
1. Permission errors stopped immediately after ClusterRole update
2. AgentRuntime controller successfully lists/watches CRDs
3. No regressions in other controllers (AgentCard, ClientRegistration, etc.)

## Type of Change

- [x] Bug fix (fixes an issue in existing functionality)
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] Code follows project style guidelines
- [x] Changes have been tested locally
- [x] Commit message follows conventional commits
- [x] DCO sign-off included
- [x] Documentation updated (if needed)

## Related Issues

This is a pre-existing bug affecting all deployments of kagenti-operator. No specific issue filed, discovered during E2E testing of PR #247.