### PR TITLE
Swap envoy-with-processor to authbridge-unified image

### DIFF
--- a/kagenti-operator/internal/webhook/config/defaults.go
+++ b/kagenti-operator/internal/webhook/config/defaults.go
@@ -11,7 +11,7 @@ func CompiledDefaults() *PlatformConfig {
 		// Compiled defaults are overridden at runtime by the platform-config
 		// ConfigMap (kagenti-platform-config). These serve as fallbacks only.
 		Images: ImageConfig{
-			EnvoyProxy:         "ghcr.io/kagenti/kagenti-extensions/envoy-with-processor:latest",
+			EnvoyProxy:         "ghcr.io/kagenti/kagenti-extensions/authbridge-unified:latest",
 			ProxyInit:          "ghcr.io/kagenti/kagenti-extensions/proxy-init:latest",
 			SpiffeHelper:       "ghcr.io/kagenti/kagenti-extensions/spiffe-helper:latest",
 			ClientRegistration: "ghcr.io/kagenti/kagenti-extensions/client-registration:latest",

--- a/kagenti-operator/internal/webhook/injector/container_builder.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder.go
@@ -381,6 +381,11 @@ func (b *ContainerBuilder) BuildEnvoyProxyContainerWithSpireOption(spireEnabled 
 			MountPath: "/etc/authproxy",
 			ReadOnly:  true,
 		},
+		{
+			Name:      "authbridge-unified-config",
+			MountPath: "/etc/authbridge",
+			ReadOnly:  true,
+		},
 	}
 	if spireEnabled {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
@@ -401,6 +406,7 @@ func (b *ContainerBuilder) BuildEnvoyProxyContainerWithSpireOption(spireEnabled 
 		Name:            EnvoyProxyContainerName,
 		Image:           b.cfg.Images.EnvoyProxy,
 		ImagePullPolicy: b.cfg.Images.PullPolicy,
+		Args:            []string{"--config", "/etc/authbridge/config.yaml"},
 		Resources:       b.cfg.Resources.EnvoyProxy,
 		Ports: []corev1.ContainerPort{
 			{

--- a/kagenti-operator/internal/webhook/injector/container_builder_test.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder_test.go
@@ -77,9 +77,10 @@ func TestBuildEnvoyProxyContainer_HasAllRequiredMounts(t *testing.T) {
 	container := builder.BuildEnvoyProxyContainerWithSpireOption(true)
 
 	requiredMounts := map[string]string{
-		"envoy-config": "/etc/envoy",
-		"shared-data":  "/shared",
-		"svid-output":  "/opt",
+		"envoy-config":              "/etc/envoy",
+		"shared-data":               "/shared",
+		"svid-output":               "/opt",
+		"authbridge-unified-config": "/etc/authbridge",
 	}
 
 	mountsByName := make(map[string]string)

--- a/kagenti-operator/internal/webhook/injector/volume_builder.go
+++ b/kagenti-operator/internal/webhook/injector/volume_builder.go
@@ -80,6 +80,17 @@ func BuildRequiredVolumes() []corev1.Volume {
 				},
 			},
 		},
+		{
+			Name: "authbridge-unified-config",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "authbridge-unified-config",
+					},
+					Optional: ptr.To(true),
+				},
+			},
+		},
 	}
 }
 
@@ -109,6 +120,17 @@ func BuildRequiredVolumesNoSpire() []corev1.Volume {
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "authproxy-routes",
+					},
+					Optional: ptr.To(true),
+				},
+			},
+		},
+		{
+			Name: "authbridge-unified-config",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "authbridge-unified-config",
 					},
 					Optional: ptr.To(true),
 				},
@@ -183,6 +205,17 @@ func BuildResolvedVolumes(spireEnabled bool, envoyConfigMapName string) []corev1
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: AuthproxyRoutesConfigMapName,
+					},
+					Optional: ptr.To(true),
+				},
+			},
+		},
+		corev1.Volume{
+			Name: "authbridge-unified-config",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "authbridge-unified-config",
 					},
 					Optional: ptr.To(true),
 				},

--- a/kagenti-operator/internal/webhook/injector/volume_builder_test.go
+++ b/kagenti-operator/internal/webhook/injector/volume_builder_test.go
@@ -23,9 +23,9 @@ import (
 func TestBuildResolvedVolumes_SpireDisabled(t *testing.T) {
 	volumes := BuildResolvedVolumes(false, "")
 
-	// Should have: shared-data, envoy-config, authproxy-routes
-	if len(volumes) != 3 {
-		t.Fatalf("expected 3 volumes, got %d", len(volumes))
+	// Should have: shared-data, envoy-config, authproxy-routes, authbridge-unified-config
+	if len(volumes) != 4 {
+		t.Fatalf("expected 4 volumes, got %d", len(volumes))
 	}
 
 	names := map[string]bool{}
@@ -33,7 +33,7 @@ func TestBuildResolvedVolumes_SpireDisabled(t *testing.T) {
 		names[v.Name] = true
 	}
 
-	for _, expected := range []string{"shared-data", "envoy-config", "authproxy-routes"} {
+	for _, expected := range []string{"shared-data", "envoy-config", "authproxy-routes", "authbridge-unified-config"} {
 		if !names[expected] {
 			t.Errorf("missing volume %q", expected)
 		}
@@ -50,9 +50,9 @@ func TestBuildResolvedVolumes_SpireDisabled(t *testing.T) {
 func TestBuildResolvedVolumes_SpireEnabled(t *testing.T) {
 	volumes := BuildResolvedVolumes(true, "")
 
-	// Should have: shared-data, spire-agent-socket, spiffe-helper-config, svid-output, envoy-config, authproxy-routes
-	if len(volumes) != 6 {
-		t.Fatalf("expected 6 volumes, got %d", len(volumes))
+	// Should have: shared-data, spire-agent-socket, spiffe-helper-config, svid-output, envoy-config, authproxy-routes, authbridge-unified-config
+	if len(volumes) != 7 {
+		t.Fatalf("expected 7 volumes, got %d", len(volumes))
 	}
 
 	names := map[string]bool{}
@@ -60,7 +60,7 @@ func TestBuildResolvedVolumes_SpireEnabled(t *testing.T) {
 		names[v.Name] = true
 	}
 
-	for _, expected := range []string{"shared-data", "spire-agent-socket", "spiffe-helper-config", "svid-output", "envoy-config", "authproxy-routes"} {
+	for _, expected := range []string{"shared-data", "spire-agent-socket", "spiffe-helper-config", "svid-output", "envoy-config", "authproxy-routes", "authbridge-unified-config"} {
 		if !names[expected] {
 			t.Errorf("missing volume %q", expected)
 		}

--- a/kagenti-operator/test/e2e/README.md
+++ b/kagenti-operator/test/e2e/README.md
@@ -14,7 +14,7 @@ End-to-end tests for the kagenti-operator. The suite runs 20 specs:
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) — `brew install kubectl`
 - Container runtime: **Docker** or **Podman**
 
-The test suite auto-detects Docker vs Podman. No env vars needed. AuthBridge sidecar images (`envoy-with-processor`, `proxy-init`, `spiffe-helper`) are pulled from `ghcr.io/kagenti/kagenti-extensions` and loaded into Kind during setup.
+The test suite auto-detects Docker vs Podman. No env vars needed. AuthBridge sidecar images (`authbridge-unified`, `proxy-init`, `spiffe-helper`) are pulled from `ghcr.io/kagenti/kagenti-extensions` and loaded into Kind during setup.
 
 ## Run
 
@@ -99,7 +99,7 @@ BeforeSuite (once per suite)
 ├── Install Prometheus Operator v0.77.1 (metrics/ServiceMonitor CRDs)
 ├── Install CertManager v1.16.3 (webhook TLS certificates)
 ├── Build & load agentcard-signer image into Kind
-├── Pull & load AuthBridge sidecar images (envoy-with-processor, proxy-init, spiffe-helper)
+├── Pull & load AuthBridge sidecar images (authbridge-unified, proxy-init, spiffe-helper)
 └── Install SPIRE via Helm (spire-crds v0.5.0 + spire v0.28.3)
 
 BeforeAll (per Describe block)

--- a/kagenti-operator/test/e2e/e2e_suite_test.go
+++ b/kagenti-operator/test/e2e/e2e_suite_test.go
@@ -55,7 +55,7 @@ var (
 
 	// sidecarImages are the AuthBridge sidecar images to pull and load into Kind
 	sidecarImages = []string{
-		"ghcr.io/kagenti/kagenti-extensions/envoy-with-processor:latest",
+		"ghcr.io/kagenti/kagenti-extensions/authbridge-unified:latest",
 		"ghcr.io/kagenti/kagenti-extensions/proxy-init:latest",
 		"ghcr.io/kagenti/kagenti-extensions/spiffe-helper:latest",
 	}

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -447,6 +447,7 @@ var _ = Describe("AuthBridge Injection E2E", Ordered, func() {
 				expectedVolumes := []string{
 					"shared-data", "spire-agent-socket", "spiffe-helper-config",
 					"svid-output", "envoy-config", "authproxy-routes",
+					"authbridge-unified-config",
 				}
 				for _, vol := range expectedVolumes {
 					g.Expect(volumes).To(ContainSubstring(vol), "expected volume %s", vol)

--- a/kagenti-operator/test/e2e/fixtures.go
+++ b/kagenti-operator/test/e2e/fixtures.go
@@ -897,6 +897,30 @@ data:
                         socket_address:
                           address: 127.0.0.1
                           port_value: 8080
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authbridge-unified-config
+  namespace: ` + authBridgeTestNamespace + `
+data:
+  config.yaml: |
+    mode: envoy-sidecar
+    inbound:
+      issuer: "https://keycloak.example.com/realms/test"
+    outbound:
+      token_url: "https://keycloak.example.com/realms/test/protocol/openid-connect/token"
+      default_policy: "passthrough"
+    identity:
+      type: client-secret
+      client_id_file: "/shared/client-id.txt"
+      client_secret_file: "/shared/client-secret.txt"
+    bypass:
+      inbound_paths:
+        - "/.well-known/*"
+        - "/healthz"
+        - "/readyz"
+        - "/livez"
 `
 }
 


### PR DESCRIPTION
## Summary

Replace the default envoy-proxy sidecar image with the unified authbridge binary (`authbridge-unified`). This is a drop-in replacement — same UID 1337, same ports, same Envoy config. The key difference: the binary reads auth configuration from a YAML config file (`/etc/authbridge/config.yaml`) instead of environment variables.

### Changes

- **`defaults.go`**: `Images.EnvoyProxy` → `ghcr.io/kagenti/kagenti-extensions/authbridge-unified:latest`
- **`container_builder.go`**: Add `--config /etc/authbridge/config.yaml` args and `authbridge-unified-config` volume mount to the envoy-proxy container
- **`volume_builder.go`**: Add `authbridge-unified-config` ConfigMap volume to all three volume builder functions
- **`volume_builder_test.go`**: Update volume count assertions

### How it works

1. The Helm chart creates `authbridge-unified-config` ConfigMap per agent namespace (kagenti/kagenti#1254)
2. The operator webhook injects the envoy-proxy container with the new image
3. The entrypoint starts Envoy + authbridge binary
4. The binary reads `/etc/authbridge/config.yaml`, derives TOKEN_URL and JWKS_URL from Keycloak settings, waits for credential files, and starts the ext_proc gRPC server

### What doesn't change

- Proxy-init, spiffe-helper, client-registration sidecars — unchanged
- Pod mutation logic, injection decisions, precedence — unchanged
- Env vars still injected (the binary ignores them, reads from config file)

### Dependencies

- kagenti-extensions `v0.5.0-alpha.1` — publishes `authbridge-unified` image to ghcr.io
- kagenti/kagenti#1254 — adds `authbridge-unified-config` ConfigMap to Helm chart

### E2E verification

Tested on Kind cluster with weather agent:
- Inbound JWT validation: working (bypass paths, invalid token rejection, valid token forwarding)
- Outbound token exchange: working (route matching, client-credentials grant, auth-target returns "authorized")
- Kagenti UI: agent card synced, chat working end-to-end

## Test plan

- [x] `go test ./internal/webhook/injector/...` — all passing
- [x] `go vet` — clean
- [ ] CI passes

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
