### PR TITLE
fix: resolve flaky E2E metrics test caused by webhook race condition

### DIFF
--- a/kagenti-operator/config/webhook/manifests.yaml
+++ b/kagenti-operator/config/webhook/manifests.yaml
@@ -21,6 +21,7 @@ webhooks:
       - kube-system
       - kube-public
       - kube-node-lease
+      - kagenti-operator-system
     matchLabels:
       kagenti-enabled: "true"
   objectSelector:

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -191,6 +191,17 @@ var _ = Describe("Manager", Ordered, func() {
 			}
 			Eventually(verifyMetricsServerStarted).Should(Succeed())
 
+			By("waiting for the webhook endpoint to be ready")
+			verifyWebhookEndpointReady := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "endpoints",
+					"kagenti-operator-webhook-service", "-n", namespace,
+					"-o", "jsonpath={.subsets[0].addresses[0].ip}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(BeEmpty(), "webhook endpoint not yet populated")
+			}
+			Eventually(verifyWebhookEndpointReady).Should(Succeed())
+
 			By("creating the curl-metrics pod to access the metrics endpoint")
 			cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
 				"--namespace", namespace,


### PR DESCRIPTION
## Summary

The E2E metrics test (`should ensure the metrics endpoint is serving metrics`) is flaky across all PRs. It fails intermittently when the `curl-metrics` pod creation is intercepted by the `inject.kagenti.io` MutatingWebhook before the webhook server is ready, resulting in `connection refused` errors.

**Evidence of systemic flakiness:**
- PR #240 (RBAC fix): 7/8 passed, 1 failed — same webhook error
- PR #249 (role-alignment): 7/8 passed, 1 failed — same webhook error
- Multiple main branch CI runs also affected

## Changes

1. **Webhook config** (`config/webhook/manifests.yaml`): Added `kagenti-operator-system` to the `namespaceSelector.matchExpressions[0].values` NotIn list. This matches the Helm chart behavior which already excludes `{{ .Release.Namespace }}`, preventing the webhook from intercepting pods in the operator's own namespace.

2. **E2E test** (`test/e2e/e2e_test.go`): Added a webhook endpoint readiness check before creating the `curl-metrics` pod. This follows the same pattern already used in the AgentCard E2E tests (lines 322-330).

## Root Cause

The `inject.kagenti.io` MutatingWebhook has `failurePolicy: Fail`. When the webhook server is not yet ready (TLS cert provisioning by cert-manager, readiness probe still failing), any pod creation that the webhook intercepts will fail with `connection refused`. The kustomize webhook config was missing the operator namespace exclusion that the Helm chart already had.

## Test Plan

- [ ] E2E Tests pass (the flaky metrics test should now be stable)
- [ ] All other CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)