### PR TITLE
fix: add SPIRE trust bundle ConfigMap to scoped cache

### DIFF
--- a/kagenti-operator/cmd/configmap_cache_test.go
+++ b/kagenti-operator/cmd/configmap_cache_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Run with: make setup-envtest && go test -v -count=1 -timeout 120s ./cmd/ -run TestConfigMapCacheVisibility
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/kagenti/operator/internal/controller"
+)
+
+func TestConfigMapCacheVisibility(t *testing.T) {
+	logf.SetLogger(zap.New(zap.WriteTo(os.Stderr), zap.UseDevMode(true)))
+
+	// 1. Start a local kube-apiserver + etcd via envtest.
+	testEnv := &envtest.Environment{}
+	if dir := firstEnvTestBinaryDir(); dir != "" {
+		testEnv.BinaryAssetsDirectory = dir
+	}
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("failed to start envtest: %v", err)
+	}
+	defer func() { _ = testEnv.Stop() }()
+
+	// 2. Create a direct (non-cached) client for seeding test data.
+	directClient, err := client.New(cfg, client.Options{Scheme: clientgoscheme.Scheme})
+	if err != nil {
+		t.Fatalf("failed to create direct client: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const (
+		spireNS         = "zero-trust-workload-identity-manager"
+		spireBundleName = "spire-bundle"
+	)
+
+	// 3. Pre-create the namespaces the scoped cache will watch.
+	for _, ns := range []string{controller.ClusterDefaultsNamespace, spireNS, "agent-team-a"} {
+		nsObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
+		if err := directClient.Create(ctx, nsObj); err != nil {
+			t.Fatalf("failed to create namespace %s: %v", ns, err)
+		}
+	}
+
+	// 4. Build the scoped cache config (function under test) and start a
+	//    manager whose ConfigMap informers are restricted to those selectors.
+	cmCacheNamespaces := buildConfigMapCacheNamespaces(true, spireBundleName, spireNS)
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:         clientgoscheme.Scheme,
+		LeaderElection: false,
+		Metrics:        metricsserver.Options{BindAddress: "0"},
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.ConfigMap{}: {Namespaces: cmCacheNamespaces},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	go func() {
+		if err := mgr.Start(ctx); err != nil {
+			t.Errorf("manager exited with error: %v", err)
+		}
+	}()
+	if !mgr.GetCache().WaitForCacheSync(ctx) {
+		t.Fatal("cache never synced")
+	}
+
+	// 5. Obtain the cached client — reads go through the scoped informer cache,
+	//    so only ConfigMaps matching our selectors will be visible.
+	cachedClient := mgr.GetClient()
+
+	// 6. Seed ConfigMaps via the direct client (bypasses the cache) so we can
+	//    then verify which ones are visible through the cached client.
+	spireBundleCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: spireBundleName, Namespace: spireNS,
+		},
+		Data: map[string]string{"bundle.crt": "FAKE-BUNDLE"},
+	}
+	clusterDefaultsCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controller.ClusterDefaultsConfigMapName,
+			Namespace: controller.ClusterDefaultsNamespace,
+			Labels:    map[string]string{"app.kubernetes.io/name": "kagenti-operator-chart"},
+		},
+		Data: map[string]string{"otel-endpoint": "collector:4317"},
+	}
+	nsDefaultsCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "team-a-defaults", Namespace: "agent-team-a",
+			Labels: map[string]string{controller.LabelNamespaceDefaults: "true"},
+		},
+		Data: map[string]string{"sampling-rate": "0.5"},
+	}
+	unrelatedCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "app-config", Namespace: spireNS,
+		},
+		Data: map[string]string{"key": "value"},
+	}
+
+	for _, cm := range []*corev1.ConfigMap{spireBundleCM, clusterDefaultsCM, nsDefaultsCM, unrelatedCM} {
+		if err := directClient.Create(ctx, cm); err != nil {
+			t.Fatalf("failed to create ConfigMap %s/%s: %v", cm.Namespace, cm.Name, err)
+		}
+	}
+
+	t.Run("SPIRE trust bundle visible through cache", func(t *testing.T) {
+		got := &corev1.ConfigMap{}
+		err := cachedClient.Get(ctx, types.NamespacedName{Name: spireBundleName, Namespace: spireNS}, got)
+		if err != nil {
+			t.Fatalf("expected SPIRE trust bundle to be visible, got: %v", err)
+		}
+		if got.Data["bundle.crt"] != "FAKE-BUNDLE" {
+			t.Fatalf("unexpected data: %v", got.Data)
+		}
+	})
+
+	t.Run("cluster defaults visible through cache", func(t *testing.T) {
+		got := &corev1.ConfigMap{}
+		err := cachedClient.Get(ctx, types.NamespacedName{
+			Name: controller.ClusterDefaultsConfigMapName, Namespace: controller.ClusterDefaultsNamespace,
+		}, got)
+		if err != nil {
+			t.Fatalf("expected cluster defaults to be visible, got: %v", err)
+		}
+	})
+
+	t.Run("namespace defaults visible through cache", func(t *testing.T) {
+		got := &corev1.ConfigMap{}
+		err := cachedClient.Get(ctx, types.NamespacedName{Name: "team-a-defaults", Namespace: "agent-team-a"}, got)
+		if err != nil {
+			t.Fatalf("expected namespace defaults to be visible, got: %v", err)
+		}
+	})
+
+	t.Run("unrelated ConfigMap in SPIRE namespace is NOT visible", func(t *testing.T) {
+		got := &corev1.ConfigMap{}
+		err := cachedClient.Get(ctx, types.NamespacedName{Name: "app-config", Namespace: spireNS}, got)
+		if err == nil {
+			t.Fatal("expected unrelated ConfigMap to be filtered out by field selector, but Get succeeded")
+		}
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("expected NotFound error, got: %v", err)
+		}
+	})
+}
+
+func firstEnvTestBinaryDir() string {
+	basePath := filepath.Join("..", "bin", "k8s")
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(basePath, entry.Name())
+		}
+	}
+	return ""
+}

--- a/kagenti-operator/cmd/main.go
+++ b/kagenti-operator/cmd/main.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -253,38 +254,51 @@ func main() {
 		})
 	}
 
+	// Scope the ConfigMap informer to only kagenti-relevant ConfigMaps.
+	// Without this, the controller would cache ALL ConfigMaps cluster-wide.
+	//
+	// Three types of ConfigMaps are relevant:
+	// 1. Cluster-level defaults in kagenti-system:
+	//    - kagenti-platform-config (platform-wide sidecar config)
+	//    - kagenti-feature-gates (which AuthBridge components are enabled)
+	//    Both are deployed by the kagenti-operator Helm chart and share the
+	//    label app.kubernetes.io/name=kagenti-operator-chart.
+	//
+	// 2. Namespace-level defaults in agent namespaces:
+	//    ConfigMaps labeled kagenti.io/defaults=true, deployed by platform
+	//    engineers via Helm/Kustomize to override cluster defaults per namespace.
+	//
+	// 3. SPIRE trust bundle (when signature verification is enabled):
+	//    The trust bundle ConfigMap (e.g. spire-bundle) in its configured namespace,
+	//    selected by metadata.name via a field selector.
+	cmCacheNamespaces := map[string]cache.Config{
+		controller.ClusterDefaultsNamespace: {
+			LabelSelector: labels.SelectorFromSet(map[string]string{
+				"app.kubernetes.io/name": "kagenti-operator-chart",
+			}),
+		},
+		cache.AllNamespaces: {
+			LabelSelector: labels.SelectorFromSet(map[string]string{
+				controller.LabelNamespaceDefaults: "true",
+			}),
+		},
+	}
+	if requireA2ASignature && spireTrustBundleConfigMapNS != "" {
+		cmCacheNamespaces[spireTrustBundleConfigMapNS] = cache.Config{
+			FieldSelector: fields.SelectorFromSet(fields.Set{
+				"metadata.name": spireTrustBundleConfigMapName,
+			}),
+		}
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:  scheme,
 		Metrics: metricsServerOptions,
 		Cache: cache.Options{
 			DefaultNamespaces: getNamespacesToWatch(),
-			// Scope the ConfigMap informer to only kagenti-relevant ConfigMaps.
-			// Without this, the controller would cache ALL ConfigMaps cluster-wide.
-			//
-			// Two types of ConfigMaps are relevant:
-			// 1. Cluster-level defaults in kagenti-system:
-			//    - kagenti-platform-config (platform-wide sidecar config)
-			//    - kagenti-feature-gates (which AuthBridge components are enabled)
-			//    Both are deployed by the kagenti-operator Helm chart and share the
-			//    label app.kubernetes.io/name=kagenti-operator-chart.
-			//
-			// 2. Namespace-level defaults in agent namespaces:
-			//    ConfigMaps labeled kagenti.io/defaults=true, deployed by platform
-			//    engineers via Helm/Kustomize to override cluster defaults per namespace.
 			ByObject: map[client.Object]cache.ByObject{
 				&corev1.ConfigMap{}: {
-					Namespaces: map[string]cache.Config{
-						controller.ClusterDefaultsNamespace: {
-							LabelSelector: labels.SelectorFromSet(map[string]string{
-								"app.kubernetes.io/name": "kagenti-operator-chart",
-							}),
-						},
-						cache.AllNamespaces: {
-							LabelSelector: labels.SelectorFromSet(map[string]string{
-								controller.LabelNamespaceDefaults: "true",
-							}),
-						},
-					},
+					Namespaces: cmCacheNamespaces,
 				},
 			},
 		},

--- a/kagenti-operator/cmd/main.go
+++ b/kagenti-operator/cmd/main.go
@@ -254,42 +254,9 @@ func main() {
 		})
 	}
 
-	// Scope the ConfigMap informer to only kagenti-relevant ConfigMaps.
-	// Without this, the controller would cache ALL ConfigMaps cluster-wide.
-	//
-	// Three types of ConfigMaps are relevant:
-	// 1. Cluster-level defaults in kagenti-system:
-	//    - kagenti-platform-config (platform-wide sidecar config)
-	//    - kagenti-feature-gates (which AuthBridge components are enabled)
-	//    Both are deployed by the kagenti-operator Helm chart and share the
-	//    label app.kubernetes.io/name=kagenti-operator-chart.
-	//
-	// 2. Namespace-level defaults in agent namespaces:
-	//    ConfigMaps labeled kagenti.io/defaults=true, deployed by platform
-	//    engineers via Helm/Kustomize to override cluster defaults per namespace.
-	//
-	// 3. SPIRE trust bundle (when signature verification is enabled):
-	//    The trust bundle ConfigMap (e.g. spire-bundle) in its configured namespace,
-	//    selected by metadata.name via a field selector.
-	cmCacheNamespaces := map[string]cache.Config{
-		controller.ClusterDefaultsNamespace: {
-			LabelSelector: labels.SelectorFromSet(map[string]string{
-				"app.kubernetes.io/name": "kagenti-operator-chart",
-			}),
-		},
-		cache.AllNamespaces: {
-			LabelSelector: labels.SelectorFromSet(map[string]string{
-				controller.LabelNamespaceDefaults: "true",
-			}),
-		},
-	}
-	if requireA2ASignature && spireTrustBundleConfigMapNS != "" {
-		cmCacheNamespaces[spireTrustBundleConfigMapNS] = cache.Config{
-			FieldSelector: fields.SelectorFromSet(fields.Set{
-				"metadata.name": spireTrustBundleConfigMapName,
-			}),
-		}
-	}
+	cmCacheNamespaces := buildConfigMapCacheNamespaces(
+		requireA2ASignature, spireTrustBundleConfigMapName, spireTrustBundleConfigMapNS,
+	)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:  scheme,
@@ -521,6 +488,51 @@ func getNamespacesToWatch() map[string]cache.Config {
 	}
 	if len(namespaces) == 0 {
 		return nil
+	}
+	return namespaces
+}
+
+// buildConfigMapCacheNamespaces returns the per-namespace cache selectors for
+// ConfigMaps. The scoped cache ensures only kagenti-relevant ConfigMaps are
+// watched instead of every ConfigMap cluster-wide.
+//
+// Three categories are included:
+//  1. Cluster-level defaults in kagenti-system (label selector).
+//  2. Namespace-level defaults in any namespace (label selector).
+//  3. SPIRE trust bundle (field selector on metadata.name), added only when
+//     signature verification is enabled.
+func buildConfigMapCacheNamespaces(
+	requireA2ASignature bool, spireTrustBundleConfigMapName, spireTrustBundleConfigMapNS string,
+) map[string]cache.Config {
+	namespaces := map[string]cache.Config{
+		controller.ClusterDefaultsNamespace: {
+			LabelSelector: labels.SelectorFromSet(map[string]string{
+				"app.kubernetes.io/name": "kagenti-operator-chart",
+			}),
+		},
+		cache.AllNamespaces: {
+			LabelSelector: labels.SelectorFromSet(map[string]string{
+				controller.LabelNamespaceDefaults: "true",
+			}),
+		},
+	}
+	if requireA2ASignature && spireTrustBundleConfigMapNS != "" {
+		if _, collision := namespaces[spireTrustBundleConfigMapNS]; collision {
+			setupLog.Error(
+				errors.New("namespace collision: --spire-trust-bundle-configmap-namespace matches "+
+					"the cluster defaults namespace"),
+				"SPIRE trust bundle will not be cached; signature verification may fail. "+
+					"Use a different namespace for the trust bundle ConfigMap",
+				"trustBundleNamespace", spireTrustBundleConfigMapNS,
+				"clusterDefaultsNamespace", controller.ClusterDefaultsNamespace,
+			)
+		} else {
+			namespaces[spireTrustBundleConfigMapNS] = cache.Config{
+				FieldSelector: fields.SelectorFromSet(fields.Set{
+					"metadata.name": spireTrustBundleConfigMapName,
+				}),
+			}
+		}
 	}
 	return namespaces
 }

--- a/kagenti-operator/cmd/main_test.go
+++ b/kagenti-operator/cmd/main_test.go
@@ -14,9 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Run with: go test -v -count=1 ./cmd/ -run TestBuildConfigMapCacheNamespaces
+
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+
+	"github.com/kagenti/operator/internal/controller"
+)
 
 func TestAuthBridgeWebhooksEnabled(t *testing.T) {
 	t.Run("enables when unset", func(t *testing.T) {
@@ -37,4 +45,88 @@ func TestAuthBridgeWebhooksEnabled(t *testing.T) {
 			t.Fatal("expected webhooks disabled when ENABLE_WEBHOOKS=false")
 		}
 	})
+}
+
+func TestBuildConfigMapCacheNamespaces(t *testing.T) {
+	t.Run("base config always includes cluster defaults and namespace defaults", func(t *testing.T) {
+		result := buildConfigMapCacheNamespaces(false, "", "")
+
+		if _, ok := result[controller.ClusterDefaultsNamespace]; !ok {
+			t.Fatalf("expected entry for %s", controller.ClusterDefaultsNamespace)
+		}
+		if _, ok := result[cache.AllNamespaces]; !ok {
+			t.Fatal("expected entry for AllNamespaces (namespace-level defaults)")
+		}
+		if len(result) != 2 {
+			t.Fatalf("expected exactly 2 entries, got %d", len(result))
+		}
+	})
+
+	t.Run("adds SPIRE trust bundle namespace when signature verification enabled", func(t *testing.T) {
+		const spireNS = "zero-trust-workload-identity-manager"
+		result := buildConfigMapCacheNamespaces(true, "spire-bundle", spireNS)
+
+		spireCfg, ok := result[spireNS]
+		if !ok {
+			t.Fatalf("expected cache entry for %s namespace", spireNS)
+		}
+		if spireCfg.FieldSelector == nil {
+			t.Fatal("expected FieldSelector on SPIRE cache entry")
+		}
+		if !spireCfg.FieldSelector.Matches(fieldSet("spire-bundle")) {
+			t.Fatal("expected FieldSelector to match ConfigMap named spire-bundle")
+		}
+		if spireCfg.FieldSelector.Matches(fieldSet("other-configmap")) {
+			t.Fatal("expected FieldSelector to NOT match other ConfigMap names")
+		}
+		if len(result) != 3 {
+			t.Fatalf("expected 3 entries (cluster + namespace + SPIRE), got %d", len(result))
+		}
+	})
+
+	t.Run("does not add SPIRE entry when flag is false", func(t *testing.T) {
+		const spireNS = "zero-trust-workload-identity-manager"
+		result := buildConfigMapCacheNamespaces(false, "spire-bundle", spireNS)
+
+		if _, ok := result[spireNS]; ok {
+			t.Fatal("expected no SPIRE entry when requireA2ASignature is false")
+		}
+		if len(result) != 2 {
+			t.Fatalf("expected 2 entries, got %d", len(result))
+		}
+	})
+
+	t.Run("does not add SPIRE entry when namespace is empty", func(t *testing.T) {
+		result := buildConfigMapCacheNamespaces(true, "spire-bundle", "")
+
+		if len(result) != 2 {
+			t.Fatalf("expected 2 entries, got %d", len(result))
+		}
+	})
+
+	t.Run("namespace collision preserves existing label selector", func(t *testing.T) {
+		result := buildConfigMapCacheNamespaces(true, "spire-bundle", controller.ClusterDefaultsNamespace)
+
+		cfg := result[controller.ClusterDefaultsNamespace]
+		if cfg.LabelSelector == nil {
+			t.Fatal("expected original LabelSelector to be preserved when namespaces collide")
+		}
+		if cfg.FieldSelector != nil {
+			t.Fatal("expected SPIRE FieldSelector to NOT be added when namespaces collide")
+		}
+		if len(result) != 2 {
+			t.Fatalf("expected 2 entries (no SPIRE entry added), got %d", len(result))
+		}
+	})
+}
+
+// fieldSet is a minimal fields.Fields implementation for test assertions.
+type fieldSet string
+
+func (f fieldSet) Has(field string) bool { return field == "metadata.name" }
+func (f fieldSet) Get(field string) string {
+	if field == "metadata.name" {
+		return string(f)
+	}
+	return ""
 }

--- a/kagenti-operator/test/utils/utils.go
+++ b/kagenti-operator/test/utils/utils.go
@@ -293,13 +293,6 @@ func InstallSpire(trustDomain string) error {
 		"--wait",
 		"--timeout", "5m",
 	)
-	if _, err := Run(cmd); err != nil {
-		return err
-	}
-
-	By("labeling spire-bundle configmap for controller cache visibility")
-	cmd = exec.Command("kubectl", "label", "--overwrite", "configmap", "spire-bundle",
-		"-n", "spire-system", "kagenti.io/defaults=true")
 	_, err := Run(cmd)
 	return err
 }


### PR DESCRIPTION
## Summary

- Add the SPIRE trust bundle ConfigMap to the manager's scoped cache via a field selector on `metadata.name`, conditionally when `--require-a2a-signature=true`
- Remove E2E workaround that manually labeled `spire-bundle` with `kagenti.io/defaults=true`

Closes #251

## Previously

The ConfigMap cache was scoped to kagenti-labeled ConfigMaps only. The SPIRE trust bundle (e.g. `spire-bundle`) is managed by SPIRE and has no kagenti labels, so `mgr.GetClient().Get()` returned "not found". Signature verification failed silently and `SignatureVerified` stayed `False`. This PR fixes this by adding a field selector entry for the trust bundle ConfigMap to the cache when signature verification is enabled.

## Test plan

- 1. Pull this branch, build the operator image, push to a registry, and deploy on OpenShift
- 2. Add signature verification flags to the manager deployment:
  ```bash
  oc edit deployment kagenti-controller-manager -n kagenti-system
  ```
  Add these args:
  ```yaml
  - "--require-a2a-signature=true"
  - "--spire-trust-domain=<your-trust-domain>"
  - "--spire-trust-bundle-configmap=spire-bundle"
  - "--spire-trust-bundle-configmap-namespace=<spire-namespace>"
  - "--spire-trust-bundle-configmap-key=bundle.crt"
  ```
- 3. Verify the operator starts without "ConfigMap not found" errors:
  ```bash
  oc logs -n kagenti-system deployment/kagenti-controller-manager \
    | grep -i "trust\|bundle\|signature"
  ```
  Expected: `"Signature verification enabled"` with no trust bundle errors.