### PR TITLE
feat(E2E): create E2E tests for AgentRuntime CRD

### DIFF
--- a/kagenti-operator/Makefile
+++ b/kagenti-operator/Makefile
@@ -92,7 +92,7 @@ test-e2e: manifests generate fmt vet ## Run the e2e tests. Expected an isolated 
 		echo "No Kind cluster is running. Please start a Kind cluster before running the e2e tests."; \
 		exit 1; \
 	}
-	go test ./test/e2e/ -v -ginkgo.v
+	go test ./test/e2e/ -v -ginkgo.v -timeout 30m
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/kagenti-operator/test/e2e/README.md
+++ b/kagenti-operator/test/e2e/README.md
@@ -1,9 +1,10 @@
 # E2E Tests
 
-End-to-end tests for the kagenti-operator. The suite runs 8 specs:
+End-to-end tests for the kagenti-operator. The suite runs 16 specs:
 
 - **Manager tests** (2 specs) — controller pod readiness and Prometheus metrics
 - **AgentCard tests** (6 specs) — webhook validation, auto-discovery, duplicate prevention, audit mode, and SPIRE signature verification
+- **AgentRuntime tests** (8 specs) — label application, status lifecycle, idempotency, error handling, tool type, StatefulSet support, identity/trace overrides, and deletion cleanup
 
 ## Prerequisites
 
@@ -20,7 +21,7 @@ The test suite auto-detects Docker vs Podman. No env vars needed.
 # Create a fresh Kind cluster
 kind delete cluster 2>/dev/null; kind create cluster
 
-# Run all 8 specs (~7 min)
+# Run all 16 specs (~12 min)
 make test-e2e
 ```
 
@@ -48,6 +49,9 @@ go test ./test/e2e/ -v -ginkgo.v -ginkgo.focus="SignatureInvalidAudit|should ver
 
 # Manager tests only
 go test ./test/e2e/ -v -ginkgo.v -ginkgo.focus="Manager"
+
+# AgentRuntime tests only (~3 min)
+go test ./test/e2e/ -v -ginkgo.v -ginkgo.focus="AgentRuntime E2E"
 ```
 
 ## Cleanup
@@ -66,6 +70,14 @@ kind delete cluster
 | Duplicate prevention | Without signature | Webhook rejects a second AgentCard targeting the same workload |
 | Audit mode | With signature | Unsigned card syncs (Synced=True) but reports SignatureVerified=False with reason SignatureInvalidAudit |
 | Signed agent | With signature | SPIRE-signed card gets SignatureVerified=True, correct SPIFFE ID, Synced=True, and Bound=True |
+| Apply labels and config-hash | Agent lifecycle | AgentRuntime controller adds `kagenti.io/type=agent`, `managed-by`, config-hash, and triggers AgentCard auto-creation |
+| Phase=Active and Ready=True | Agent lifecycle | AgentRuntime CR reaches Active phase with Ready=True condition |
+| Idempotent re-reconcile | Agent lifecycle | Deployment generation stays stable over 30s (no spurious updates) |
+| Clean up on deletion | Agent lifecycle | Deletion preserves `kagenti.io/type`, removes `managed-by`, updates config-hash to defaults-only |
+| Missing target error | Error cases | AgentRuntime targeting non-existent Deployment sets Phase=Error |
+| Tool type label | Tool type | AgentRuntime with type=tool applies `kagenti.io/type=tool` label and no AgentCard is created |
+| StatefulSet target | StatefulSet target | AgentRuntime applies labels, config-hash, and reaches Active for a StatefulSet workload |
+| Identity/trace overrides | Identity and trace overrides | AgentRuntime with identity+trace spec produces a different config-hash than a minimal CR |
 
 ## Architecture
 
@@ -145,6 +157,50 @@ kind load docker-image           ▼                   kubectl apply --server-si
 └──────────────────────────────────────────────────────────────────┘
 ```
 
+### AgentRuntime test infrastructure
+
+The AgentRuntime E2E tests use a separate namespace (`e2e-agentruntime-test`) and lightweight
+`pause:3.9` containers (no HTTP serving needed). The test creates ConfigMap fixtures to exercise
+the 3-layer config merge:
+
+```
+BeforeAll (AgentRuntime E2E)
+├── Deploy controller (make install + make deploy)
+├── Wait for controller pod Running + webhook endpoint ready
+├── Create namespace e2e-agentruntime-test (PSA restricted)
+├── Ensure kagenti-system namespace exists
+├── Create kagenti-platform-config ConfigMap (cluster defaults, layer 1)
+└── Create runtime-ns-defaults ConfigMap (namespace defaults, layer 2)
+```
+
+```
+AgentRuntime controller flow:
+                                                    ┌─ kagenti-system ──────────────────┐
+                                                    │  kagenti-platform-config ConfigMap │
+                                                    │  (cluster defaults, layer 1)       │
+                                                    └────────────┬──────────────────────┘
+                                                                 │
+┌─ AgentRuntime CR ─────────┐     ┌─ Controller ────────────┐    │    ┌─ e2e-agentruntime-test ────────┐
+│  spec.type: agent         │────▶│  Resolve target          │◀───┘    │  runtime-ns-defaults ConfigMap  │
+│  spec.targetRef:          │     │  Resolve config (3-layer)│◀────────│  (namespace defaults, layer 2)  │
+│    name: runtime-agent-   │     │  Apply labels + hash     │         │                                  │
+│          target           │     │  Set Phase=Active        │         │  runtime-agent-target Deployment │
+└───────────────────────────┘     └──────────┬───────────────┘         │  runtime-tool-target Deployment  │
+                                             │                         │  runtime-sts-target StatefulSet  │
+                                             │                         │  runtime-minimal-target Deploy.  │
+                                             │                         │  runtime-overrides-target Deploy.│
+                                             │                         └──────────────────────────────────┘
+                                             ▼
+                                  Target Deployment updated:
+                                  ├── kagenti.io/type = agent|tool
+                                  ├── app.kubernetes.io/managed-by = kagenti-operator
+                                  └── kagenti.io/config-hash = SHA256 (pod template annotation)
+```
+
+**Cross-controller note:** The agent target fixture includes `protocol.kagenti.io/a2a`. When
+AgentRuntime adds `kagenti.io/type=agent`, AgentCardSync auto-creates an AgentCard that fails
+to sync (pause container serves no HTTP). This is expected and harmless.
+
 ### Test scenario details
 
 #### Reject missing targetRef
@@ -156,7 +212,7 @@ Applies an AgentCard with no `spec.targetRef`. The validating webhook checks
 
 Deploys `noproto-agent` with `kagenti.io/type=agent` but no `protocol.kagenti.io/*` label.
 The sync controller's `shouldSyncWorkload()` requires both the agent type AND a protocol
-label, so it skips this workload. The test uses `Consistently` for 15s to prove no card appears.
+label, so it skips this workload. The test uses `Consistently` for 30s to prove no card appears.
 
 #### Auto-discovery
 
@@ -197,6 +253,75 @@ The most complex scenario. Controller runs with `--require-a2a-signature=true` (
 Test verifies: `SignatureVerified=True` (reason `SignatureValid`),
 `signatureSpiffeId = spiffe://example.org/ns/e2e-agentcard-test/sa/signed-agent-sa`,
 `Synced=True`, `Bound=True`.
+
+#### Apply labels and config-hash
+
+Deploys `runtime-agent-target` (pause container with `protocol.kagenti.io/a2a` label) and
+creates an AgentRuntime CR with `type: agent` targeting it. The controller resolves the target,
+merges 3-layer config (cluster ConfigMap `kagenti-platform-config` in `kagenti-system` +
+namespace ConfigMap with `kagenti.io/defaults=true` + CR-level overrides), and applies labels
+to the Deployment. Test verifies `kagenti.io/type=agent` on both workload metadata and pod
+template, `app.kubernetes.io/managed-by=kagenti-operator` on workload metadata, and
+`kagenti.io/config-hash` annotation (non-empty, 64 hex chars) on the pod template. Also
+verifies the cross-controller interaction: once `kagenti.io/type=agent` is applied alongside
+the existing `protocol.kagenti.io/a2a` label, AgentCardSync auto-creates an AgentCard
+(`runtime-agent-target-deployment-card`) with the correct `managed-by` label and targetRef.
+
+#### Phase=Active and Ready=True
+
+Uses the AgentRuntime CR from the previous test (ordered context). Once the controller has
+resolved the target and applied configuration, it sets `status.phase=Active` and the `Ready`
+condition to `True`. Test verifies both fields via jsonpath.
+
+#### Idempotent re-reconcile
+
+With the AgentRuntime CR and target Deployment already reconciled, records the Deployment's
+`metadata.generation` and asserts it stays constant over 30 seconds using `Consistently`.
+A generation change would indicate the controller is making spurious updates to the Deployment
+spec on each reconcile loop, which would trigger unnecessary rolling restarts.
+
+#### Clean up on deletion
+
+Deletes the AgentRuntime CR and verifies the finalizer (`kagenti.io/cleanup`) runs correctly:
+
+1. **Target Deployment still exists** — the controller cleans up labels, not the workload
+2. **`kagenti.io/type=agent` preserved** — workload remains classified after runtime removal
+3. **`app.kubernetes.io/managed-by` removed** — workload is no longer operator-managed
+4. **`kagenti.io/config-hash` changes** — updated to a defaults-only hash (cluster + namespace
+   defaults without CR-level overrides), which differs from the initial hash and triggers a
+   rolling update
+5. **AgentRuntime CR returns 404** — finalizer completed and CR was fully deleted
+
+#### Missing target error
+
+Creates an AgentRuntime CR targeting `nonexistent-deployment`. The controller's target
+resolution fails because no Deployment with that name exists. The controller sets
+`status.phase=Error`. Test verifies the Error phase via jsonpath, then cleans up the CR.
+
+#### Tool type label
+
+Deploys `runtime-tool-target` (pause container without protocol labels) and creates an
+AgentRuntime CR with `type: tool`. The controller applies `kagenti.io/type=tool` to the
+workload metadata. Unlike the agent fixture, the tool target has no `protocol.kagenti.io/*`
+label, so AgentCardSync does not auto-create an AgentCard. The test verifies this with a
+15-second `Consistently` check confirming no AgentCard referencing `runtime-tool-target` exists.
+
+#### StatefulSet target
+
+Deploys `runtime-sts-target` (StatefulSet with headless Service and pause container) and
+creates an AgentRuntime CR with `kind: StatefulSet` in the targetRef. The controller resolves
+the StatefulSet target identically to Deployments via `runtimePodTemplateAccessor`. Test
+verifies `kagenti.io/type=agent` and `app.kubernetes.io/managed-by=kagenti-operator` on
+StatefulSet metadata, Phase=Active, and a valid 64-char config-hash on the pod template.
+
+#### Identity and trace overrides
+
+Deploys two target Deployments and creates two AgentRuntime CRs: one minimal (no overrides)
+and one with `spec.identity.spiffe.trustDomain` and `spec.trace` (endpoint, protocol, sampling
+rate). Both CRs reach Phase=Active. The test records each Deployment's `kagenti.io/config-hash`
+annotation and asserts they differ, proving that identity and trace overrides are included in
+the config hash computation. This validates the full CRD → controller → config merge path for
+optional spec fields.
 
 ## Troubleshooting
 

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -1033,8 +1033,10 @@ rules:
 			_, err = utils.KubectlApplyStdin(runtimeOverridesTargetDeploymentFixture(), agentRuntimeTestNamespace)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(utils.WaitForDeploymentReady("runtime-minimal-target", agentRuntimeTestNamespace, 2*time.Minute)).To(Succeed())
-			Expect(utils.WaitForDeploymentReady("runtime-overrides-target", agentRuntimeTestNamespace, 2*time.Minute)).To(Succeed())
+			Expect(utils.WaitForDeploymentReady(
+				"runtime-minimal-target", agentRuntimeTestNamespace, 2*time.Minute)).To(Succeed())
+			Expect(utils.WaitForDeploymentReady(
+				"runtime-overrides-target", agentRuntimeTestNamespace, 2*time.Minute)).To(Succeed())
 
 			By("creating minimal AgentRuntime CR (no overrides)")
 			_, err = utils.KubectlApplyStdin(runtimeMinimalCRFixture(), agentRuntimeTestNamespace)

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -203,34 +203,39 @@ var _ = Describe("Manager", Ordered, func() {
 			Eventually(verifyWebhookEndpointReady).Should(Succeed())
 
 			By("creating the curl-metrics pod to access the metrics endpoint")
-			cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
-				"--namespace", namespace,
-				"--image=curlimages/curl:latest",
-				"--overrides",
-				fmt.Sprintf(`{
-					"spec": {
-						"containers": [{
-							"name": "curl",
-							"image": "curlimages/curl:latest",
-							"command": ["/bin/sh", "-c"],
-							"args": ["curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics"],
-							"securityContext": {
-								"allowPrivilegeEscalation": false,
-								"capabilities": {
-									"drop": ["ALL"]
-								},
-								"runAsNonRoot": true,
-								"runAsUser": 1000,
-								"seccompProfile": {
-									"type": "RuntimeDefault"
+			Eventually(func() error {
+				cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
+					"--namespace", namespace,
+					"--image=curlimages/curl:latest",
+					"--overrides",
+					fmt.Sprintf(`{
+						"spec": {
+							"containers": [{
+								"name": "curl",
+								"image": "curlimages/curl:latest",
+								"command": ["/bin/sh", "-c"],
+								"args": ["curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics"],
+								"securityContext": {
+									"allowPrivilegeEscalation": false,
+									"capabilities": {
+										"drop": ["ALL"]
+									},
+									"runAsNonRoot": true,
+									"runAsUser": 1000,
+									"seccompProfile": {
+										"type": "RuntimeDefault"
+									}
 								}
-							}
-						}],
-						"serviceAccount": "%s"
-					}
-				}`, token, metricsServiceName, namespace, serviceAccountName))
-			_, err = utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create curl-metrics pod")
+							}],
+							"serviceAccountName": "%s"
+						}
+					}`, token, metricsServiceName, namespace, serviceAccountName))
+				_, runErr := utils.Run(cmd)
+				if runErr != nil && strings.Contains(runErr.Error(), "already exists") {
+					return nil
+				}
+				return runErr
+			}, 1*time.Minute, 5*time.Second).Should(Succeed(), "Failed to create curl-metrics pod")
 
 			By("waiting for the curl-metrics pod to complete.")
 			verifyCurlUp := func(g Gomega) {

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -867,6 +867,9 @@ rules:
 			}, 30*time.Second, 5*time.Second).Should(Succeed())
 		})
 
+		// Note: the AgentCard auto-created by AgentCardSync (runtime-agent-target-deployment-card)
+		// persists after AgentRuntime deletion because kagenti.io/type=agent is preserved on the
+		// Deployment and AgentCardSync owns the card independently of the AgentRuntime lifecycle.
 		It("should clean up on deletion", func() {
 			By("deleting the AgentRuntime CR")
 			cmd := exec.Command("kubectl", "delete", "agentruntime", "test-agent-runtime",
@@ -931,6 +934,15 @@ rules:
 				g.Expect(phase).To(Equal("Error"))
 			}).Should(Succeed())
 
+			By("verifying error condition mentions the target")
+			Eventually(func(g Gomega) {
+				msg, err := utils.KubectlGetJsonpath("agentruntime", "test-missing-target",
+					agentRuntimeTestNamespace,
+					"{.status.conditions[?(@.type=='Ready')].message}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(msg).To(ContainSubstring("nonexistent-deployment"))
+			}).Should(Succeed())
+
 			By("cleaning up")
 			cmd := exec.Command("kubectl", "delete", "agentruntime", "test-missing-target",
 				"-n", agentRuntimeTestNamespace, "--ignore-not-found")
@@ -958,12 +970,13 @@ rules:
 			}).Should(Succeed())
 
 			By("verifying no AgentCard is created for tool-type workload")
-			Consistently(func() string {
+			Consistently(func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "agentcards", "-n", agentRuntimeTestNamespace,
 					"-o", "jsonpath={.items[*].metadata.name}")
-				output, _ := utils.Run(cmd)
-				return output
-			}, 15*time.Second, 3*time.Second).ShouldNot(ContainSubstring("runtime-tool-target"))
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(ContainSubstring("runtime-tool-target"))
+			}, 15*time.Second, 3*time.Second).Should(Succeed())
 
 			By("cleaning up")
 			cmd := exec.Command("kubectl", "delete", "agentruntime", "test-tool-runtime",

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025.
+Copyright 2026.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -634,6 +634,462 @@ var _ = Describe("AgentCard E2E", Ordered, func() {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(boundStatus).To(Equal("True"))
 			}).Should(Succeed())
+		})
+	})
+})
+
+var _ = Describe("AgentRuntime E2E", Ordered, func() {
+	const controllerNamespace = "kagenti-operator-system"
+
+	BeforeAll(func() {
+		By("ensuring mlflow-operator ClusterRole exists for ServiceAccount informer")
+		clusterRoleCmd := exec.Command("kubectl", "apply", "-f", "-")
+		clusterRoleCmd.Stdin = strings.NewReader(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mlflow-operator-mlflow-integration
+rules:
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["list", "watch"]
+`)
+		_, _ = utils.Run(clusterRoleCmd)
+
+		Expect(utils.DeployController(controllerNamespace, projectImage)).To(Succeed(), "Failed to deploy controller")
+
+		By("waiting for controller-manager to be ready")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
+				"-n", controllerNamespace,
+				"-o", "go-template={{ range .items }}{{ if not .metadata.deletionTimestamp }}{{ .status.phase }}{{ end }}{{ end }}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(ContainSubstring("Running"))
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+		By("waiting for webhook endpoint to be ready")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "endpoints",
+				"kagenti-operator-webhook-service", "-n", controllerNamespace,
+				"-o", "jsonpath={.subsets[0].addresses[0].ip}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).NotTo(BeEmpty(), "webhook endpoint not yet populated")
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+		By("creating test namespace")
+		cmd := exec.Command("kubectl", "create", "ns", agentRuntimeTestNamespace)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd = exec.Command("kubectl", "label", "--overwrite", "ns", agentRuntimeTestNamespace,
+			"pod-security.kubernetes.io/enforce=restricted")
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("ensuring kagenti-system namespace exists")
+		cmd = exec.Command("kubectl", "create", "ns", "kagenti-system")
+		_, _ = utils.Run(cmd) // ignore error; namespace may already exist
+
+		By("creating cluster defaults ConfigMap")
+		_, err = utils.KubectlApplyStdin(runtimeClusterDefaultsConfigMapFixture(), "kagenti-system")
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating namespace defaults ConfigMap")
+		_, err = utils.KubectlApplyStdin(runtimeNamespaceDefaultsConfigMapFixture(), agentRuntimeTestNamespace)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		By("deleting test namespace")
+		cmd := exec.Command("kubectl", "delete", "ns", agentRuntimeTestNamespace, "--ignore-not-found")
+		_, _ = utils.Run(cmd)
+
+		By("cleaning up cluster defaults ConfigMap")
+		cmd = exec.Command("kubectl", "delete", "configmap", "kagenti-platform-config",
+			"-n", "kagenti-system", "--ignore-not-found")
+		_, _ = utils.Run(cmd)
+
+		By("cleaning up mlflow-operator ClusterRole")
+		cmd = exec.Command("kubectl", "delete", "clusterrole",
+			"mlflow-operator-mlflow-integration", "--ignore-not-found")
+		_, _ = utils.Run(cmd)
+
+		utils.UndeployController()
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			// Dump controller logs
+			cmd := exec.Command("kubectl", "logs", "-l", "control-plane=controller-manager",
+				"-n", controllerNamespace, "--tail=100")
+			logs, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Controller logs:\n%s\n", logs)
+			}
+
+			// Dump events in test namespace
+			cmd = exec.Command("kubectl", "get", "events", "-n", agentRuntimeTestNamespace, "--sort-by=.lastTimestamp")
+			events, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Events:\n%s\n", events)
+			}
+
+			// Dump AgentRuntimes
+			cmd = exec.Command("kubectl", "get", "agentruntimes", "-n", agentRuntimeTestNamespace, "-o", "yaml")
+			runtimes, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "AgentRuntimes:\n%s\n", runtimes)
+			}
+
+			// Dump Deployments
+			cmd = exec.Command("kubectl", "get", "deployments", "-n", agentRuntimeTestNamespace, "-o", "yaml")
+			deploys, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Deployments:\n%s\n", deploys)
+			}
+		}
+	})
+
+	SetDefaultEventuallyTimeout(2 * time.Minute)
+	SetDefaultEventuallyPollingInterval(time.Second)
+
+	Context("Agent lifecycle", Ordered, func() {
+		var initialConfigHash string
+
+		It("should apply labels and config-hash to target Deployment", func() {
+			By("deploying the agent target workload")
+			_, err := utils.KubectlApplyStdin(runtimeTargetDeploymentFixture(), agentRuntimeTestNamespace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(utils.WaitForDeploymentReady("runtime-agent-target", agentRuntimeTestNamespace, 2*time.Minute)).To(Succeed())
+
+			By("creating AgentRuntime CR")
+			_, err = utils.KubectlApplyStdin(runtimeAgentCRFixture(), agentRuntimeTestNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying kagenti.io/type=agent on workload metadata")
+			Eventually(func(g Gomega) {
+				typeLabel, err := utils.KubectlGetJsonpath("deployment", "runtime-agent-target",
+					agentRuntimeTestNamespace, "{.metadata.labels['kagenti\\.io/type']}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(typeLabel).To(Equal("agent"))
+			}).Should(Succeed())
+
+			By("verifying app.kubernetes.io/managed-by on workload metadata")
+			Eventually(func(g Gomega) {
+				managedBy, err := utils.KubectlGetJsonpath("deployment", "runtime-agent-target",
+					agentRuntimeTestNamespace, "{.metadata.labels['app\\.kubernetes\\.io/managed-by']}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(managedBy).To(Equal("kagenti-operator"))
+			}).Should(Succeed())
+
+			By("verifying kagenti.io/type=agent on pod template")
+			Eventually(func(g Gomega) {
+				podTypeLabel, err := utils.KubectlGetJsonpath("deployment", "runtime-agent-target",
+					agentRuntimeTestNamespace,
+					"{.spec.template.metadata.labels['kagenti\\.io/type']}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(podTypeLabel).To(Equal("agent"))
+			}).Should(Succeed())
+
+			By("verifying config-hash annotation on pod template")
+			Eventually(func(g Gomega) {
+				hash, err := utils.KubectlGetJsonpath("deployment", "runtime-agent-target",
+					agentRuntimeTestNamespace,
+					"{.spec.template.metadata.annotations['kagenti\\.io/config-hash']}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(hash).NotTo(BeEmpty())
+				g.Expect(hash).To(HaveLen(64))
+				initialConfigHash = hash
+			}).Should(Succeed())
+
+			By("verifying AgentCard is auto-created by AgentCardSync")
+			cardName := "runtime-agent-target-deployment-card"
+			Eventually(func(g Gomega) {
+				managedBy, err := utils.KubectlGetJsonpath("agentcard", cardName,
+					agentRuntimeTestNamespace,
+					"{.metadata.labels['app\\.kubernetes\\.io/managed-by']}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(managedBy).To(Equal("kagenti-operator"))
+			}).Should(Succeed())
+
+			By("verifying AgentCard targetRef points to the runtime target")
+			Eventually(func(g Gomega) {
+				kind, err := utils.KubectlGetJsonpath("agentcard", cardName,
+					agentRuntimeTestNamespace, "{.spec.targetRef.kind}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(kind).To(Equal("Deployment"))
+
+				name, err := utils.KubectlGetJsonpath("agentcard", cardName,
+					agentRuntimeTestNamespace, "{.spec.targetRef.name}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(name).To(Equal("runtime-agent-target"))
+			}).Should(Succeed())
+		})
+
+		It("should set Phase=Active and Ready=True", func() {
+			By("verifying phase is Active")
+			Eventually(func(g Gomega) {
+				phase, err := utils.KubectlGetJsonpath("agentruntime", "test-agent-runtime",
+					agentRuntimeTestNamespace, "{.status.phase}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(phase).To(Equal("Active"))
+			}).Should(Succeed())
+
+			By("verifying Ready condition is True")
+			Eventually(func(g Gomega) {
+				readyStatus, err := utils.KubectlGetJsonpath("agentruntime", "test-agent-runtime",
+					agentRuntimeTestNamespace,
+					"{.status.conditions[?(@.type=='Ready')].status}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(readyStatus).To(Equal("True"))
+			}).Should(Succeed())
+		})
+
+		It("should not change Deployment generation on re-reconcile", func() {
+			By("recording current deployment generation")
+			gen, err := utils.KubectlGetJsonpath("deployment", "runtime-agent-target",
+				agentRuntimeTestNamespace, "{.metadata.generation}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gen).NotTo(BeEmpty())
+
+			By("verifying generation stays stable for 30s")
+			Consistently(func(g Gomega) {
+				currentGen, err := utils.KubectlGetJsonpath("deployment", "runtime-agent-target",
+					agentRuntimeTestNamespace, "{.metadata.generation}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(currentGen).To(Equal(gen))
+			}, 30*time.Second, 5*time.Second).Should(Succeed())
+		})
+
+		It("should clean up on deletion", func() {
+			By("deleting the AgentRuntime CR")
+			cmd := exec.Command("kubectl", "delete", "agentruntime", "test-agent-runtime",
+				"-n", agentRuntimeTestNamespace)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying AgentRuntime CR is gone")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "agentruntime", "test-agent-runtime",
+					"-n", agentRuntimeTestNamespace)
+				_, err := cmd.CombinedOutput()
+				g.Expect(err).To(HaveOccurred(), "AgentRuntime should be deleted")
+			}).Should(Succeed())
+
+			By("verifying target deployment still exists")
+			cmd = exec.Command("kubectl", "get", "deployment", "runtime-agent-target",
+				"-n", agentRuntimeTestNamespace)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying kagenti.io/type label is preserved")
+			Eventually(func(g Gomega) {
+				typeLabel, err := utils.KubectlGetJsonpath("deployment", "runtime-agent-target",
+					agentRuntimeTestNamespace, "{.metadata.labels['kagenti\\.io/type']}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(typeLabel).To(Equal("agent"))
+			}).Should(Succeed())
+
+			By("verifying managed-by label is removed")
+			Eventually(func(g Gomega) {
+				managedBy, err := utils.KubectlGetJsonpath("deployment", "runtime-agent-target",
+					agentRuntimeTestNamespace, "{.metadata.labels['app\\.kubernetes\\.io/managed-by']}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(managedBy).To(BeEmpty())
+			}).Should(Succeed())
+
+			By("verifying config-hash changed to defaults-only hash")
+			Eventually(func(g Gomega) {
+				hash, err := utils.KubectlGetJsonpath("deployment", "runtime-agent-target",
+					agentRuntimeTestNamespace,
+					"{.spec.template.metadata.annotations['kagenti\\.io/config-hash']}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(hash).NotTo(BeEmpty())
+				g.Expect(hash).To(HaveLen(64))
+				g.Expect(hash).NotTo(Equal(initialConfigHash))
+			}).Should(Succeed())
+		})
+	})
+
+	Context("Error cases", func() {
+		It("should set Phase=Error for missing target", func() {
+			By("creating AgentRuntime targeting non-existent deployment")
+			_, err := utils.KubectlApplyStdin(runtimeMissingTargetCRFixture(), agentRuntimeTestNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying phase is Error")
+			Eventually(func(g Gomega) {
+				phase, err := utils.KubectlGetJsonpath("agentruntime", "test-missing-target",
+					agentRuntimeTestNamespace, "{.status.phase}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(phase).To(Equal("Error"))
+			}).Should(Succeed())
+
+			By("cleaning up")
+			cmd := exec.Command("kubectl", "delete", "agentruntime", "test-missing-target",
+				"-n", agentRuntimeTestNamespace, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+	})
+
+	Context("Tool type", func() {
+		It("should apply kagenti.io/type=tool label", func() {
+			By("deploying the tool target workload")
+			_, err := utils.KubectlApplyStdin(runtimeToolTargetDeploymentFixture(), agentRuntimeTestNamespace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(utils.WaitForDeploymentReady("runtime-tool-target", agentRuntimeTestNamespace, 2*time.Minute)).To(Succeed())
+
+			By("creating tool AgentRuntime CR")
+			_, err = utils.KubectlApplyStdin(runtimeToolCRFixture(), agentRuntimeTestNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying kagenti.io/type=tool on workload metadata")
+			Eventually(func(g Gomega) {
+				typeLabel, err := utils.KubectlGetJsonpath("deployment", "runtime-tool-target",
+					agentRuntimeTestNamespace, "{.metadata.labels['kagenti\\.io/type']}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(typeLabel).To(Equal("tool"))
+			}).Should(Succeed())
+
+			By("verifying no AgentCard is created for tool-type workload")
+			Consistently(func() string {
+				cmd := exec.Command("kubectl", "get", "agentcards", "-n", agentRuntimeTestNamespace,
+					"-o", "jsonpath={.items[*].metadata.name}")
+				output, _ := utils.Run(cmd)
+				return output
+			}, 15*time.Second, 3*time.Second).ShouldNot(ContainSubstring("runtime-tool-target"))
+
+			By("cleaning up")
+			cmd := exec.Command("kubectl", "delete", "agentruntime", "test-tool-runtime",
+				"-n", agentRuntimeTestNamespace, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+	})
+
+	Context("StatefulSet target", func() {
+		It("should apply labels and config-hash to a StatefulSet workload", func() {
+			By("deploying the StatefulSet target workload")
+			_, err := utils.KubectlApplyStdin(runtimeStatefulSetTargetFixture(), agentRuntimeTestNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for StatefulSet to be ready")
+			Eventually(func(g Gomega) {
+				ready, err := utils.KubectlGetJsonpath("statefulset", "runtime-sts-target",
+					agentRuntimeTestNamespace, "{.status.readyReplicas}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(ready).To(Equal("1"))
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("creating AgentRuntime CR targeting StatefulSet")
+			_, err = utils.KubectlApplyStdin(runtimeStatefulSetCRFixture(), agentRuntimeTestNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying kagenti.io/type=agent on StatefulSet metadata")
+			Eventually(func(g Gomega) {
+				typeLabel, err := utils.KubectlGetJsonpath("statefulset", "runtime-sts-target",
+					agentRuntimeTestNamespace, "{.metadata.labels['kagenti\\.io/type']}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(typeLabel).To(Equal("agent"))
+			}).Should(Succeed())
+
+			By("verifying app.kubernetes.io/managed-by on StatefulSet metadata")
+			Eventually(func(g Gomega) {
+				managedBy, err := utils.KubectlGetJsonpath("statefulset", "runtime-sts-target",
+					agentRuntimeTestNamespace, "{.metadata.labels['app\\.kubernetes\\.io/managed-by']}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(managedBy).To(Equal("kagenti-operator"))
+			}).Should(Succeed())
+
+			By("verifying Phase=Active")
+			Eventually(func(g Gomega) {
+				phase, err := utils.KubectlGetJsonpath("agentruntime", "test-sts-runtime",
+					agentRuntimeTestNamespace, "{.status.phase}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(phase).To(Equal("Active"))
+			}).Should(Succeed())
+
+			By("verifying config-hash on pod template")
+			Eventually(func(g Gomega) {
+				hash, err := utils.KubectlGetJsonpath("statefulset", "runtime-sts-target",
+					agentRuntimeTestNamespace,
+					"{.spec.template.metadata.annotations['kagenti\\.io/config-hash']}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(hash).To(HaveLen(64))
+			}).Should(Succeed())
+
+			By("cleaning up")
+			cmd := exec.Command("kubectl", "delete", "agentruntime", "test-sts-runtime",
+				"-n", agentRuntimeTestNamespace, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+	})
+
+	Context("Identity and trace overrides", func() {
+		It("should produce a different config-hash than a minimal CR", func() {
+			By("deploying two target workloads")
+			_, err := utils.KubectlApplyStdin(runtimeMinimalTargetDeploymentFixture(), agentRuntimeTestNamespace)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = utils.KubectlApplyStdin(runtimeOverridesTargetDeploymentFixture(), agentRuntimeTestNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(utils.WaitForDeploymentReady("runtime-minimal-target", agentRuntimeTestNamespace, 2*time.Minute)).To(Succeed())
+			Expect(utils.WaitForDeploymentReady("runtime-overrides-target", agentRuntimeTestNamespace, 2*time.Minute)).To(Succeed())
+
+			By("creating minimal AgentRuntime CR (no overrides)")
+			_, err = utils.KubectlApplyStdin(runtimeMinimalCRFixture(), agentRuntimeTestNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating AgentRuntime CR with identity and trace overrides")
+			_, err = utils.KubectlApplyStdin(runtimeOverridesCRFixture(), agentRuntimeTestNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			var minimalHash, overridesHash string
+
+			By("waiting for minimal CR to reach Active")
+			Eventually(func(g Gomega) {
+				phase, err := utils.KubectlGetJsonpath("agentruntime", "test-minimal-runtime",
+					agentRuntimeTestNamespace, "{.status.phase}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(phase).To(Equal("Active"))
+			}).Should(Succeed())
+
+			By("recording minimal config-hash")
+			Eventually(func(g Gomega) {
+				hash, err := utils.KubectlGetJsonpath("deployment", "runtime-minimal-target",
+					agentRuntimeTestNamespace,
+					"{.spec.template.metadata.annotations['kagenti\\.io/config-hash']}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(hash).To(HaveLen(64))
+				minimalHash = hash
+			}).Should(Succeed())
+
+			By("waiting for overrides CR to reach Active")
+			Eventually(func(g Gomega) {
+				phase, err := utils.KubectlGetJsonpath("agentruntime", "test-overrides-runtime",
+					agentRuntimeTestNamespace, "{.status.phase}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(phase).To(Equal("Active"))
+			}).Should(Succeed())
+
+			By("recording overrides config-hash")
+			Eventually(func(g Gomega) {
+				hash, err := utils.KubectlGetJsonpath("deployment", "runtime-overrides-target",
+					agentRuntimeTestNamespace,
+					"{.spec.template.metadata.annotations['kagenti\\.io/config-hash']}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(hash).To(HaveLen(64))
+				overridesHash = hash
+			}).Should(Succeed())
+
+			By("verifying config-hashes differ")
+			Expect(overridesHash).NotTo(Equal(minimalHash),
+				"identity/trace overrides should produce a different config-hash")
+
+			By("cleaning up")
+			cmd := exec.Command("kubectl", "delete", "agentruntime", "test-minimal-runtime", "test-overrides-runtime",
+				"-n", agentRuntimeTestNamespace, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
 		})
 	})
 })

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -934,11 +934,11 @@ rules:
 				g.Expect(phase).To(Equal("Error"))
 			}).Should(Succeed())
 
-			By("verifying error condition mentions the target")
+			By("verifying TargetResolved condition mentions the target")
 			Eventually(func(g Gomega) {
 				msg, err := utils.KubectlGetJsonpath("agentruntime", "test-missing-target",
 					agentRuntimeTestNamespace,
-					"{.status.conditions[?(@.type=='Ready')].message}")
+					"{.status.conditions[?(@.type=='TargetResolved')].message}")
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(msg).To(ContainSubstring("nonexistent-deployment"))
 			}).Should(Succeed())

--- a/kagenti-operator/test/e2e/fixtures.go
+++ b/kagenti-operator/test/e2e/fixtures.go
@@ -465,3 +465,334 @@ spec:
       agentcard: "true"
 `
 }
+
+// --- AgentRuntime E2E fixtures ---
+
+const agentRuntimeTestNamespace = "e2e-agentruntime-test"
+
+// runtimeTargetDeploymentFixture returns YAML for the agent target Deployment (pause container).
+// Includes protocol label to test cross-controller interaction with AgentCardSync.
+func runtimeTargetDeploymentFixture() string {
+	return `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: runtime-agent-target
+  namespace: ` + agentRuntimeTestNamespace + `
+  labels:
+    app.kubernetes.io/name: runtime-agent-target
+    protocol.kagenti.io/a2a: ""
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: runtime-agent-target
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: runtime-agent-target
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.9
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+`
+}
+
+// runtimeAgentCRFixture returns YAML for an AgentRuntime CR with type=agent.
+func runtimeAgentCRFixture() string {
+	return `apiVersion: agent.kagenti.dev/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: test-agent-runtime
+  namespace: ` + agentRuntimeTestNamespace + `
+spec:
+  type: agent
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: runtime-agent-target
+`
+}
+
+// runtimeMissingTargetCRFixture returns YAML for an AgentRuntime CR targeting a non-existent deployment.
+func runtimeMissingTargetCRFixture() string {
+	return `apiVersion: agent.kagenti.dev/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: test-missing-target
+  namespace: ` + agentRuntimeTestNamespace + `
+spec:
+  type: agent
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nonexistent-deployment
+`
+}
+
+// runtimeToolTargetDeploymentFixture returns YAML for the tool target Deployment (pause container, no protocol labels).
+func runtimeToolTargetDeploymentFixture() string {
+	return `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: runtime-tool-target
+  namespace: ` + agentRuntimeTestNamespace + `
+  labels:
+    app.kubernetes.io/name: runtime-tool-target
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: runtime-tool-target
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: runtime-tool-target
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.9
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+`
+}
+
+// runtimeToolCRFixture returns YAML for an AgentRuntime CR with type=tool.
+func runtimeToolCRFixture() string {
+	return `apiVersion: agent.kagenti.dev/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: test-tool-runtime
+  namespace: ` + agentRuntimeTestNamespace + `
+spec:
+  type: tool
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: runtime-tool-target
+`
+}
+
+// runtimeClusterDefaultsConfigMapFixture returns YAML for the cluster-level defaults ConfigMap
+// in kagenti-system namespace (layer 1 of 3-layer config merge).
+func runtimeClusterDefaultsConfigMapFixture() string {
+	return `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kagenti-platform-config
+  namespace: kagenti-system
+data:
+  trace.endpoint: "http://otel-collector.observability:4317"
+`
+}
+
+// runtimeNamespaceDefaultsConfigMapFixture returns YAML for the namespace-level defaults ConfigMap
+// (layer 2 of 3-layer config merge). Must have kagenti.io/defaults=true label.
+func runtimeNamespaceDefaultsConfigMapFixture() string {
+	return `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: runtime-ns-defaults
+  namespace: ` + agentRuntimeTestNamespace + `
+  labels:
+    kagenti.io/defaults: "true"
+data:
+  log.level: debug
+`
+}
+
+// runtimeStatefulSetTargetFixture returns YAML for a StatefulSet target with headless Service.
+func runtimeStatefulSetTargetFixture() string {
+	return `apiVersion: v1
+kind: Service
+metadata:
+  name: runtime-sts-target
+  namespace: ` + agentRuntimeTestNamespace + `
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: runtime-sts-target
+  ports:
+    - port: 80
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: runtime-sts-target
+  namespace: ` + agentRuntimeTestNamespace + `
+  labels:
+    app.kubernetes.io/name: runtime-sts-target
+spec:
+  serviceName: runtime-sts-target
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: runtime-sts-target
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: runtime-sts-target
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.9
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+`
+}
+
+// runtimeStatefulSetCRFixture returns YAML for an AgentRuntime CR targeting a StatefulSet.
+func runtimeStatefulSetCRFixture() string {
+	return `apiVersion: agent.kagenti.dev/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: test-sts-runtime
+  namespace: ` + agentRuntimeTestNamespace + `
+spec:
+  type: agent
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: runtime-sts-target
+`
+}
+
+// runtimeMinimalTargetDeploymentFixture returns YAML for a minimal target Deployment (baseline for hash comparison).
+func runtimeMinimalTargetDeploymentFixture() string {
+	return `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: runtime-minimal-target
+  namespace: ` + agentRuntimeTestNamespace + `
+  labels:
+    app.kubernetes.io/name: runtime-minimal-target
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: runtime-minimal-target
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: runtime-minimal-target
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.9
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+`
+}
+
+// runtimeMinimalCRFixture returns YAML for an AgentRuntime CR without overrides (baseline for hash comparison).
+func runtimeMinimalCRFixture() string {
+	return `apiVersion: agent.kagenti.dev/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: test-minimal-runtime
+  namespace: ` + agentRuntimeTestNamespace + `
+spec:
+  type: agent
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: runtime-minimal-target
+`
+}
+
+// runtimeOverridesTargetDeploymentFixture returns YAML for the overrides test target Deployment.
+func runtimeOverridesTargetDeploymentFixture() string {
+	return `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: runtime-overrides-target
+  namespace: ` + agentRuntimeTestNamespace + `
+  labels:
+    app.kubernetes.io/name: runtime-overrides-target
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: runtime-overrides-target
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: runtime-overrides-target
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.9
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+`
+}
+
+// runtimeOverridesCRFixture returns YAML for an AgentRuntime CR with identity and trace overrides.
+func runtimeOverridesCRFixture() string {
+	return `apiVersion: agent.kagenti.dev/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: test-overrides-runtime
+  namespace: ` + agentRuntimeTestNamespace + `
+spec:
+  type: agent
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: runtime-overrides-target
+  identity:
+    spiffe:
+      trustDomain: custom.example.com
+  trace:
+    endpoint: "custom-collector.observability:4317"
+    protocol: grpc
+    sampling:
+      rate: 0.5
+`
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary
  - Add 8 E2E test scenarios for the AgentRuntime controller running on a real Kind cluster
  - Cover agent lifecycle (labels, status, idempotency, deletion cleanup), error handling, tool type classification,
   StatefulSet support, identity/trace config overrides, and cross-controller AgentCard auto-creation
  - Add 14 fixture functions for Deployments, StatefulSets, AgentRuntime CRs, and ConfigMaps
  - Update README with scenario table, architecture diagrams, and run instructions

  
## Related issue(s)
[RHAIENG-4354](https://redhat.atlassian.net/browse/RHAIENG-4354)

## (Optional) Testing Instructions
 ```bash
  # Create Kind cluster
  kind delete cluster 2>/dev/null; kind create cluster

  # Run E2E AgentRuntime tests
  go test ./test/e2e/ -v -ginkgo.v -ginkgo.focus="AgentRuntime E2E"

  # Cleanup
  kind delete cluster
```

🤖 Assisted-by: [Claude Code](https://claude.com/claude-code)