### PR TITLE
feat: defaults-only sidecar injection without AgentRuntime CR

### DIFF
--- a/kagenti-operator/cmd/main.go
+++ b/kagenti-operator/cmd/main.go
@@ -442,6 +442,16 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "AuthBridge")
 			os.Exit(1)
 		}
+
+		// Defaults-only config reconciler: propagates ConfigMap changes to
+		// workloads that have kagenti.io/type but no AgentRuntime CR.
+		if err = (&injector.DefaultsConfigReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "DefaultsConfig")
+			os.Exit(1)
+		}
 	}
 	// +kubebuilder:scaffold:builder
 

--- a/kagenti-operator/internal/webhook/injector/defaults_config_reconciler.go
+++ b/kagenti-operator/internal/webhook/injector/defaults_config_reconciler.go
@@ -1,0 +1,300 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package injector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/kagenti/operator/internal/controller"
+)
+
+var defaultsLog = log.Log.WithName("defaults-config-reconciler")
+
+// DefaultsConfigReconciler watches cluster and namespace ConfigMaps and
+// updates the kagenti.io/config-hash annotation on workloads that have
+// the kagenti.io/type label but are NOT managed by an AgentRuntime CR.
+//
+// This ensures that sidecar configuration stays current even when no
+// AgentRuntime CR exists (e.g. after CR deletion with the type label
+// preserved, or workloads that rely purely on platform defaults).
+//
+// NOTE: This reconciler intentionally lives in the webhook package for
+// now. It is expected to move to a dedicated controller in the future.
+type DefaultsConfigReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+func (r *DefaultsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("configmap", req.NamespacedName)
+
+	// Determine scope from the request key. We cannot rely solely on
+	// fetching the ConfigMap because it may have been deleted — and a
+	// deletion still changes the defaults-only hash (one input is gone).
+	var namespaces []string
+
+	cm := &corev1.ConfigMap{}
+	err := r.Get(ctx, req.NamespacedName, cm)
+
+	switch {
+	case err == nil && isClusterConfigMap(cm):
+		// Cluster-level ConfigMap updated — affects all namespaces.
+		ns, err := r.namespacesWithKagentiWorkloads(ctx)
+		if err != nil {
+			logger.Error(err, "failed to list namespaces with kagenti workloads")
+			return ctrl.Result{}, err
+		}
+		namespaces = ns
+
+	case err == nil && isNamespaceDefaultsConfigMap(cm):
+		// Namespace-level defaults ConfigMap updated.
+		namespaces = []string{cm.Namespace}
+
+	case err == nil:
+		// ConfigMap exists but is not relevant (predicate should prevent this).
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		// ConfigMap was deleted. Use the request key to infer scope.
+		if isClusterConfigMapKey(req.NamespacedName) {
+			ns, err := r.namespacesWithKagentiWorkloads(ctx)
+			if err != nil {
+				logger.Error(err, "failed to list namespaces with kagenti workloads")
+				return ctrl.Result{}, err
+			}
+			namespaces = ns
+		} else {
+			// Namespace-level ConfigMap deleted — re-hash workloads in that namespace.
+			namespaces = []string{req.Namespace}
+		}
+		logger.Info("ConfigMap deleted, re-hashing affected workloads")
+
+	default:
+		return ctrl.Result{}, err
+	}
+
+	var firstErr error
+	for _, ns := range namespaces {
+		if err := r.reconcileWorkloadsInNamespace(ctx, ns); err != nil {
+			logger.Error(err, "failed to reconcile workloads", "namespace", ns)
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return ctrl.Result{}, firstErr
+}
+
+// reconcileWorkloadsInNamespace updates config-hash on Deployments and
+// StatefulSets that carry the kagenti.io/type label but are not managed
+// by an AgentRuntime CR. Errors from individual workload updates are
+// accumulated and returned so that controller-runtime requeues the request.
+func (r *DefaultsConfigReconciler) reconcileWorkloadsInNamespace(ctx context.Context, namespace string) error {
+	logger := log.FromContext(ctx).WithValues("namespace", namespace)
+	var errs []error
+
+	// Process Deployments
+	deployList := &appsv1.DeploymentList{}
+	if err := r.List(ctx, deployList,
+		client.InNamespace(namespace),
+		client.HasLabels{KagentiTypeLabel},
+	); err != nil {
+		return err
+	}
+	for i := range deployList.Items {
+		dep := &deployList.Items[i]
+		if isManagedByAgentRuntime(dep) {
+			continue
+		}
+		if err := r.updateConfigHash(ctx, namespace, dep.Name, "Deployment"); err != nil {
+			logger.Error(err, "failed to update Deployment config-hash", "name", dep.Name)
+			errs = append(errs, err)
+		}
+	}
+
+	// Process StatefulSets
+	ssList := &appsv1.StatefulSetList{}
+	if err := r.List(ctx, ssList,
+		client.InNamespace(namespace),
+		client.HasLabels{KagentiTypeLabel},
+	); err != nil {
+		return err
+	}
+	for i := range ssList.Items {
+		ss := &ssList.Items[i]
+		if isManagedByAgentRuntime(ss) {
+			continue
+		}
+		if err := r.updateConfigHash(ctx, namespace, ss.Name, "StatefulSet"); err != nil {
+			logger.Error(err, "failed to update StatefulSet config-hash", "name", ss.Name)
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// updateConfigHash computes the defaults-only hash and applies it to
+// the workload's PodTemplateSpec if it differs from the current value.
+func (r *DefaultsConfigReconciler) updateConfigHash(ctx context.Context, namespace, name, kind string) error {
+	logger := log.FromContext(ctx).WithValues("workload", name, "kind", kind)
+
+	newHash, err := controller.ComputeDefaultsOnlyHash(ctx, r.Client, namespace)
+	if err != nil {
+		return err
+	}
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		key := types.NamespacedName{Name: name, Namespace: namespace}
+
+		switch kind {
+		case "Deployment":
+			dep := &appsv1.Deployment{}
+			if err := r.Get(ctx, key, dep); err != nil {
+				return client.IgnoreNotFound(err)
+			}
+			current := dep.Spec.Template.Annotations[controller.AnnotationConfigHash]
+			if current == newHash {
+				return nil
+			}
+			if dep.Spec.Template.Annotations == nil {
+				dep.Spec.Template.Annotations = make(map[string]string)
+			}
+			dep.Spec.Template.Annotations[controller.AnnotationConfigHash] = newHash
+			logger.Info("Updating config-hash to defaults-only",
+				"oldHash", truncateHash(current), "newHash", truncateHash(newHash))
+			return r.Update(ctx, dep)
+
+		case "StatefulSet":
+			ss := &appsv1.StatefulSet{}
+			if err := r.Get(ctx, key, ss); err != nil {
+				return client.IgnoreNotFound(err)
+			}
+			current := ss.Spec.Template.Annotations[controller.AnnotationConfigHash]
+			if current == newHash {
+				return nil
+			}
+			if ss.Spec.Template.Annotations == nil {
+				ss.Spec.Template.Annotations = make(map[string]string)
+			}
+			ss.Spec.Template.Annotations[controller.AnnotationConfigHash] = newHash
+			logger.Info("Updating config-hash to defaults-only",
+				"oldHash", truncateHash(current), "newHash", truncateHash(newHash))
+			return r.Update(ctx, ss)
+
+		default:
+			return fmt.Errorf("unsupported workload kind: %s", kind)
+		}
+	})
+}
+
+// namespacesWithKagentiWorkloads returns all namespaces that contain at
+// least one Deployment or StatefulSet with the kagenti.io/type label.
+func (r *DefaultsConfigReconciler) namespacesWithKagentiWorkloads(ctx context.Context) ([]string, error) {
+	seen := make(map[string]bool)
+
+	deployList := &appsv1.DeploymentList{}
+	if err := r.List(ctx, deployList, client.HasLabels{KagentiTypeLabel}); err != nil {
+		return nil, err
+	}
+	for i := range deployList.Items {
+		seen[deployList.Items[i].Namespace] = true
+	}
+
+	ssList := &appsv1.StatefulSetList{}
+	if err := r.List(ctx, ssList, client.HasLabels{KagentiTypeLabel}); err != nil {
+		return nil, err
+	}
+	for i := range ssList.Items {
+		seen[ssList.Items[i].Namespace] = true
+	}
+
+	namespaces := make([]string, 0, len(seen))
+	for ns := range seen {
+		namespaces = append(namespaces, ns)
+	}
+	return namespaces, nil
+}
+
+// SetupWithManager registers the reconciler with the controller-runtime manager.
+func (r *DefaultsConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("defaults-config").
+		For(&corev1.ConfigMap{}, builder.WithPredicates(kagentiConfigMapPredicate())).
+		Complete(r)
+}
+
+// kagentiConfigMapPredicate filters to only cluster-level defaults and
+// namespace-level defaults ConfigMaps.
+func kagentiConfigMapPredicate() predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		cm, ok := obj.(*corev1.ConfigMap)
+		if !ok {
+			return false
+		}
+		return isClusterConfigMap(cm) || isNamespaceDefaultsConfigMap(cm)
+	})
+}
+
+func isClusterConfigMap(cm *corev1.ConfigMap) bool {
+	return isClusterConfigMapKey(types.NamespacedName{Name: cm.Name, Namespace: cm.Namespace})
+}
+
+// isClusterConfigMapKey checks whether a NamespacedName refers to one of the
+// cluster-level defaults ConfigMaps. Used for both live objects and deletion
+// events where the object no longer exists.
+func isClusterConfigMapKey(key types.NamespacedName) bool {
+	if key.Namespace != controller.ClusterDefaultsNamespace {
+		return false
+	}
+	return key.Name == controller.ClusterDefaultsConfigMapName ||
+		key.Name == controller.ClusterFeatureGatesConfigMapName
+}
+
+func isNamespaceDefaultsConfigMap(cm *corev1.ConfigMap) bool {
+	labels := cm.GetLabels()
+	return labels != nil && labels[controller.LabelNamespaceDefaults] == "true"
+}
+
+// isManagedByAgentRuntime checks if a workload is actively managed by
+// an AgentRuntime CR. The AgentRuntime controller sets this label when
+// the CR is active and removes it on CR deletion.
+func isManagedByAgentRuntime(obj client.Object) bool {
+	labels := obj.GetLabels()
+	return labels != nil && labels[controller.LabelManagedBy] == controller.LabelManagedByValue
+}
+
+func truncateHash(h string) string {
+	if len(h) > 12 {
+		return h[:12]
+	}
+	return h
+}

--- a/kagenti-operator/internal/webhook/injector/defaults_config_reconciler.go
+++ b/kagenti-operator/internal/webhook/injector/defaults_config_reconciler.go
@@ -36,8 +36,6 @@ import (
 	"github.com/kagenti/operator/internal/controller"
 )
 
-var defaultsLog = log.Log.WithName("defaults-config-reconciler")
-
 // DefaultsConfigReconciler watches cluster and namespace ConfigMaps and
 // updates the kagenti.io/config-hash annotation on workloads that have
 // the kagenti.io/type label but are NOT managed by an AgentRuntime CR.

--- a/kagenti-operator/internal/webhook/injector/defaults_config_reconciler.go
+++ b/kagenti-operator/internal/webhook/injector/defaults_config_reconciler.go
@@ -216,6 +216,7 @@ func (r *DefaultsConfigReconciler) updateConfigHash(ctx context.Context, namespa
 
 // namespacesWithKagentiWorkloads returns all namespaces that contain at
 // least one Deployment or StatefulSet with the kagenti.io/type label.
+// TODO: consider adding a field indexer on KagentiTypeLabel if cluster size grows.
 func (r *DefaultsConfigReconciler) namespacesWithKagentiWorkloads(ctx context.Context) ([]string, error) {
 	seen := make(map[string]bool)
 

--- a/kagenti-operator/internal/webhook/injector/defaults_config_reconciler_test.go
+++ b/kagenti-operator/internal/webhook/injector/defaults_config_reconciler_test.go
@@ -1,0 +1,693 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package injector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kagenti/operator/internal/controller"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newReconcilerScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	return scheme
+}
+
+func newDefaultsReconciler(objs ...client.Object) *DefaultsConfigReconciler {
+	scheme := newReconcilerScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &DefaultsConfigReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+}
+
+func newLabeledDeployment(name, namespace string, extraLabels map[string]string) *appsv1.Deployment {
+	labels := map[string]string{
+		KagentiTypeLabel: KagentiTypeAgent,
+	}
+	for k, v := range extraLabels {
+		labels[k] = v
+	}
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": name},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": name},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "agent", Image: "agent:latest"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newLabeledStatefulSet(name, namespace string) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				KagentiTypeLabel: KagentiTypeAgent,
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": name},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": name},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "agent", Image: "agent:latest"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newClusterDefaultsConfigMap(data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controller.ClusterDefaultsConfigMapName,
+			Namespace: controller.ClusterDefaultsNamespace,
+		},
+		Data: data,
+	}
+}
+
+func newNamespaceDefaultsConfigMap(namespace string, data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ns-defaults",
+			Namespace: namespace,
+			Labels: map[string]string{
+				controller.LabelNamespaceDefaults: "true",
+			},
+		},
+		Data: data,
+	}
+}
+
+func TestDefaultsConfigReconciler_SkipsManagedWorkload(t *testing.T) {
+	dep := newLabeledDeployment("my-agent", "team1", map[string]string{
+		controller.LabelManagedBy: controller.LabelManagedByValue,
+	})
+	cm := newClusterDefaultsConfigMap(map[string]string{"key": "val"})
+
+	r := newDefaultsReconciler(dep, cm)
+	ctx := context.Background()
+
+	_, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      controller.ClusterDefaultsConfigMapName,
+			Namespace: controller.ClusterDefaultsNamespace,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+
+	// Verify config-hash was NOT set (workload is managed by AgentRuntime)
+	updated := &appsv1.Deployment{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(dep), updated); err != nil {
+		t.Fatalf("failed to get deployment: %v", err)
+	}
+	if hash := updated.Spec.Template.Annotations[controller.AnnotationConfigHash]; hash != "" {
+		t.Errorf("expected no config-hash on managed workload, got %q", hash)
+	}
+}
+
+func TestDefaultsConfigReconciler_UpdatesUnmanagedWorkload(t *testing.T) {
+	dep := newLabeledDeployment("my-agent", "team1", nil)
+	cm := newClusterDefaultsConfigMap(map[string]string{"key": "val"})
+
+	r := newDefaultsReconciler(dep, cm)
+	ctx := context.Background()
+
+	_, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      controller.ClusterDefaultsConfigMapName,
+			Namespace: controller.ClusterDefaultsNamespace,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+
+	updated := &appsv1.Deployment{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(dep), updated); err != nil {
+		t.Fatalf("failed to get deployment: %v", err)
+	}
+	hash := updated.Spec.Template.Annotations[controller.AnnotationConfigHash]
+	if hash == "" {
+		t.Fatal("expected config-hash to be set on unmanaged workload")
+	}
+}
+
+func TestDefaultsConfigReconciler_IdempotentWhenHashUnchanged(t *testing.T) {
+	dep := newLabeledDeployment("my-agent", "team1", nil)
+	cm := newClusterDefaultsConfigMap(map[string]string{"key": "val"})
+
+	r := newDefaultsReconciler(dep, cm)
+	ctx := context.Background()
+
+	// First reconcile — sets the hash
+	_, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      controller.ClusterDefaultsConfigMapName,
+			Namespace: controller.ClusterDefaultsNamespace,
+		},
+	})
+	if err != nil {
+		t.Fatalf("first Reconcile() returned error: %v", err)
+	}
+
+	updated := &appsv1.Deployment{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(dep), updated); err != nil {
+		t.Fatalf("failed to get deployment: %v", err)
+	}
+	rvAfterFirst := updated.ResourceVersion
+
+	// Second reconcile — should be a no-op
+	_, err = r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      controller.ClusterDefaultsConfigMapName,
+			Namespace: controller.ClusterDefaultsNamespace,
+		},
+	})
+	if err != nil {
+		t.Fatalf("second Reconcile() returned error: %v", err)
+	}
+
+	if err := r.Get(ctx, client.ObjectKeyFromObject(dep), updated); err != nil {
+		t.Fatalf("failed to get deployment: %v", err)
+	}
+	if updated.ResourceVersion != rvAfterFirst {
+		t.Error("expected no update on second reconcile (hash unchanged)")
+	}
+}
+
+func TestDefaultsConfigReconciler_HandlesNamespaceDefaults(t *testing.T) {
+	dep := newLabeledDeployment("my-agent", "team1", nil)
+	cm := newNamespaceDefaultsConfigMap("team1", map[string]string{"ns-key": "ns-val"})
+
+	r := newDefaultsReconciler(dep, cm)
+	ctx := context.Background()
+
+	_, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "ns-defaults",
+			Namespace: "team1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+
+	updated := &appsv1.Deployment{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(dep), updated); err != nil {
+		t.Fatalf("failed to get deployment: %v", err)
+	}
+	hash := updated.Spec.Template.Annotations[controller.AnnotationConfigHash]
+	if hash == "" {
+		t.Fatal("expected config-hash to be set for namespace defaults change")
+	}
+}
+
+func TestDefaultsConfigReconciler_IgnoresIrrelevantConfigMap(t *testing.T) {
+	dep := newLabeledDeployment("my-agent", "team1", nil)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unrelated-config",
+			Namespace: "team1",
+		},
+		Data: map[string]string{"foo": "bar"},
+	}
+
+	r := newDefaultsReconciler(dep, cm)
+	ctx := context.Background()
+
+	_, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "unrelated-config",
+			Namespace: "team1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+
+	updated := &appsv1.Deployment{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(dep), updated); err != nil {
+		t.Fatalf("failed to get deployment: %v", err)
+	}
+	if hash := updated.Spec.Template.Annotations[controller.AnnotationConfigHash]; hash != "" {
+		t.Errorf("expected no config-hash update for irrelevant ConfigMap, got %q", hash)
+	}
+}
+
+func TestDefaultsConfigReconciler_HandlesStatefulSet(t *testing.T) {
+	ss := newLabeledStatefulSet("my-agent", "team1")
+	cm := newClusterDefaultsConfigMap(map[string]string{"key": "val"})
+
+	r := newDefaultsReconciler(ss, cm)
+	ctx := context.Background()
+
+	_, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      controller.ClusterDefaultsConfigMapName,
+			Namespace: controller.ClusterDefaultsNamespace,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+
+	updated := &appsv1.StatefulSet{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(ss), updated); err != nil {
+		t.Fatalf("failed to get statefulset: %v", err)
+	}
+	hash := updated.Spec.Template.Annotations[controller.AnnotationConfigHash]
+	if hash == "" {
+		t.Fatal("expected config-hash to be set on unmanaged StatefulSet")
+	}
+}
+
+func TestDefaultsConfigReconciler_ConfigMapNotFound(t *testing.T) {
+	r := newDefaultsReconciler()
+	ctx := context.Background()
+
+	_, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "nonexistent",
+			Namespace: "team1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() should not error on NotFound, got: %v", err)
+	}
+}
+
+func TestDefaultsConfigReconciler_ConfigMapDeleted_UpdatesWorkloads(t *testing.T) {
+	// When a namespace defaults ConfigMap is deleted, the defaults-only hash
+	// changes (one input is gone). The reconciler should still update workloads.
+	dep := newLabeledDeployment("my-agent", "team1", nil)
+	// Pre-set a stale hash to verify it gets updated
+	dep.Spec.Template.Annotations = map[string]string{
+		controller.AnnotationConfigHash: "stale-hash-value",
+	}
+
+	// No ConfigMap in the fake client — simulates deletion
+	r := newDefaultsReconciler(dep)
+	ctx := context.Background()
+
+	_, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "ns-defaults",
+			Namespace: "team1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+
+	updated := &appsv1.Deployment{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(dep), updated); err != nil {
+		t.Fatalf("failed to get deployment: %v", err)
+	}
+	hash := updated.Spec.Template.Annotations[controller.AnnotationConfigHash]
+	if hash == "stale-hash-value" {
+		t.Error("expected config-hash to be updated after ConfigMap deletion")
+	}
+	if hash == "" {
+		t.Error("expected config-hash to be set to defaults-only hash")
+	}
+}
+
+func TestDefaultsConfigReconciler_ClusterConfigMapDeleted_UpdatesAllNamespaces(t *testing.T) {
+	dep1 := newLabeledDeployment("agent-1", "team1", nil)
+	dep1.Spec.Template.Annotations = map[string]string{
+		controller.AnnotationConfigHash: "stale-hash",
+	}
+	dep2 := newLabeledDeployment("agent-2", "team2", nil)
+	dep2.Spec.Template.Annotations = map[string]string{
+		controller.AnnotationConfigHash: "stale-hash",
+	}
+
+	// No cluster ConfigMap — simulates deletion
+	r := newDefaultsReconciler(dep1, dep2)
+	ctx := context.Background()
+
+	_, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      controller.ClusterDefaultsConfigMapName,
+			Namespace: controller.ClusterDefaultsNamespace,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+
+	for _, dep := range []*appsv1.Deployment{dep1, dep2} {
+		updated := &appsv1.Deployment{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(dep), updated); err != nil {
+			t.Fatalf("failed to get deployment %s: %v", dep.Name, err)
+		}
+		hash := updated.Spec.Template.Annotations[controller.AnnotationConfigHash]
+		if hash == "stale-hash" || hash == "" {
+			t.Errorf("deployment %s/%s: expected config-hash to be updated, got %q",
+				dep.Namespace, dep.Name, hash)
+		}
+	}
+}
+
+func TestDefaultsConfigReconciler_MixedManagedAndUnmanaged(t *testing.T) {
+	// Both managed and unmanaged workloads in the same namespace — only
+	// the unmanaged one should get its config-hash updated.
+	managed := newLabeledDeployment("managed-agent", "team1", map[string]string{
+		controller.LabelManagedBy: controller.LabelManagedByValue,
+	})
+	unmanaged := newLabeledDeployment("orphan-agent", "team1", nil)
+	cm := newClusterDefaultsConfigMap(map[string]string{"key": "val"})
+
+	r := newDefaultsReconciler(managed, unmanaged, cm)
+	ctx := context.Background()
+
+	_, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      controller.ClusterDefaultsConfigMapName,
+			Namespace: controller.ClusterDefaultsNamespace,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+
+	// Managed workload should NOT be updated
+	updatedManaged := &appsv1.Deployment{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(managed), updatedManaged); err != nil {
+		t.Fatalf("failed to get managed deployment: %v", err)
+	}
+	if hash := updatedManaged.Spec.Template.Annotations[controller.AnnotationConfigHash]; hash != "" {
+		t.Errorf("expected no config-hash on managed workload, got %q", hash)
+	}
+
+	// Unmanaged workload should be updated
+	updatedUnmanaged := &appsv1.Deployment{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(unmanaged), updatedUnmanaged); err != nil {
+		t.Fatalf("failed to get unmanaged deployment: %v", err)
+	}
+	if hash := updatedUnmanaged.Spec.Template.Annotations[controller.AnnotationConfigHash]; hash == "" {
+		t.Error("expected config-hash on unmanaged workload")
+	}
+}
+
+func TestDefaultsConfigReconciler_MultiNamespaceFanOut(t *testing.T) {
+	// Cluster ConfigMap change should update workloads across multiple namespaces.
+	dep1 := newLabeledDeployment("agent-a", "ns1", nil)
+	dep2 := newLabeledDeployment("agent-b", "ns2", nil)
+	dep3 := newLabeledDeployment("agent-c", "ns3", nil)
+	cm := newClusterDefaultsConfigMap(map[string]string{"key": "val"})
+
+	r := newDefaultsReconciler(dep1, dep2, dep3, cm)
+	ctx := context.Background()
+
+	_, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      controller.ClusterDefaultsConfigMapName,
+			Namespace: controller.ClusterDefaultsNamespace,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+
+	for _, dep := range []*appsv1.Deployment{dep1, dep2, dep3} {
+		updated := &appsv1.Deployment{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(dep), updated); err != nil {
+			t.Fatalf("failed to get deployment %s/%s: %v", dep.Namespace, dep.Name, err)
+		}
+		hash := updated.Spec.Template.Annotations[controller.AnnotationConfigHash]
+		if hash == "" {
+			t.Errorf("deployment %s/%s: expected config-hash to be set", dep.Namespace, dep.Name)
+		}
+	}
+}
+
+func TestDefaultsConfigReconciler_FeatureGatesConfigMapTrigger(t *testing.T) {
+	dep := newLabeledDeployment("my-agent", "team1", nil)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controller.ClusterFeatureGatesConfigMapName,
+			Namespace: controller.ClusterDefaultsNamespace,
+		},
+		Data: map[string]string{"globalEnabled": "true"},
+	}
+
+	r := newDefaultsReconciler(dep, cm)
+	ctx := context.Background()
+
+	_, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      controller.ClusterFeatureGatesConfigMapName,
+			Namespace: controller.ClusterDefaultsNamespace,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+
+	updated := &appsv1.Deployment{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(dep), updated); err != nil {
+		t.Fatalf("failed to get deployment: %v", err)
+	}
+	hash := updated.Spec.Template.Annotations[controller.AnnotationConfigHash]
+	if hash == "" {
+		t.Fatal("expected config-hash to be set for feature-gates ConfigMap change")
+	}
+}
+
+func TestIsClusterConfigMapKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      types.NamespacedName
+		expected bool
+	}{
+		{
+			name:     "platform config",
+			key:      types.NamespacedName{Name: controller.ClusterDefaultsConfigMapName, Namespace: controller.ClusterDefaultsNamespace},
+			expected: true,
+		},
+		{
+			name:     "feature gates",
+			key:      types.NamespacedName{Name: controller.ClusterFeatureGatesConfigMapName, Namespace: controller.ClusterDefaultsNamespace},
+			expected: true,
+		},
+		{
+			name:     "wrong namespace",
+			key:      types.NamespacedName{Name: controller.ClusterDefaultsConfigMapName, Namespace: "other-ns"},
+			expected: false,
+		},
+		{
+			name:     "random configmap",
+			key:      types.NamespacedName{Name: "random", Namespace: "random-ns"},
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isClusterConfigMapKey(tc.key); got != tc.expected {
+				t.Errorf("isClusterConfigMapKey() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestIsClusterConfigMap(t *testing.T) {
+	tests := []struct {
+		name      string
+		cm        *corev1.ConfigMap
+		expected  bool
+	}{
+		{
+			name: "platform config",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      controller.ClusterDefaultsConfigMapName,
+					Namespace: controller.ClusterDefaultsNamespace,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "feature gates",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      controller.ClusterFeatureGatesConfigMapName,
+					Namespace: controller.ClusterDefaultsNamespace,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "wrong namespace",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      controller.ClusterDefaultsConfigMapName,
+					Namespace: "other-ns",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "wrong name",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-config",
+					Namespace: controller.ClusterDefaultsNamespace,
+				},
+			},
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isClusterConfigMap(tc.cm); got != tc.expected {
+				t.Errorf("isClusterConfigMap() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestIsNamespaceDefaultsConfigMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		cm       *corev1.ConfigMap
+		expected bool
+	}{
+		{
+			name: "has defaults label",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ns-defaults",
+					Namespace: "team1",
+					Labels: map[string]string{
+						controller.LabelNamespaceDefaults: "true",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "no labels",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ns-defaults",
+					Namespace: "team1",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "wrong label value",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ns-defaults",
+					Namespace: "team1",
+					Labels: map[string]string{
+						controller.LabelNamespaceDefaults: "false",
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isNamespaceDefaultsConfigMap(tc.cm); got != tc.expected {
+				t.Errorf("isNamespaceDefaultsConfigMap() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestIsManagedByAgentRuntime(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   map[string]string
+		expected bool
+	}{
+		{
+			name: "managed",
+			labels: map[string]string{
+				controller.LabelManagedBy: controller.LabelManagedByValue,
+			},
+			expected: true,
+		},
+		{
+			name:     "not managed - no labels",
+			labels:   nil,
+			expected: false,
+		},
+		{
+			name: "not managed - different value",
+			labels: map[string]string{
+				controller.LabelManagedBy: "other",
+			},
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dep := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test",
+					Labels: tc.labels,
+				},
+			}
+			if got := isManagedByAgentRuntime(dep); got != tc.expected {
+				t.Errorf("isManagedByAgentRuntime() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}

--- a/kagenti-operator/internal/webhook/injector/defaults_config_reconciler_test.go
+++ b/kagenti-operator/internal/webhook/injector/defaults_config_reconciler_test.go
@@ -545,9 +545,9 @@ func TestIsClusterConfigMapKey(t *testing.T) {
 
 func TestIsClusterConfigMap(t *testing.T) {
 	tests := []struct {
-		name      string
-		cm        *corev1.ConfigMap
-		expected  bool
+		name     string
+		cm       *corev1.ConfigMap
+		expected bool
 	}{
 		{
 			name: "platform config",

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -162,9 +162,10 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 		return false, nil
 	}
 
-	// AgentRuntime CR must exist for injection to proceed. This makes
-	// AgentRuntime creation the trigger for sidecar injection — pods
-	// deployed before the CR is created will not be injected.
+	// Read AgentRuntime CR overrides. If no CR exists the webhook still
+	// injects sidecars using defaults-only config (platform + namespace
+	// defaults, no per-workload overrides). ResolveConfig handles nil
+	// overrides transparently.
 	arOverrides, err := ReadAgentRuntimeOverrides(ctx, m.Client, namespace, crName)
 	if err != nil {
 		mutatorLog.Error(err, "failed to read AgentRuntime",
@@ -172,9 +173,8 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 		return false, err
 	}
 	if arOverrides == nil {
-		mutatorLog.Info("Skipping mutation: no matching AgentRuntime CR found",
+		mutatorLog.Info("No AgentRuntime CR found, injecting with defaults-only config",
 			"namespace", namespace, "crName", crName)
-		return false, nil
 	}
 
 	// Derive SPIRE mode from the injection decision: if spiffe-helper is being

--- a/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
@@ -133,8 +133,9 @@ func TestEnsureServiceAccount_AlreadyExistsNoLabels(t *testing.T) {
 	}
 }
 
-func TestInjectAuthBridge_NoAgentRuntime_SkipsInjection(t *testing.T) {
-	// Agent pod with correct labels but no AgentRuntime CR → no injection.
+func TestInjectAuthBridge_NoAgentRuntime_InjectsWithDefaults(t *testing.T) {
+	// Agent pod with correct labels but no AgentRuntime CR → inject with
+	// defaults-only config (platform + namespace defaults, no CR overrides).
 	m := newTestMutator()
 	ctx := context.Background()
 
@@ -147,12 +148,19 @@ func TestInjectAuthBridge_NoAgentRuntime_SkipsInjection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InjectAuthBridge() returned error: %v", err)
 	}
-	if injected {
-		t.Fatal("expected InjectAuthBridge to return false when no AgentRuntime CR exists")
+	if !injected {
+		t.Fatal("expected InjectAuthBridge to return true with defaults-only config")
 	}
-	if len(podSpec.Containers) != 0 || len(podSpec.InitContainers) != 0 {
-		t.Errorf("expected no containers injected, got containers=%v initContainers=%v",
-			podSpec.Containers, podSpec.InitContainers)
+
+	// Verify specific sidecar containers are present
+	if !containerExists(podSpec.Containers, EnvoyProxyContainerName) {
+		t.Errorf("expected %s container to be injected", EnvoyProxyContainerName)
+	}
+	if !containerExists(podSpec.Containers, SpiffeHelperContainerName) {
+		t.Errorf("expected %s container to be injected", SpiffeHelperContainerName)
+	}
+	if !containerExists(podSpec.InitContainers, ProxyInitContainerName) {
+		t.Errorf("expected %s init container to be injected", ProxyInitContainerName)
 	}
 }
 

--- a/kagenti-operator/internal/webhook/v1alpha1/authbridge_webhook_test.go
+++ b/kagenti-operator/internal/webhook/v1alpha1/authbridge_webhook_test.go
@@ -167,7 +167,7 @@ var _ = Describe("AuthBridge Pod Webhook", func() {
 	})
 
 	Context("when a Pod has kagenti.io/type=agent but no AgentRuntime CR", func() {
-		It("should not inject sidecars", func() {
+		It("should inject sidecars with defaults-only config", func() {
 			pod := newTestPod("no-runtime-pod", map[string]string{
 				"kagenti.io/type":   "agent",
 				"kagenti.io/inject": "enabled",
@@ -179,8 +179,8 @@ var _ = Describe("AuthBridge Pod Webhook", func() {
 			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(containerNames(pod.Spec.Containers)).NotTo(ContainElement(injector.EnvoyProxyContainerName))
-			Expect(initContainerNames(pod.Spec.InitContainers)).NotTo(ContainElement(injector.ProxyInitContainerName))
+			Expect(containerNames(pod.Spec.Containers)).To(ContainElement(injector.EnvoyProxyContainerName))
+			Expect(initContainerNames(pod.Spec.InitContainers)).To(ContainElement(injector.ProxyInitContainerName))
 		})
 	})
 

--- a/kagenti-operator/test/e2e/fixtures.go
+++ b/kagenti-operator/test/e2e/fixtures.go
@@ -114,6 +114,7 @@ spec:
       labels:
         app.kubernetes.io/name: noproto-agent
         kagenti.io/type: agent
+        kagenti.io/inject: disabled
     spec:
       securityContext:
         runAsNonRoot: true

--- a/kagenti-operator/test/e2e/fixtures.go
+++ b/kagenti-operator/test/e2e/fixtures.go
@@ -40,6 +40,7 @@ spec:
       labels:
         app.kubernetes.io/name: echo-agent
         kagenti.io/type: agent
+        kagenti.io/inject: disabled
         protocol.kagenti.io/a2a: ""
     spec:
       securityContext:
@@ -94,6 +95,9 @@ spec:
 
 // noProtocolAgentFixture returns YAML for noproto-agent Deployment (S2) - has
 // kagenti.io/type=agent but NO protocol.kagenti.io/* label.
+// kagenti.io/inject=disabled is set because this test validates AgentCard sync
+// behaviour, not sidecar injection. Without the opt-out the defaults-only
+// injection path would inject sidecars that the pause container cannot support.
 func noProtocolAgentFixture() string {
 	return `apiVersion: apps/v1
 kind: Deployment
@@ -182,6 +186,7 @@ spec:
       labels:
         app.kubernetes.io/name: audit-agent
         kagenti.io/type: agent
+        kagenti.io/inject: disabled
         protocol.kagenti.io/a2a: ""
     spec:
       securityContext:
@@ -335,6 +340,7 @@ spec:
       labels:
         app.kubernetes.io/name: signed-agent
         kagenti.io/type: agent
+        kagenti.io/inject: disabled
         protocol.kagenti.io/a2a: ""
     spec:
       serviceAccountName: signed-agent-sa


### PR DESCRIPTION
## Summary

- Webhook now injects sidecars using defaults-only config (platform + namespace defaults) when no AgentRuntime CR exists, instead of skipping injection entirely
- New `DefaultsConfigReconciler` watches cluster and namespace ConfigMaps and updates `kagenti.io/config-hash` on workloads not managed by an AgentRuntime CR, triggering rolling updates when defaults change
- Handles ConfigMap deletion events by re-hashing affected workloads
- Errors from individual workload updates are accumulated and returned for requeue

Closes: RHAIENG-4177

## Changes

| File | Description |
|------|-------------|
| `internal/webhook/injector/pod_mutator.go` | Remove early return when no AgentRuntime CR found — inject with defaults |
| `internal/webhook/injector/defaults_config_reconciler.go` | New reconciler for ConfigMap-driven config propagation to orphaned workloads |
| `internal/webhook/injector/defaults_config_reconciler_test.go` | 18 unit tests covering all reconciler paths |
| `internal/webhook/injector/pod_mutator_test.go` | Updated to expect injection with specific container names |
| `internal/webhook/v1alpha1/authbridge_webhook_test.go` | Updated integration test for defaults-only injection |
| `cmd/main.go` | Register new reconciler inside `authBridgeWebhooksEnabled()` guard |

## Test plan

- [x] `TestInjectAuthBridge_NoAgentRuntime_InjectsWithDefaults` — verifies envoy-proxy, spiffe-helper, proxy-init injected
- [x] `TestDefaultsConfigReconciler_UpdatesUnmanagedWorkload` — config-hash set on orphaned Deployment
- [x] `TestDefaultsConfigReconciler_SkipsManagedWorkload` — managed workloads untouched
- [x] `TestDefaultsConfigReconciler_ConfigMapDeleted_UpdatesWorkloads` — deletion triggers re-hash
- [x] `TestDefaultsConfigReconciler_MultiNamespaceFanOut` — cluster ConfigMap change fans out to all namespaces
- [x] `TestDefaultsConfigReconciler_MixedManagedAndUnmanaged` — only unmanaged workloads updated
- [x] `TestDefaultsConfigReconciler_IdempotentWhenHashUnchanged` — no spurious updates
- [x] Integration test: webhook injects sidecars for pods with `kagenti.io/type=agent` and no CR
- [x] All existing tests continue to pass

 Signed-off-by: Varsha Prasad Narsing <varshaprasad96@gmail.com>     