### PR TITLE
docs: add AgentRuntime documentation for Phase 4 (#862)

### DIFF
--- a/kagenti-operator/GETTING_STARTED.md
+++ b/kagenti-operator/GETTING_STARTED.md
@@ -40,15 +40,150 @@ This scenario demonstrates the complete lifecycle of an AI agent deployment on t
 ## Overview
 
 ### Kagenti Operator
-The Kagenti Operator discovers, indexes, and secures AI agents deployed in Kubernetes. Agents are deployed as standard Kubernetes **Deployments** or **StatefulSets** with the `kagenti.io/type: agent` label. The operator automatically creates **AgentCard** resources for discovered workloads to enable Kubernetes-native agent discovery.
+The Kagenti Operator discovers, indexes, and secures AI agents deployed in Kubernetes. There are two ways to enroll workloads:
 
-> **Note:** The `Agent` Custom Resource is deprecated and will be removed in a future release. Use standard Kubernetes Deployments or StatefulSets with the `kagenti.io/type: agent` label instead.
+1. **AgentRuntime CR (Recommended)** — Create a clean Deployment and an `AgentRuntime` CR pointing to it. The controller applies labels and triggers sidecar injection automatically. Your workload manifests stay free of kagenti-specific labels.
+2. **Manual labels** — Add the `kagenti.io/type: agent` label directly to your Deployment or StatefulSet. This is simpler for quick tests but does not provide identity or observability configuration.
+
+> **Note:** The `Agent` Custom Resource is deprecated and will be removed in a future release.
 
 ---
 
-## Deploy an Agent
+## Deploy an Agent with AgentRuntime (Recommended)
 
-Deploy an agent as a standard Kubernetes Deployment with the required `kagenti.io/type: agent` label. The operator will automatically discover the workload and create an AgentCard for it.
+The AgentRuntime approach keeps your workload manifests clean — no kagenti labels required. The controller applies labels, computes a config hash, and triggers the AuthBridge webhook to inject sidecars.
+
+### Step 1: Deploy a Clean Deployment
+
+```yaml
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: weather-agent
+  namespace: team1
+  labels:
+    app.kubernetes.io/name: weather-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: weather-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: weather-agent
+    spec:
+      containers:
+      - name: agent
+        image: "ghcr.io/kagenti/agent-examples/weather_service:v0.0.1-alpha.3"
+        ports:
+        - containerPort: 8000
+        imagePullPolicy: Always
+        env:
+        - name: PORT
+          value: "8000"
+        - name: UV_CACHE_DIR
+          value: /app/.cache/uv
+        - name: MCP_URL
+          value: http://weather-tool-mcp.team1.svc.cluster.local:8000/mcp
+        - name: LLM_API_BASE
+          value: http://host.docker.internal:11434/v1
+        - name: LLM_API_KEY
+          value: dummy
+        - name: LLM_MODEL
+          value: llama3.2:3b-instruct-fp16
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: weather-agent
+  namespace: team1
+spec:
+  selector:
+    app.kubernetes.io/name: weather-agent
+  ports:
+  - name: http
+    port: 8000
+    targetPort: 8000
+EOF
+```
+
+### Step 2: Create an AgentRuntime CR
+
+```yaml
+kubectl apply -f - <<EOF
+apiVersion: agent.kagenti.dev/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: weather-agent-runtime
+  namespace: team1
+spec:
+  type: agent
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: weather-agent
+EOF
+```
+
+The controller will:
+1. Resolve `targetRef` and verify the Deployment exists
+2. Apply `kagenti.io/type: agent` and `app.kubernetes.io/managed-by: kagenti-operator` labels
+3. Compute a config hash from cluster/namespace/CR configuration and set it as a `kagenti.io/config-hash` annotation on the PodTemplateSpec
+4. Trigger a rolling update — new Pods are created with the `kagenti.io/type` label, which the AuthBridge webhook matches to inject sidecars
+
+### Step 3: Check Status
+
+```bash
+# Check AgentRuntime status
+kubectl get agentruntime -n team1
+
+# Example output:
+# NAME                      TYPE    TARGET          PHASE    AGE
+# weather-agent-runtime     agent   weather-agent   Active   2m
+
+# View detailed conditions
+kubectl describe agentruntime weather-agent-runtime -n team1
+
+# Verify labels were applied to the Deployment
+kubectl get deployment weather-agent -n team1 --show-labels
+
+# Check that pods received sidecar injection
+kubectl get pods -n team1 -l kagenti.io/type=agent -o jsonpath='{.items[0].spec.containers[*].name}'
+```
+
+### Updating Configuration
+
+When you update the AgentRuntime CR (e.g., changing the trust domain or trace endpoint), the controller recomputes the config hash and triggers a rolling update automatically:
+
+```bash
+kubectl patch agentruntime weather-agent-runtime -n team1 --type merge -p '
+spec:
+  trace:
+    endpoint: otel-collector.observability.svc.cluster.local:4317
+    protocol: grpc
+    sampling:
+      rate: 0.5
+'
+```
+
+### Deleting an AgentRuntime
+
+When you delete the AgentRuntime CR, the controller performs a graceful cleanup:
+- Preserves the `kagenti.io/type` label (so AgentCard discovery continues)
+- Updates the config hash to defaults-only (triggers a rollback to default sidecar configuration)
+- Removes the `app.kubernetes.io/managed-by` label
+
+```bash
+kubectl delete agentruntime weather-agent-runtime -n team1
+```
+
+---
+
+## Deploy an Agent with Manual Labels (Alternative)
+
+Deploy an agent as a standard Kubernetes Deployment with the required `kagenti.io/type: agent` label. The operator will automatically discover the workload and create an AgentCard for it. This approach does not provide AgentRuntime's identity or observability configuration.
 
 ### Quick Example Deployment
 
@@ -431,6 +566,7 @@ kubectl run curl-test --image=curlimages/curl:8.1.2 --rm -i --tty -n team1 -- \
 
 ## Next Steps
 
+- [Controller-Webhook Interaction](docs/controller-webhook-interaction.md) — How the AgentRuntime controller and AuthBridge webhook coordinate
 - [Dynamic Agent Discovery](docs/dynamic-agent-discovery.md) — How AgentCard enables agent discovery
 - [Signature Verification](docs/agentcard-signature-verification.md) — Set up JWS signature verification
 - [Identity Binding](docs/agentcard-identity-binding.md) — Configure SPIFFE identity binding

--- a/kagenti-operator/config/samples/agent_v1alpha1_agentruntime_basic.yaml
+++ b/kagenti-operator/config/samples/agent_v1alpha1_agentruntime_basic.yaml
@@ -1,0 +1,16 @@
+# Basic AgentRuntime: enroll a Deployment as an agent with default configuration.
+# The controller applies kagenti.io/type label and triggers sidecar injection.
+# Identity and trace settings come from cluster and namespace defaults.
+apiVersion: agent.kagenti.dev/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: weather-agent-runtime
+  namespace: default
+  labels:
+    app.kubernetes.io/name: weather-agent
+spec:
+  type: agent
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: weather-agent

--- a/kagenti-operator/config/samples/agent_v1alpha1_agentruntime_full.yaml
+++ b/kagenti-operator/config/samples/agent_v1alpha1_agentruntime_full.yaml
@@ -1,0 +1,23 @@
+# Full AgentRuntime: enroll a Deployment as an agent with per-workload overrides.
+# Overrides the SPIFFE trust domain and configures OTEL trace collection.
+apiVersion: agent.kagenti.dev/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: weather-agent-runtime
+  namespace: default
+  labels:
+    app.kubernetes.io/name: weather-agent
+spec:
+  type: agent
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: weather-agent
+  identity:
+    spiffe:
+      trustDomain: custom.example.com
+  trace:
+    endpoint: otel-collector.observability.svc.cluster.local:4317
+    protocol: grpc
+    sampling:
+      rate: 0.1

--- a/kagenti-operator/config/samples/agent_v1alpha1_agentruntime_tool.yaml
+++ b/kagenti-operator/config/samples/agent_v1alpha1_agentruntime_tool.yaml
@@ -1,0 +1,20 @@
+# Tool AgentRuntime: enroll a Deployment as a tool (e.g., MCP server).
+# Requires the injectTools feature gate to be enabled for sidecar injection.
+apiVersion: agent.kagenti.dev/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: calculator-tool-runtime
+  namespace: default
+  labels:
+    app.kubernetes.io/name: calculator-tool
+spec:
+  type: tool
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: calculator-tool
+  trace:
+    endpoint: otel-collector.observability.svc.cluster.local:4318
+    protocol: http
+    sampling:
+      rate: 1.0

--- a/kagenti-operator/config/samples/kustomization.yaml
+++ b/kagenti-operator/config/samples/kustomization.yaml
@@ -1,4 +1,6 @@
 ## Append samples of your project ##
 resources:
-- weather-agent-image-deployment.yaml
+- agent_v1alpha1_agentruntime_basic.yaml
+- agent_v1alpha1_agentruntime_full.yaml
+- agent_v1alpha1_agentruntime_tool.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/kagenti-operator/docs/architecture.md
+++ b/kagenti-operator/docs/architecture.md
@@ -310,14 +310,50 @@ When `spec.identityBinding` is configured on an AgentCard:
 
 ### RBAC
 
-The operator implements least-privilege access control:
+The operator implements least-privilege access control. All permissions are declared as `+kubebuilder:rbac` markers on the controller source files and compiled into the `manager-role` ClusterRole at `config/rbac/role.yaml`.
 
-#### Operator Permissions
-- Read/Write: AgentCard CRs, AgentRuntime CRs
-- Read/Update/Patch: Deployments, StatefulSets (for label/annotation application)
-- Read: Services, Pods
-- Read: ConfigMaps (cluster defaults + namespace defaults)
-- Create/Patch: Events
+#### AgentRuntime Controller Permissions
+
+Source: `internal/controller/agentruntime_controller.go`
+
+| API Group | Resources | Verbs | Purpose |
+|-----------|-----------|-------|---------|
+| `agent.kagenti.dev` | `agentruntimes` | get, list, watch, create, update, patch, delete | Full lifecycle management of the primary resource |
+| `agent.kagenti.dev` | `agentruntimes/status` | get, update, patch | Set phase (Pending/Active/Error), conditions, and configuredPods count |
+| `agent.kagenti.dev` | `agentruntimes/finalizers` | update | Add/remove `kagenti.io/cleanup` finalizer for graceful deletion |
+| `apps` | `deployments`, `statefulsets` | get, list, watch, update, patch | Resolve targetRef, apply labels (`kagenti.io/type`, `managed-by`) and config-hash annotation |
+| `""` (core) | `configmaps` | get, list, watch | Read cluster defaults (`kagenti-platform-config`), feature gates (`kagenti-feature-gates`), and namespace defaults |
+| `""` (core) | `pods` | get, list, watch | Count configured pods and verify ownership chains |
+| `""` (core) | `events` | create, patch | Record reconciliation events (TargetNotFound, ConfigWarning, Configured) |
+
+#### AgentCard Controller Permissions
+
+Source: `internal/controller/agentcard_controller.go`
+
+| API Group | Resources | Verbs | Purpose |
+|-----------|-----------|-------|---------|
+| `agent.kagenti.dev` | `agentcards` | get, list, watch, create, update, patch, delete | Full lifecycle management |
+| `agent.kagenti.dev` | `agentcards/status` | get, update, patch | Store cached card data, sync conditions, signature results |
+| `agent.kagenti.dev` | `agentcards/finalizers` | update | Finalizer management |
+| `apps` | `deployments`, `statefulsets` | get, list, watch, update, patch | Resolve targetRef and propagate signature labels |
+| `""` (core) | `services` | get, list, watch | Construct service URLs for agent card fetching |
+| `""` (core) | `configmaps` | get, list, watch | Read SPIRE trust bundle for signature verification |
+
+#### AgentCard NetworkPolicy Controller Permissions
+
+Source: `internal/controller/agentcard_networkpolicy_controller.go`
+
+| API Group | Resources | Verbs | Purpose |
+|-----------|-----------|-------|---------|
+| `networking.k8s.io` | `networkpolicies` | get, list, watch, create, update, patch, delete | Create permissive/restrictive NetworkPolicies based on signature verification |
+| `""` (core) | `pods` | get, list, watch, update, patch | Resolve pod selectors from workload pod template labels |
+
+#### Cross-Namespace Considerations
+
+- The operator uses a **ClusterRole** and **ClusterRoleBinding** in cluster-wide mode, allowing it to reconcile resources across all namespaces
+- In **namespaced mode** (`NAMESPACES2WATCH` env var), the same permissions are scoped to specific namespaces via **Role** and **RoleBinding**
+- The AgentRuntime controller reads ConfigMaps from `kagenti-system` (cluster defaults) regardless of mode — this requires cross-namespace read access
+- Namespace defaults ConfigMaps are read from the workload's own namespace
 
 ### Secret Management
 
@@ -434,6 +470,7 @@ The operator exposes metrics via Prometheus:
 ## Additional Resources
 
 - [API Reference](./api-reference.md) — CRD specifications
+- [Controller-Webhook Interaction](./controller-webhook-interaction.md) — AgentRuntime controller and AuthBridge webhook coordination
 - [Dynamic Agent Discovery](./dynamic-agent-discovery.md) — AgentCard discovery system
 - [Signature Verification](./agentcard-signature-verification.md) — JWS signature setup guide
 - [Identity Binding](./agentcard-identity-binding.md) — SPIFFE identity binding guide

--- a/kagenti-operator/docs/controller-webhook-interaction.md
+++ b/kagenti-operator/docs/controller-webhook-interaction.md
@@ -1,0 +1,224 @@
+# Controller-Webhook Interaction
+
+This document describes how the AgentRuntime controller and AuthBridge mutating webhook coordinate to configure and inject sidecars into agent and tool workloads. Both components run in the same operator binary.
+
+## Two-Phase Model
+
+The AgentRuntime system uses a two-phase model:
+
+1. **Controller phase**: The AgentRuntime controller watches CRs and applies labels + a config-hash annotation to the target workload's PodTemplateSpec. This triggers a Kubernetes rolling update.
+2. **Webhook phase**: The AuthBridge mutating webhook intercepts Pod CREATE requests. When a Pod has the `kagenti.io/type` label (applied by the controller), the webhook injects sidecar containers.
+
+The controller never mutates Pods directly. The webhook does not decide *which labels to apply* — that is encoded by the controller. However, the webhook does require a matching AgentRuntime CR to exist as a gate before injecting sidecars, and reads the CR for per-workload configuration overrides.
+
+## Sequence Diagrams
+
+### AgentRuntime CR Create
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant API as API Server
+    participant Val as Validating Webhook
+    participant Ctrl as AgentRuntime Controller
+    participant WH as AuthBridge Webhook
+    participant K8s as Kubernetes (ReplicaSet)
+
+    User->>API: kubectl apply AgentRuntime CR
+    API->>Val: Validate (reject duplicate targetRef)
+    Val-->>API: Allowed
+    API-->>Ctrl: Reconcile event
+
+    Ctrl->>API: Get target Deployment
+    Ctrl->>API: Get cluster defaults ConfigMap (kagenti-platform-config)
+    Ctrl->>API: Get feature gates ConfigMap (kagenti-feature-gates)
+    Ctrl->>API: List namespace defaults ConfigMaps (kagenti.io/defaults=true)
+    Note over Ctrl: Merge config: cluster → namespace → CR spec
+    Note over Ctrl: Compute SHA256 config hash
+
+    Ctrl->>API: Patch Deployment:<br/>+ kagenti.io/type label<br/>+ managed-by label<br/>+ config-hash annotation on PodTemplateSpec
+    API-->>K8s: PodTemplateSpec changed → rolling update
+    K8s->>API: Create new Pod (with kagenti.io/type label)
+    API->>WH: Mutating admission (Pod CREATE)
+    WH->>API: Read AgentRuntime CR overrides
+    WH->>API: Read namespace ConfigMaps
+    Note over WH: Merge config and build sidecar containers
+    WH-->>API: Patch Pod with sidecar containers + volumes
+    API-->>K8s: Pod created with sidecars
+
+    Ctrl->>API: Update AgentRuntime status (phase=Active, conditions, configuredPods)
+```
+
+### AgentRuntime CR Update (Config Change)
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant API as API Server
+    participant Ctrl as AgentRuntime Controller
+    participant WH as AuthBridge Webhook
+    participant K8s as Kubernetes (ReplicaSet)
+
+    User->>API: kubectl patch AgentRuntime (e.g., change trace endpoint)
+    API-->>Ctrl: Reconcile event
+
+    Ctrl->>API: Get target Deployment
+    Note over Ctrl: Recompute config hash with updated CR values
+    Note over Ctrl: New hash ≠ old hash → update needed
+
+    Ctrl->>API: Patch Deployment config-hash annotation
+    API-->>K8s: PodTemplateSpec changed → rolling update
+    K8s->>API: Create new Pod
+    API->>WH: Mutating admission (Pod CREATE)
+    Note over WH: Resolve config with updated AgentRuntime values
+    WH-->>API: Patch Pod with updated sidecar config
+    API-->>K8s: Pod created with new config
+
+    Ctrl->>API: Update AgentRuntime status
+```
+
+### ConfigMap Change (Cluster or Namespace Defaults)
+
+```mermaid
+sequenceDiagram
+    participant Admin
+    participant API as API Server
+    participant Ctrl as AgentRuntime Controller
+    participant K8s as Kubernetes (ReplicaSet)
+
+    Admin->>API: Update kagenti-platform-config ConfigMap
+    API-->>Ctrl: Watch fires → reconcile all affected AgentRuntimes
+
+    loop For each AgentRuntime targeting a workload
+        Ctrl->>API: Get target Deployment
+        Note over Ctrl: Recompute config hash with new defaults
+        alt Hash changed
+            Ctrl->>API: Patch Deployment config-hash annotation
+            API-->>K8s: Rolling update → new Pods with updated sidecars
+        else Hash unchanged
+            Note over Ctrl: No-op (CR overrides masked the change)
+        end
+        Ctrl->>API: Update AgentRuntime status
+    end
+```
+
+### AgentRuntime CR Delete
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant API as API Server
+    participant Ctrl as AgentRuntime Controller
+    participant K8s as Kubernetes (ReplicaSet)
+
+    User->>API: kubectl delete AgentRuntime CR
+    API-->>Ctrl: Reconcile (deletionTimestamp set)
+
+    Note over Ctrl: Finalizer kagenti.io/cleanup is present
+
+    Ctrl->>API: Patch Deployment:<br/>- Preserve kagenti.io/type label<br/>- Update config-hash to defaults-only<br/>- Remove managed-by label
+    API-->>K8s: PodTemplateSpec changed → rolling update
+    Note over K8s: New Pods get sidecars with default config only
+
+    Ctrl->>API: Remove finalizer from AgentRuntime CR
+    API->>API: CR garbage collected
+```
+
+## Responsibility Split
+
+| Concern | Controller | Webhook |
+|---------|-----------|---------|
+| Detect config change | Yes (3-layer merge + hash) | No |
+| Trigger pod restart | Yes (annotation on PodTemplateSpec) | No |
+| Read ConfigMap data | Yes (for hash computation) | Yes (for sidecar configuration) |
+| Merge config values | Yes (same 3-layer merge) | Yes (independently, same algorithm) |
+| Mutate pod spec | No | Yes (sidecar injection) |
+| Read AgentRuntime CR | Yes (primary resource) | Yes (for per-workload overrides) |
+| Apply workload labels | Yes | No |
+| Decide injection eligibility | No (encodes in labels) | Yes (objectSelector + precedence chain) |
+
+## 3-Layer Configuration Merge
+
+Both the controller and webhook perform the same 3-layer configuration merge independently:
+
+```
+┌──────────────────────────────────────┐
+│ Layer 3: AgentRuntime CR overrides   │  ← highest precedence
+│   (spec.identity, spec.trace)        │
+├──────────────────────────────────────┤
+│ Layer 2: Namespace defaults          │
+│   (ConfigMap with                    │
+│    kagenti.io/defaults=true label)   │
+├──────────────────────────────────────┤
+│ Layer 1: Cluster defaults            │  ← lowest precedence
+│   (kagenti-platform-config in        │
+│    kagenti-system namespace)         │
+└──────────────────────────────────────┘
+```
+
+**Feature gates** (`kagenti-feature-gates` ConfigMap) are platform-wide policy and are **not** part of the merge hierarchy. They control which sidecar components are enabled globally and cannot be overridden by namespace defaults or AgentRuntime CRs.
+
+The controller uses the merged config to compute a deterministic SHA256 hash. This hash is set as the `kagenti.io/config-hash` annotation on the workload's PodTemplateSpec. When any layer changes, the hash changes, which triggers a Kubernetes rolling update.
+
+The webhook performs the same merge at Pod CREATE time to resolve the actual configuration values used for sidecar container environment variables.
+
+> **Note:** The controller and webhook use slightly different sources for layer 1. The controller reads the `kagenti-platform-config` ConfigMap from `kagenti-system` via the API server. The webhook uses compiled defaults overlaid with `/etc/kagenti/config.yaml` (PlatformConfig), which is designed to carry equivalent values. Both produce the same effective defaults in a correctly deployed cluster.
+
+## Global and Cluster Configuration
+
+When workloads are deployed with the right labels (`kagenti.io/type: agent` or `tool`), the webhook uses two levels of global configuration regardless of whether an AgentRuntime CR exists:
+
+### PlatformConfig (Global Defaults)
+
+The webhook loads **PlatformConfig** at startup from compiled defaults overlaid with `/etc/kagenti/config.yaml`. This provides:
+
+- Sidecar container images and resource requests/limits
+- Proxy ports and UID
+- Token exchange defaults (token URL, audience, scopes)
+- SPIFFE trust domain and socket path
+- Observability settings (trace endpoint, protocol, sampling)
+
+PlatformConfig is hot-reloaded via fsnotify when the config file changes. It forms **layer 1** (lowest precedence) of the 3-layer merge.
+
+### Feature Gates (Global Policy)
+
+Feature gates are loaded from the `kagenti-feature-gates` ConfigMap (mounted at `/etc/kagenti/feature-gates/feature-gates.yaml`) and hot-reloaded. They act as cluster-wide kill switches:
+
+| Gate | Default | Effect |
+|------|---------|--------|
+| `globalEnabled` | `true` | Master kill switch — `false` disables all injection |
+| `envoyProxy` | `true` | Enable/disable envoy-proxy + proxy-init |
+| `spiffeHelper` | `true` | Enable/disable spiffe-helper |
+| `clientRegistration` | `true` | Enable/disable client-registration |
+| `injectTools` | `false` | Allow injection for `kagenti.io/type=tool` workloads |
+| `perWorkloadConfigResolution` | `false` | Switch from ValueFrom refs to literal env var injection |
+
+Feature gates are **not** part of the 3-layer merge — they cannot be overridden by namespace defaults or AgentRuntime CRs.
+
+### Config Resolution Modes
+
+When `perWorkloadConfigResolution` is **false** (default), the webhook builds sidecar containers with `ValueFrom` ConfigMapKeyRef/SecretKeyRef references. Kubelet resolves these at container start time from namespace ConfigMaps. This means workloads pick up namespace ConfigMap changes on next pod restart without needing a config hash change.
+
+When `perWorkloadConfigResolution` is **true**, the webhook resolves all config values at admission time by reading namespace ConfigMaps and AgentRuntime CR overrides, then injects literal environment variable values into the sidecar containers.
+
+## Defaults-Only Path (No AgentRuntime CR)
+
+When a workload has `kagenti.io/type` labels applied manually (without an AgentRuntime CR):
+
+- The webhook still evaluates the workload for injection using PlatformConfig and feature gates
+- The AgentRuntime override layer (layer 3) is skipped — configuration comes from PlatformConfig (layer 1) and namespace ConfigMaps (layer 2) only
+- No controller manages the config hash — configuration drift is not detected automatically, and changes to cluster/namespace defaults do not trigger rolling updates
+- The controller does not watch or reconcile these workloads
+- Per-workload identity (SPIFFE trust domain) and trace overrides are not available
+
+The AgentRuntime CR is the recommended approach because it provides:
+- Automatic rolling updates on config change (any layer)
+- Per-workload identity and trace overrides
+- Status reporting (phase, conditions, configured pod count)
+- Graceful cleanup via finalizer
+
+## Related Documentation
+
+- [API Reference](api-reference.md) — AgentRuntime and AgentCard CRD specifications
+- [AuthBridge Webhook Design](authbridge-webhook.md) — Sidecar injection precedence chain and configuration merge
+- [Architecture](architecture.md) — Overall operator architecture


### PR DESCRIPTION




-->
## Summary
Add documentation for the AgentRuntime controller covering:
- GETTING_STARTED.md: AgentRuntime workflow as recommended approach
- Controller-webhook interaction doc with Mermaid sequence diagrams
- RBAC section in architecture.md with per-controller permission tables
- Sample YAMLs (basic, full, tool) in config/samples/

Signed-off-by: Varsha Prasad Narsing <varshaprasad96@gmail.com> 
Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

## Related issue(s)

## (Optional) Testing Instructions

Fixes #
