### PR TITLE
feat: create AuthBridge sidecar injection E2E tests

### DIFF
--- a/kagenti-operator/test/e2e/README.md
+++ b/kagenti-operator/test/e2e/README.md
@@ -1,8 +1,9 @@
 # E2E Tests
 
-End-to-end tests for the kagenti-operator. The suite runs 16 specs:
+End-to-end tests for the kagenti-operator. The suite runs 20 specs:
 
 - **Manager tests** (2 specs) — controller pod readiness and Prometheus metrics
+- **AuthBridge Injection tests** (4 specs) — sidecar injection, idempotency, opt-out, and HTTP validation
 - **AgentCard tests** (6 specs) — webhook validation, auto-discovery, duplicate prevention, audit mode, and SPIRE signature verification
 - **AgentRuntime tests** (8 specs) — label application, status lifecycle, idempotency, error handling, tool type, StatefulSet support, identity/trace overrides, and deletion cleanup
 
@@ -13,7 +14,7 @@ End-to-end tests for the kagenti-operator. The suite runs 16 specs:
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) — `brew install kubectl`
 - Container runtime: **Docker** or **Podman**
 
-The test suite auto-detects Docker vs Podman. No env vars needed.
+The test suite auto-detects Docker vs Podman. No env vars needed. AuthBridge sidecar images (`envoy-with-processor`, `proxy-init`, `spiffe-helper`) are pulled from `ghcr.io/kagenti/kagenti-extensions` and loaded into Kind during setup.
 
 ## Run
 
@@ -21,7 +22,7 @@ The test suite auto-detects Docker vs Podman. No env vars needed.
 # Create a fresh Kind cluster
 kind delete cluster 2>/dev/null; kind create cluster
 
-# Run all 16 specs (~12 min)
+# Run all 20 specs (~15 min)
 make test-e2e
 ```
 
@@ -41,6 +42,9 @@ make test-e2e
 ## Run specific scenarios
 
 ```bash
+# AuthBridge injection tests only (~3 min)
+go test ./test/e2e/ -v -ginkgo.v -ginkgo.focus="AuthBridge"
+
 # Webhook + auto-discovery tests only (~4 min)
 go test ./test/e2e/ -v -ginkgo.v -ginkgo.focus="should reject AgentCard|should not create|should auto-create|should reject duplicate"
 
@@ -64,6 +68,10 @@ kind delete cluster
 
 | Scenario | Context | What it tests |
 |----------|---------|---------------|
+| Inject sidecars | AuthBridge injection | Webhook injects `envoy-proxy`, `spiffe-helper` containers, `proxy-init` init container, and expected volumes |
+| Idempotency | AuthBridge injection | Pod recreation produces exactly 1 of each sidecar (no duplicates) |
+| Injection opt-out | AuthBridge injection | Pod with `kagenti.io/inject=disabled` label gets zero sidecars |
+| HTTP validation | AuthBridge injection | Traffic flows through injected envoy proxy (curl → service → iptables → envoy → app) |
 | Reject missing targetRef | Without signature | Webhook rejects AgentCard with no `spec.targetRef` |
 | No protocol label | Without signature | Workload with `kagenti.io/type=agent` but no `protocol.kagenti.io/*` label gets no auto-created card |
 | Auto-discovery | Without signature | Properly labeled workload gets an auto-created AgentCard with correct targetRef, protocol, and Synced=True |
@@ -91,13 +99,16 @@ BeforeSuite (once per suite)
 ├── Install Prometheus Operator v0.77.1 (metrics/ServiceMonitor CRDs)
 ├── Install CertManager v1.16.3 (webhook TLS certificates)
 ├── Build & load agentcard-signer image into Kind
+├── Pull & load AuthBridge sidecar images (envoy-with-processor, proxy-init, spiffe-helper)
 └── Install SPIRE via Helm (spire-crds v0.5.0 + spire v0.28.3)
 
 BeforeAll (per Describe block)
-├── make install → applies AgentCard CRD via kustomize
+├── make install → applies AgentCard + AgentRuntime CRDs via kustomize
 ├── make deploy → creates namespace, RBAC, Deployment, webhook, ServiceMonitor
 ├── Wait for controller pod Running + webhook endpoint ready
-└── Create test namespace e2e-agentcard-test (labeled agentcard=true + PSA restricted)
+└── Create test namespace:
+    ├── e2e-authbridge-test (kagenti-enabled=true, PSA privileged — for proxy-init NET_ADMIN)
+    └── e2e-agentcard-test (agentcard=true, PSA restricted)
 ```
 
 ### How the operator is installed
@@ -135,21 +146,25 @@ kind load docker-image           ▼                   kubectl apply --server-si
                             ▼
 ┌─ kagenti-operator-system ────────────────────────────────────────┐
 │  Controller Manager Pod                                           │
-│  ├── Webhook server (validates AgentCard create/update)           │
+│  ├── Mutating webhook (injects AuthBridge sidecars into pods)     │
+│  ├── Validating webhook (validates AgentCard/AgentRuntime CRs)    │
 │  ├── Metrics server (HTTPS, scraped by Prometheus)                │
 │  ├── AgentCardSync controller                                     │
 │  │   watches Deployments → auto-creates AgentCards                │
 │  └── AgentCard controller                                         │
 │      fetches card metadata, verifies signatures, evaluates binding│
-└───────────────────────────┬──────────────────────────────────────┘
-                            │ fetches /.well-known/agent-card.json
-                            ▼
-┌─ e2e-agentcard-test ─────────────────────────────────────────────┐
-│  Agent Deployments (echo-agent, audit-agent, signed-agent)        │
-│  Services (expose agents for card fetching)                       │
-│  AgentCard CRs (auto-created or manually applied)                 │
-└───────────────────────────▲──────────────────────────────────────┘
-                            │ SPIRE CSI volume provides SVIDs
+└──────────┬────────────────────────────────┬──────────────────────┘
+           │ injects sidecars               │ fetches agent-card.json
+           ▼                                ▼
+┌─ e2e-authbridge-test ────────────┐ ┌─ e2e-agentcard-test ────────┐
+│  authbridge-agent Deployment      │ │  Agent Deployments           │
+│  ├── echo container (app:8080)    │ │  (echo, audit, signed)       │
+│  ├── envoy-proxy (injected)       │ │  Services + AgentCard CRs    │
+│  ├── spiffe-helper (injected)     │ └──────────▲─────────────────┘
+│  └── proxy-init (injected init)   │            │ SPIRE CSI volumes
+│  disabled-agent (no injection)    │            │
+│  ConfigMaps + AgentRuntime CR     │            │
+└──────────────────────────────────┘            │
 ┌─ spire-system ───────────┴──────────────────────────────────────┐
 │  SPIRE Server → issues SVIDs via ClusterSPIFFEID policies         │
 │  SPIRE Agent (DaemonSet) → distributes SVIDs via CSI driver       │
@@ -202,6 +217,36 @@ AgentRuntime adds `kagenti.io/type=agent`, AgentCardSync auto-creates an AgentCa
 to sync (pause container serves no HTTP). This is expected and harmless.
 
 ### Test scenario details
+
+#### Inject sidecars
+
+Deploys `authbridge-agent` with `kagenti.io/type=agent` label and a matching AgentRuntime CR.
+The mutating webhook (`inject.kagenti.io`) intercepts the pod CREATE, calls `InjectAuthBridge`,
+and adds: `envoy-proxy` sidecar (envoy with passthrough config), `spiffe-helper` sidecar
+(manages SVID rotation), and `proxy-init` init container (sets up iptables rules for traffic
+interception as root with NET_ADMIN/NET_RAW). The test verifies container names, init container
+names, and injected volumes (`shared-data`, `spire-agent-socket`, `spiffe-helper-config`,
+`svid-output`, `envoy-config`, `authproxy-routes`).
+
+#### Idempotency
+
+Deletes the running `authbridge-agent` pod and waits for the Deployment to recreate it.
+Verifies the new pod has exactly 1 `envoy-proxy`, 1 `spiffe-helper`, and 1 `proxy-init` —
+no duplicate injection occurs on pod recreation.
+
+#### Injection opt-out
+
+Deploys `disabled-agent` with `kagenti.io/inject=disabled` label on the pod template.
+The webhook's `objectSelector` (matching `kagenti.io/inject NOT IN [disabled]`) filters
+this pod at the API server level, so the webhook handler is never called. The test verifies
+zero sidecar containers and zero init containers.
+
+#### HTTP validation
+
+Waits for `envoy-proxy` to be ready, then:
+1. Execs into the echo container and curls envoy admin at `127.0.0.1:9901/server_info` (asserts 200)
+2. Runs a curl pod targeting the `authbridge-agent` Service on port 8080
+3. Asserts HTTP 200, proving traffic flows: curl → Service → iptables → envoy:15124 → app:8080
 
 #### Reject missing targetRef
 

--- a/kagenti-operator/test/e2e/e2e_suite_test.go
+++ b/kagenti-operator/test/e2e/e2e_suite_test.go
@@ -52,6 +52,13 @@ var (
 
 	// signerImage is the agentcard-signer init-container image
 	signerImage = "ghcr.io/kagenti/kagenti-operator/agentcard-signer:e2e-test"
+
+	// sidecarImages are the AuthBridge sidecar images to pull and load into Kind
+	sidecarImages = []string{
+		"ghcr.io/kagenti/kagenti-extensions/envoy-with-processor:latest",
+		"ghcr.io/kagenti/kagenti-extensions/proxy-init:latest",
+		"ghcr.io/kagenti/kagenti-extensions/spiffe-helper:latest",
+	}
 )
 
 // TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
@@ -113,6 +120,10 @@ var _ = BeforeSuite(func() {
 	By("loading the agentcard-signer image on Kind")
 	err = utils.LoadImageToKindClusterWithName(signerImage)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the agentcard-signer image into Kind")
+
+	By("pulling and loading AuthBridge sidecar images into Kind")
+	Expect(utils.PullAndLoadSidecarImages(sidecarImages)).To(Succeed(),
+		"Failed to pull and load AuthBridge sidecar images")
 
 	if !skipSpireInstall {
 		By("checking if SPIRE is installed already")

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -444,7 +444,11 @@ var _ = Describe("AuthBridge Injection E2E", Ordered, func() {
 					authBridgeTestNamespace,
 					"{.items[?(@.metadata.labels.app\\.kubernetes\\.io/name=='authbridge-agent')].spec.volumes[*].name}")
 				g.Expect(err).NotTo(HaveOccurred())
-				for _, vol := range []string{"shared-data", "spire-agent-socket", "spiffe-helper-config", "svid-output", "envoy-config", "authproxy-routes"} {
+				expectedVolumes := []string{
+					"shared-data", "spire-agent-socket", "spiffe-helper-config",
+					"svid-output", "envoy-config", "authproxy-routes",
+				}
+				for _, vol := range expectedVolumes {
 					g.Expect(volumes).To(ContainSubstring(vol), "expected volume %s", vol)
 				}
 			}).Should(Succeed())
@@ -521,7 +525,9 @@ var _ = Describe("AuthBridge Injection E2E", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("waiting for deployment to be ready")
-			Expect(utils.WaitForDeploymentReady("authbridge-disabled-agent", authBridgeTestNamespace, 2*time.Minute)).To(Succeed())
+			Expect(utils.WaitForDeploymentReady(
+				"authbridge-disabled-agent", authBridgeTestNamespace, 2*time.Minute,
+			)).To(Succeed())
 
 			By("verifying only pause container, no sidecars")
 			cmd := exec.Command("kubectl", "get", "pods",

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -318,6 +318,299 @@ type tokenRequest struct {
 	} `json:"status"`
 }
 
+var _ = Describe("AuthBridge Injection E2E", Ordered, func() {
+	const controllerNamespace = "kagenti-operator-system"
+
+	BeforeAll(func() {
+		Expect(utils.DeployController(controllerNamespace, projectImage)).To(Succeed(), "Failed to deploy controller")
+
+		By("waiting for controller-manager to be ready")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
+				"-n", controllerNamespace,
+				"-o", "go-template={{ range .items }}{{ if not .metadata.deletionTimestamp }}{{ .status.phase }}{{ end }}{{ end }}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(ContainSubstring("Running"))
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+		By("waiting for webhook endpoint to be ready")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "endpoints",
+				"kagenti-operator-webhook-service", "-n", controllerNamespace,
+				"-o", "jsonpath={.subsets[0].addresses[0].ip}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).NotTo(BeEmpty(), "webhook endpoint not yet populated")
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+		By("creating auth bridge test namespace")
+		cmd := exec.Command("kubectl", "create", "ns", authBridgeTestNamespace)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd = exec.Command("kubectl", "label", "--overwrite", "ns", authBridgeTestNamespace,
+			"kagenti-enabled=true",
+			"pod-security.kubernetes.io/enforce=privileged",
+			"pod-security.kubernetes.io/warn=baseline")
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating ClusterSPIFFEID for auth bridge test namespace")
+		_, err = utils.KubectlApplyStdin(authBridgeClusterSPIFFEIDFixture(), "")
+		Expect(err).NotTo(HaveOccurred())
+
+		By("applying auth bridge ConfigMaps")
+		_, err = utils.KubectlApplyStdin(authBridgeConfigMapFixture(), authBridgeTestNamespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating AgentRuntime CR for authbridge-agent (with retry for webhook readiness)")
+		Eventually(func() error {
+			_, err := utils.KubectlApplyStdin(authBridgeAgentRuntimeFixture(), authBridgeTestNamespace)
+			return err
+		}, 1*time.Minute, 5*time.Second).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		By("deleting auth bridge test namespace")
+		cmd := exec.Command("kubectl", "delete", "ns", authBridgeTestNamespace, "--ignore-not-found")
+		_, _ = utils.Run(cmd)
+
+		By("cleaning up ClusterSPIFFEID")
+		cmd = exec.Command("kubectl", "delete", "clusterspiffeid", "e2e-authbridge-test", "--ignore-not-found")
+		_, _ = utils.Run(cmd)
+
+		utils.UndeployController()
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			cmd := exec.Command("kubectl", "logs", "-l", "control-plane=controller-manager",
+				"-n", controllerNamespace, "--tail=100")
+			logs, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Controller logs:\n%s\n", logs)
+			}
+
+			cmd = exec.Command("kubectl", "get", "events", "-n", authBridgeTestNamespace, "--sort-by=.lastTimestamp")
+			events, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Events:\n%s\n", events)
+			}
+
+			cmd = exec.Command("kubectl", "describe", "pods", "-n", authBridgeTestNamespace)
+			desc, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Pod descriptions:\n%s\n", desc)
+			}
+		}
+	})
+
+	SetDefaultEventuallyTimeout(2 * time.Minute)
+	SetDefaultEventuallyPollingInterval(time.Second)
+
+	Context("Sidecar injection", Ordered, func() {
+		It("should inject envoy-proxy, proxy-init, and spiffe-helper", func() {
+			By("deploying authbridge-agent")
+			_, err := utils.KubectlApplyStdin(authBridgeAgentFixture(), authBridgeTestNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for deployment to be ready")
+			Expect(utils.WaitForDeploymentReady("authbridge-agent", authBridgeTestNamespace, 3*time.Minute)).To(Succeed())
+
+			By("verifying injected sidecar containers")
+			Eventually(func(g Gomega) {
+				containers, err := utils.KubectlGetJsonpath("pod", "",
+					authBridgeTestNamespace,
+					"{.items[?(@.metadata.labels.app\\.kubernetes\\.io/name=='authbridge-agent')].spec.containers[*].name}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(containers).To(ContainSubstring("envoy-proxy"))
+				g.Expect(containers).To(ContainSubstring("spiffe-helper"))
+				g.Expect(containers).NotTo(ContainSubstring("kagenti-client-registration"))
+			}).Should(Succeed())
+
+			By("verifying injected init containers")
+			Eventually(func(g Gomega) {
+				initContainers, err := utils.KubectlGetJsonpath("pod", "",
+					authBridgeTestNamespace,
+					"{.items[?(@.metadata.labels.app\\.kubernetes\\.io/name=='authbridge-agent')].spec.initContainers[*].name}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(initContainers).To(ContainSubstring("proxy-init"))
+			}).Should(Succeed())
+
+			By("verifying injected volumes")
+			Eventually(func(g Gomega) {
+				volumes, err := utils.KubectlGetJsonpath("pod", "",
+					authBridgeTestNamespace,
+					"{.items[?(@.metadata.labels.app\\.kubernetes\\.io/name=='authbridge-agent')].spec.volumes[*].name}")
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, vol := range []string{"shared-data", "spire-agent-socket", "spiffe-helper-config", "svid-output", "envoy-config", "authproxy-routes"} {
+					g.Expect(volumes).To(ContainSubstring(vol), "expected volume %s", vol)
+				}
+			}).Should(Succeed())
+		})
+
+		It("should not duplicate sidecars on pod recreation (idempotency)", func() {
+			By("getting current pod name")
+			var oldPodName string
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "pods",
+					"-l", "app.kubernetes.io/name=authbridge-agent",
+					"-n", authBridgeTestNamespace,
+					"-o", "jsonpath={.items[0].metadata.name}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(BeEmpty())
+				oldPodName = output
+			}).Should(Succeed())
+
+			By("deleting the pod")
+			cmd := exec.Command("kubectl", "delete", "pod", oldPodName, "-n", authBridgeTestNamespace)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for new pod to be running with a different name")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "pods",
+					"-l", "app.kubernetes.io/name=authbridge-agent",
+					"-n", authBridgeTestNamespace,
+					"-o", "jsonpath={.items[0].metadata.name}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(BeEmpty())
+				g.Expect(output).NotTo(Equal(oldPodName), "new pod should have a different name")
+
+				phase, err := utils.KubectlGetJsonpath("pod", output, authBridgeTestNamespace, "{.status.phase}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(phase).To(Equal("Running"))
+			}, 3*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("verifying exactly 1 envoy-proxy, 1 spiffe-helper, 1 proxy-init")
+			cmd = exec.Command("kubectl", "get", "pods",
+				"-l", "app.kubernetes.io/name=authbridge-agent",
+				"-n", authBridgeTestNamespace,
+				"-o", "jsonpath={.items[0].spec.containers[*].name}")
+			containers, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.Count(containers, "envoy-proxy")).To(Equal(1), "expected exactly 1 envoy-proxy")
+			Expect(strings.Count(containers, "spiffe-helper")).To(Equal(1), "expected exactly 1 spiffe-helper")
+
+			cmd = exec.Command("kubectl", "get", "pods",
+				"-l", "app.kubernetes.io/name=authbridge-agent",
+				"-n", authBridgeTestNamespace,
+				"-o", "jsonpath={.items[0].spec.initContainers[*].name}")
+			initContainers, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.Count(initContainers, "proxy-init")).To(Equal(1), "expected exactly 1 proxy-init")
+		})
+	})
+
+	Context("Injection opt-out", func() {
+		It("should not inject when kagenti.io/inject=disabled", func() {
+			By("creating AgentRuntime for disabled agent")
+			_, err := utils.KubectlApplyStdin(authBridgeDisabledAgentRuntimeFixture(), authBridgeTestNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying AgentRuntime CR exists")
+			_, err = utils.KubectlGetJsonpath("agentruntime", "authbridge-disabled-agent",
+				authBridgeTestNamespace, "{.metadata.name}")
+			Expect(err).NotTo(HaveOccurred(), "AgentRuntime CR must exist before deploying disabled agent")
+
+			By("deploying disabled agent")
+			_, err = utils.KubectlApplyStdin(authBridgeDisabledAgentFixture(), authBridgeTestNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for deployment to be ready")
+			Expect(utils.WaitForDeploymentReady("authbridge-disabled-agent", authBridgeTestNamespace, 2*time.Minute)).To(Succeed())
+
+			By("verifying only pause container, no sidecars")
+			cmd := exec.Command("kubectl", "get", "pods",
+				"-l", "app.kubernetes.io/name=authbridge-disabled-agent",
+				"-n", authBridgeTestNamespace,
+				"-o", "jsonpath={.items[0].spec.containers[*].name}")
+			containers, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(containers).To(Equal("pause"), "expected only pause container")
+
+			By("verifying no init containers")
+			cmd = exec.Command("kubectl", "get", "pods",
+				"-l", "app.kubernetes.io/name=authbridge-disabled-agent",
+				"-n", authBridgeTestNamespace,
+				"-o", "jsonpath={.items[0].spec.initContainers[*].name}")
+			initContainers, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.TrimSpace(initContainers)).To(BeEmpty(), "expected no init containers")
+		})
+	})
+
+	Context("HTTP validation", func() {
+		It("should route HTTP traffic through the injected envoy proxy", func() {
+			By("waiting for envoy-proxy container to be ready")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "pods",
+					"-l", "app.kubernetes.io/name=authbridge-agent",
+					"-n", authBridgeTestNamespace,
+					"-o", "jsonpath={.items[0].status.containerStatuses[?(@.name=='envoy-proxy')].ready}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("true"), "envoy-proxy container not ready")
+			}, 3*time.Minute, 2*time.Second).Should(Succeed())
+
+			// Verify envoy admin is responding. The request originates from the echo
+			// container (non-proxy UID) so proxy-init iptables redirect it through
+			// envoy's outbound listener, which forwards to the original destination
+			// 127.0.0.1:9901 (envoy admin). The response is genuinely from envoy admin.
+			By("hitting envoy admin interface from the echo container")
+			var podName string
+			cmd := exec.Command("kubectl", "get", "pods",
+				"-l", "app.kubernetes.io/name=authbridge-agent",
+				"-n", authBridgeTestNamespace,
+				"-o", "jsonpath={.items[0].metadata.name}")
+			podName, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			podName = strings.TrimSpace(podName)
+
+			cmd = exec.Command("kubectl", "exec", podName,
+				"-n", authBridgeTestNamespace,
+				"-c", "echo",
+				"--", "python3", "-c",
+				"import urllib.request; r = urllib.request.urlopen('http://127.0.0.1:9901/server_info'); print(r.status)")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.TrimSpace(output)).To(Equal("200"), "envoy admin should return 200")
+
+			By("running a curl pod to hit authbridge-agent service")
+			curlPodName := "curl-authbridge-test"
+			cmd = exec.Command("kubectl", "run", curlPodName,
+				"--restart=Never",
+				"--namespace", authBridgeTestNamespace,
+				"--image=curlimages/curl:latest",
+				"--command", "--",
+				"curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
+				fmt.Sprintf("http://authbridge-agent.%s.svc:8080/", authBridgeTestNamespace))
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for curl pod to complete")
+			Eventually(func(g Gomega) {
+				phase, err := utils.KubectlGetJsonpath("pod", curlPodName, authBridgeTestNamespace, "{.status.phase}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(phase).To(Equal("Succeeded"))
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("verifying HTTP 200 response")
+			cmd = exec.Command("kubectl", "logs", curlPodName, "-n", authBridgeTestNamespace)
+			curlOutput, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.TrimSpace(curlOutput)).To(Equal("200"), "expected HTTP 200 through envoy proxy")
+
+			By("cleaning up curl pod")
+			cmd = exec.Command("kubectl", "delete", "pod", curlPodName, "-n", authBridgeTestNamespace, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+	})
+})
+
 var _ = Describe("AgentCard E2E", Ordered, func() {
 	const controllerNamespace = "kagenti-operator-system"
 	const controllerDeployment = "kagenti-operator-controller-manager"

--- a/kagenti-operator/test/e2e/fixtures.go
+++ b/kagenti-operator/test/e2e/fixtures.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2e
 
 const testNamespace = "e2e-agentcard-test"
+const authBridgeTestNamespace = "e2e-authbridge-test"
 
 // echoAgentFixture returns YAML for echo-agent Deployment + Service (used by S1, S3).
 func echoAgentFixture() string {
@@ -794,5 +795,268 @@ spec:
     protocol: grpc
     sampling:
       rate: 0.5
+`
+}
+
+// --- AuthBridge Injection E2E fixtures ---
+
+// authBridgeConfigMapFixture returns YAML for the 3 ConfigMaps required by
+// the auth bridge webhook: authbridge-config, spiffe-helper-config, envoy-config.
+// Only the mandatory keys are set (ISSUER, KEYCLOAK_URL, KEYCLOAK_REALM, TOKEN_URL,
+// DEFAULT_OUTBOUND_POLICY). The operator reads additional optional keys
+// (EXPECTED_AUDIENCE, TARGET_AUDIENCE, SPIRE_ENABLED, etc.) which default to empty.
+func authBridgeConfigMapFixture() string {
+	return `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authbridge-config
+  namespace: ` + authBridgeTestNamespace + `
+data:
+  ISSUER: "https://keycloak.example.com/realms/test"
+  KEYCLOAK_URL: "https://keycloak.example.com"
+  KEYCLOAK_REALM: "test"
+  TOKEN_URL: "https://keycloak.example.com/realms/test/protocol/openid-connect/token"
+  DEFAULT_OUTBOUND_POLICY: "passthrough"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spiffe-helper-config
+  namespace: ` + authBridgeTestNamespace + `
+data:
+  helper.conf: |
+    agent_address = "/spiffe-workload-api/spire-agent.sock"
+    cmd = ""
+    cmd_args = ""
+    cert_dir = "/opt"
+    renew_signal = ""
+    svid_file_name = "svid.pem"
+    svid_key_file_name = "svid_key.pem"
+    svid_bundle_file_name = "svid_bundle.pem"
+    jwt_svids = [{jwt_audience="kagenti", jwt_svid_file_name="jwt_svid.token"}]
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-config
+  namespace: ` + authBridgeTestNamespace + `
+data:
+  envoy.yaml: |
+    admin:
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 9901
+    static_resources:
+      listeners:
+        - name: outbound
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 15123
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.tcp_proxy
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                    stat_prefix: outbound_passthrough
+                    cluster: original_dst
+        - name: inbound
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 15124
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.tcp_proxy
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                    stat_prefix: inbound_passthrough
+                    cluster: local_app
+      clusters:
+        - name: original_dst
+          connect_timeout: 5s
+          type: ORIGINAL_DST
+          lb_policy: CLUSTER_PROVIDED
+        - name: local_app
+          connect_timeout: 5s
+          type: STATIC
+          load_assignment:
+            cluster_name: local_app
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: 127.0.0.1
+                          port_value: 8080
+`
+}
+
+// authBridgeAgentRuntimeFixture returns YAML for an AgentRuntime CR targeting
+// the authbridge-agent Deployment.
+func authBridgeAgentRuntimeFixture() string {
+	return `apiVersion: agent.kagenti.dev/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: authbridge-agent
+  namespace: ` + authBridgeTestNamespace + `
+spec:
+  type: agent
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: authbridge-agent
+`
+}
+
+// authBridgeAgentFixture returns YAML for the authbridge-agent Deployment,
+// ServiceAccount, and Service. The deployment uses a Python echo server on
+// port 8080 and has the kagenti.io/type=agent label required for injection.
+func authBridgeAgentFixture() string {
+	return `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: authbridge-agent
+  namespace: ` + authBridgeTestNamespace + `
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authbridge-agent
+  namespace: ` + authBridgeTestNamespace + `
+  labels:
+    kagenti.io/type: agent
+    app.kubernetes.io/name: authbridge-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: authbridge-agent
+      kagenti.io/type: agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: authbridge-agent
+        kagenti.io/type: agent
+    spec:
+      serviceAccountName: authbridge-agent
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: echo
+          image: docker.io/python:3.11-slim
+          imagePullPolicy: IfNotPresent
+          command:
+            - python3
+            - -c
+            - |
+              import http.server, json
+              class H(http.server.BaseHTTPRequestHandler):
+                  def do_GET(self):
+                      self.send_response(200)
+                      self.send_header('Content-Type', 'application/json')
+                      self.end_headers()
+                      self.wfile.write(json.dumps({"status":"ok"}).encode())
+                  def log_message(self, *a): pass
+              http.server.HTTPServer(('', 8080), H).serve_forever()
+          ports:
+            - containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authbridge-agent
+  namespace: ` + authBridgeTestNamespace + `
+spec:
+  selector:
+    app.kubernetes.io/name: authbridge-agent
+  ports:
+    - port: 8080
+      targetPort: 8080
+`
+}
+
+// authBridgeDisabledAgentFixture returns YAML for a Deployment that opts out
+// of sidecar injection via the kagenti.io/inject=disabled pod template label.
+func authBridgeDisabledAgentFixture() string {
+	return `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authbridge-disabled-agent
+  namespace: ` + authBridgeTestNamespace + `
+  labels:
+    kagenti.io/type: agent
+    app.kubernetes.io/name: authbridge-disabled-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: authbridge-disabled-agent
+      kagenti.io/type: agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: authbridge-disabled-agent
+        kagenti.io/type: agent
+        kagenti.io/inject: disabled
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.9
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+`
+}
+
+// authBridgeDisabledAgentRuntimeFixture returns YAML for an AgentRuntime CR
+// targeting the disabled agent.
+func authBridgeDisabledAgentRuntimeFixture() string {
+	return `apiVersion: agent.kagenti.dev/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: authbridge-disabled-agent
+  namespace: ` + authBridgeTestNamespace + `
+spec:
+  type: agent
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: authbridge-disabled-agent
+`
+}
+
+// authBridgeClusterSPIFFEIDFixture returns YAML for a ClusterSPIFFEID matching
+// the auth bridge test namespace.
+func authBridgeClusterSPIFFEIDFixture() string {
+	return `apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterSPIFFEID
+metadata:
+  name: e2e-authbridge-test
+spec:
+  spiffeIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"
+  podSelector:
+    matchLabels:
+      kagenti.io/type: agent
+  namespaceSelector:
+    matchLabels:
+      kagenti-enabled: "true"
 `
 }

--- a/kagenti-operator/test/utils/utils.go
+++ b/kagenti-operator/test/utils/utils.go
@@ -537,7 +537,9 @@ func EnsureCertManagerWebhookReady(timeout time.Duration) error {
 		}
 		time.Sleep(5 * time.Second)
 	}
-	return fmt.Errorf("cert-manager webhook did not become ready within 60s (after waiting up to %v for deployment)", timeout)
+	return fmt.Errorf(
+		"cert-manager webhook did not become ready within 60s "+
+			"(after waiting up to %v for deployment)", timeout)
 }
 
 // certManagerWebhookProbe returns true if the cert-manager webhook is serving valid TLS.

--- a/kagenti-operator/test/utils/utils.go
+++ b/kagenti-operator/test/utils/utils.go
@@ -214,6 +214,23 @@ func LoadImageToKindClusterWithName(name string) error {
 	return archiveErr
 }
 
+// PullAndLoadSidecarImages pulls each image via the detected container tool
+// and loads it into the Kind cluster.
+func PullAndLoadSidecarImages(images []string) error {
+	containerTool := DetectContainerTool()
+	for _, img := range images {
+		_, _ = fmt.Fprintf(GinkgoWriter, "pulling image %s with %s\n", img, containerTool)
+		cmd := exec.Command(containerTool, "pull", img)
+		if _, err := Run(cmd); err != nil {
+			return fmt.Errorf("failed to pull image %s: %w", img, err)
+		}
+		if err := LoadImageToKindClusterWithName(img); err != nil {
+			return fmt.Errorf("failed to load image %s into Kind: %w", img, err)
+		}
+	}
+	return nil
+}
+
 // GetNonEmptyLines converts given command output string into individual objects
 // according to line breakers, and ignores the empty elements in it.
 func GetNonEmptyLines(output string) []string {
@@ -341,10 +358,12 @@ func KubectlApplyStdin(yaml, namespace string) (string, error) {
 
 // KubectlGetJsonpath gets a value using jsonpath from a resource.
 func KubectlGetJsonpath(resource, name, namespace, jsonpath string) (string, error) {
-	cmd := exec.Command("kubectl", "get", resource, name,
-		"-n", namespace,
-		"-o", fmt.Sprintf("jsonpath=%s", jsonpath),
-	)
+	args := []string{"get", resource}
+	if name != "" {
+		args = append(args, name)
+	}
+	args = append(args, "-n", namespace, "-o", fmt.Sprintf("jsonpath=%s", jsonpath))
+	cmd := exec.Command("kubectl", args...)
 	output, err := Run(cmd)
 	return strings.TrimSpace(output), err
 }
@@ -473,10 +492,67 @@ func DeployController(namespace, img string) error {
 		return err
 	}
 
+	By("ensuring cert-manager webhook is responsive before deploy")
+	if err := EnsureCertManagerWebhookReady(2 * time.Minute); err != nil {
+		return fmt.Errorf("cert-manager webhook not ready: %w", err)
+	}
+
 	By("deploying the controller-manager")
 	cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", img))
 	_, err := Run(cmd)
 	return err
+}
+
+// EnsureCertManagerWebhookReady waits for the cert-manager webhook to be responsive.
+// This is needed when re-deploying after an undeploy, because the webhook's TLS
+// serving certificate can become stale.
+func EnsureCertManagerWebhookReady(timeout time.Duration) error {
+	By("ensuring cert-manager webhook is responsive")
+
+	// Quick check — if the webhook is already working, return immediately
+	if certManagerWebhookProbe() {
+		return nil
+	}
+
+	// Re-apply the cert-manager manifest (idempotent) and wait for webhook
+	By("re-applying cert-manager to refresh webhook TLS")
+	url := fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
+	cmd := exec.Command("kubectl", "apply", "-f", url)
+	if _, err := Run(cmd); err != nil {
+		return fmt.Errorf("failed to re-apply cert-manager: %w", err)
+	}
+	cmd = exec.Command("kubectl", "wait", "deployment.apps/cert-manager-webhook",
+		"--for", "condition=Available",
+		"--namespace", "cert-manager",
+		"--timeout", fmt.Sprintf("%ds", int(timeout.Seconds())))
+	if _, err := Run(cmd); err != nil {
+		return fmt.Errorf("cert-manager-webhook not available: %w", err)
+	}
+
+	// Poll until the webhook actually validates requests (fresh deadline after the wait above)
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		if certManagerWebhookProbe() {
+			return nil
+		}
+		time.Sleep(5 * time.Second)
+	}
+	return fmt.Errorf("cert-manager webhook did not become ready within 60s (after waiting up to %v for deployment)", timeout)
+}
+
+// certManagerWebhookProbe returns true if the cert-manager webhook is serving valid TLS.
+func certManagerWebhookProbe() bool {
+	cmd := exec.Command("kubectl", "apply", "--dry-run=server", "-f", "-")
+	cmd.Stdin = strings.NewReader(`apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: e2e-probe
+  namespace: default
+spec:
+  selfSigned: {}
+`)
+	_, err := Run(cmd)
+	return err == nil
 }
 
 // UndeployController undeploys the controller-manager and uninstalls CRDs.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

- Add 4 E2E test cases that deploy the operator to a Kind cluster and verify actual pod mutation by the AuthBridge injection webhook
- Add test utilities for sidecar image loading, cert-manager readiness, and kubectl helpers
 - Update E2E README with AuthBridge test documentation, architecture diagrams, and run instructions


  ## Test scenarios

  | Scenario | What it verifies |
  |----------|-----------------|
  | Sidecar injection | Webhook injects `envoy-proxy`, `spiffe-helper` containers, `proxy-init` init container, and 6 expected volumes |
  | Idempotency | Pod recreation produces exactly 1 of each sidecar (no duplicates) |
  | Injection opt-out | Pod with `kagenti.io/inject=disabled` label gets zero sidecars and zero init containers |
  | HTTP validation | Traffic flows end-to-end through the injected envoy proxy (curl → Service → iptables → envoy → app) |


## Related issue(s)
[[RHAIENG-4355](https://redhat.atlassian.net/browse/RHAIENG-4355)]

🤖 Assisted-by: [Claude Code](https://claude.com/claude-code)
