### PR TITLE
feat: mode-aware image selection and proxy-sidecar injection

### DIFF
--- a/kagenti-operator/internal/webhook/config/defaults.go
+++ b/kagenti-operator/internal/webhook/config/defaults.go
@@ -11,7 +11,8 @@ func CompiledDefaults() *PlatformConfig {
 		// Compiled defaults are overridden at runtime by the platform-config
 		// ConfigMap (kagenti-platform-config). These serve as fallbacks only.
 		Images: ImageConfig{
-			EnvoyProxy:         "ghcr.io/kagenti/kagenti-extensions/authbridge-unified:latest",
+			EnvoyProxy:         "ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:latest",
+			AuthBridgeLight:    "ghcr.io/kagenti/kagenti-extensions/authbridge-light:latest",
 			ProxyInit:          "ghcr.io/kagenti/kagenti-extensions/proxy-init:latest",
 			SpiffeHelper:       "ghcr.io/kagenti/kagenti-extensions/spiffe-helper:latest",
 			ClientRegistration: "ghcr.io/kagenti/kagenti-extensions/client-registration:latest",

--- a/kagenti-operator/internal/webhook/config/types.go
+++ b/kagenti-operator/internal/webhook/config/types.go
@@ -19,6 +19,7 @@ type PlatformConfig struct {
 
 type ImageConfig struct {
 	EnvoyProxy         string            `json:"envoyProxy" yaml:"envoyProxy"`
+	AuthBridgeLight    string            `json:"authbridgeLight" yaml:"authbridgeLight"`
 	ProxyInit          string            `json:"proxyInit" yaml:"proxyInit"`
 	SpiffeHelper       string            `json:"spiffeHelper" yaml:"spiffeHelper"`
 	ClientRegistration string            `json:"clientRegistration" yaml:"clientRegistration"`

--- a/kagenti-operator/internal/webhook/injector/constants.go
+++ b/kagenti-operator/internal/webhook/injector/constants.go
@@ -10,3 +10,17 @@ const (
 	// default is operator-managed Keycloak credentials (no sidecar).
 	LabelClientRegistrationInject = "kagenti.io/client-registration-inject"
 )
+
+// AuthBridge deployment mode annotation.
+// Controls which image variant and injection pattern is used.
+const (
+	AnnotationAuthBridgeMode = "kagenti.io/authbridge-mode"
+
+	// Mode values
+	ModeEnvoySidecar = "envoy-sidecar" // default: iptables + Envoy + ext_proc
+	ModeProxySidecar = "proxy-sidecar" // HTTP_PROXY env + lightweight authbridge
+	ModeWaypoint     = "waypoint"      // standalone deployment (not injected)
+
+	// Container name for proxy-sidecar mode
+	AuthBridgeProxyContainerName = "authbridge-proxy"
+)

--- a/kagenti-operator/internal/webhook/injector/container_builder.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder.go
@@ -441,6 +441,55 @@ func (b *ContainerBuilder) BuildEnvoyProxyContainerWithSpireOption(spireEnabled 
 	}
 }
 
+// BuildProxySidecarContainer creates a lightweight authbridge container for proxy-sidecar mode.
+// Uses authbridge-light image (no Envoy). The app uses HTTP_PROXY env vars to route
+// outbound traffic through the forward proxy. Inbound traffic goes through the reverse proxy.
+func (b *ContainerBuilder) BuildProxySidecarContainer(spireEnabled bool) corev1.Container {
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "shared-data",
+			MountPath: "/shared",
+		},
+		{
+			Name:      "authbridge-unified-config",
+			MountPath: "/etc/authbridge",
+			ReadOnly:  true,
+		},
+	}
+	if spireEnabled {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "svid-output",
+			MountPath: "/opt",
+		})
+	}
+
+	return corev1.Container{
+		Name:            AuthBridgeProxyContainerName,
+		Image:           b.cfg.Images.AuthBridgeLight,
+		ImagePullPolicy: b.cfg.Images.PullPolicy,
+		Args:            []string{"--mode", "proxy-sidecar", "--config", "/etc/authbridge/config.yaml"},
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "reverse-proxy",
+				ContainerPort: 8080,
+				Protocol:      corev1.ProtocolTCP,
+			},
+			{
+				Name:          "forward-proxy",
+				ContainerPort: 8081,
+				Protocol:      corev1.ProtocolTCP,
+			},
+		},
+		Resources: b.cfg.Resources.EnvoyProxy,
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:                ptr.To(int64(1001)),
+			RunAsNonRoot:             ptr.To(true),
+			AllowPrivilegeEscalation: ptr.To(false),
+		},
+		VolumeMounts: volumeMounts,
+	}
+}
+
 // buildEnvoyProxyEnvResolved returns literal env vars from resolved config.
 func (b *ContainerBuilder) buildEnvoyProxyEnvResolved() []corev1.EnvVar {
 	return []corev1.EnvVar{

--- a/kagenti-operator/internal/webhook/injector/container_builder_test.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder_test.go
@@ -702,3 +702,56 @@ func TestBuildEnvoyProxyContainer_HasExpectedAudienceFromConfigMap(t *testing.T)
 		t.Error("envoy-proxy container missing EXPECTED_AUDIENCE env var from ConfigMap")
 	}
 }
+
+func TestBuildProxySidecarContainer_SpireDisabled(t *testing.T) {
+	builder := NewContainerBuilder(config.CompiledDefaults())
+	container := builder.BuildProxySidecarContainer(false)
+
+	if container.Name != AuthBridgeProxyContainerName {
+		t.Errorf("container name = %q, want %q", container.Name, AuthBridgeProxyContainerName)
+	}
+	if container.Image != config.CompiledDefaults().Images.AuthBridgeLight {
+		t.Errorf("image = %q, want %q", container.Image, config.CompiledDefaults().Images.AuthBridgeLight)
+	}
+
+	// Should have --mode proxy-sidecar --config args
+	if len(container.Args) < 4 || container.Args[0] != "--mode" || container.Args[1] != "proxy-sidecar" {
+		t.Errorf("args = %v, want [--mode proxy-sidecar --config ...]", container.Args)
+	}
+
+	// Should have reverse-proxy and forward-proxy ports
+	portNames := map[string]bool{}
+	for _, p := range container.Ports {
+		portNames[p.Name] = true
+	}
+	if !portNames["reverse-proxy"] {
+		t.Error("missing reverse-proxy port")
+	}
+	if !portNames["forward-proxy"] {
+		t.Error("missing forward-proxy port")
+	}
+
+	// Should NOT have svid-output volume mount (SPIRE disabled)
+	for _, vm := range container.VolumeMounts {
+		if vm.Name == "svid-output" {
+			t.Error("svid-output volume mount should not be present when SPIRE is disabled")
+		}
+	}
+}
+
+func TestBuildProxySidecarContainer_SpireEnabled(t *testing.T) {
+	builder := NewContainerBuilder(config.CompiledDefaults())
+	container := builder.BuildProxySidecarContainer(true)
+
+	// Should have svid-output volume mount
+	found := false
+	for _, vm := range container.VolumeMounts {
+		if vm.Name == "svid-output" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("svid-output volume mount should be present when SPIRE is enabled")
+	}
+}

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -248,6 +248,70 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 			"namespace", namespace, "crName", crName)
 	}
 
+	// ========================================
+	// Mode-aware injection
+	// ========================================
+	//
+	// The authbridge-mode annotation selects the deployment pattern:
+	//   envoy-sidecar (default) — iptables + Envoy + ext_proc (authbridge-envoy image)
+	//   proxy-sidecar           — HTTP_PROXY env + lightweight authbridge (authbridge-light image)
+	//   waypoint                — standalone deployment, not injected as sidecar
+	authBridgeMode := annotations[AnnotationAuthBridgeMode]
+	if authBridgeMode == "" {
+		authBridgeMode = ModeEnvoySidecar
+	}
+
+	if authBridgeMode == ModeWaypoint {
+		mutatorLog.Info("waypoint mode — skipping sidecar injection (waypoint is a standalone deployment)",
+			"namespace", namespace, "crName", crName)
+		return false, nil
+	}
+
+	if authBridgeMode == ModeProxySidecar {
+		// Proxy-sidecar mode: inject lightweight authbridge container + HTTP_PROXY env vars.
+		// No iptables, no proxy-init, no Envoy.
+		if !containerExists(podSpec.Containers, AuthBridgeProxyContainerName) {
+			podSpec.Containers = append(podSpec.Containers, builder.BuildProxySidecarContainer(spireEnabled))
+		}
+
+		// Inject HTTP_PROXY env vars into all existing app containers
+		for i := range podSpec.Containers {
+			c := &podSpec.Containers[i]
+			if c.Name == AuthBridgeProxyContainerName {
+				continue
+			}
+			injectHTTPProxyEnv(c, 8081)
+		}
+
+		// spiffe-helper and client-registration are still injected
+		if decision.SpiffeHelper.Inject && !containerExists(podSpec.Containers, SpiffeHelperContainerName) {
+			podSpec.Containers = append(podSpec.Containers, builder.BuildSpiffeHelperContainer())
+		}
+		if decision.ClientRegistration.Inject && !containerExists(podSpec.Containers, ClientRegistrationContainerName) {
+			podSpec.Containers = append(podSpec.Containers, builder.BuildClientRegistrationContainerWithSpireOption(crName, namespace, spireEnabled))
+		}
+
+		// Inject volumes (shared-data, authbridge-unified-config, spire volumes if enabled)
+		for i := range requiredVolumes {
+			if !volumeExists(podSpec.Volumes, requiredVolumes[i].Name) {
+				podSpec.Volumes = append(podSpec.Volumes, requiredVolumes[i])
+			}
+		}
+
+		mutatorLog.Info("proxy-sidecar mode injection complete",
+			"namespace", namespace, "crName", crName,
+			"image", builder.cfg.Images.AuthBridgeLight)
+
+		if spireEnabled {
+			ensureFSGroup(podSpec)
+		}
+		return true, nil
+	}
+
+	// ========================================
+	// Envoy-sidecar mode (default)
+	// ========================================
+
 	// Conditionally inject sidecars based on precedence decisions.
 	// Two modes controlled by the combinedSidecar feature gate:
 	//   true  → combined mode: single "authbridge" container replaces envoy-proxy +
@@ -417,4 +481,31 @@ func ensureFSGroup(podSpec *corev1.PodSpec) {
 		podSpec.SecurityContext.FSGroup = &fsGroupValue
 		mutatorLog.Info("Set fsGroup for shared volume access", "fsGroup", fsGroupValue)
 	}
+}
+
+// injectHTTPProxyEnv adds HTTP_PROXY, HTTPS_PROXY, and NO_PROXY env vars to a container.
+// Used in proxy-sidecar mode so the app routes outbound traffic through authbridge's
+// forward proxy without iptables interception.
+func injectHTTPProxyEnv(c *corev1.Container, forwardProxyPort int32) {
+	proxyURL := fmt.Sprintf("http://127.0.0.1:%d", forwardProxyPort)
+	envs := []corev1.EnvVar{
+		{Name: "HTTP_PROXY", Value: proxyURL},
+		{Name: "HTTPS_PROXY", Value: proxyURL},
+		{Name: "NO_PROXY", Value: "127.0.0.1,localhost"},
+	}
+	for _, env := range envs {
+		if !envExists(c.Env, env.Name) {
+			c.Env = append(c.Env, env)
+		}
+	}
+}
+
+// envExists checks if an env var with the given name already exists.
+func envExists(envs []corev1.EnvVar, name string) bool {
+	for _, e := range envs {
+		if e.Name == name {
+			return true
+		}
+	}
+	return false
 }

--- a/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
@@ -626,3 +626,159 @@ func TestInjectAuthBridge_NilAnnotations(t *testing.T) {
 	}
 	t.Fatal("proxy-init container not found in initContainers")
 }
+
+// ========================================
+// Mode-aware injection tests
+// ========================================
+
+func TestInjectAuthBridge_WaypointMode_SkipsInjection(t *testing.T) {
+	m := newTestMutator()
+	ctx := context.Background()
+
+	podSpec := &corev1.PodSpec{
+		Containers: []corev1.Container{
+			{Name: "agent", Image: "my-agent:latest"},
+		},
+	}
+	labels := map[string]string{
+		KagentiTypeLabel: KagentiTypeAgent,
+	}
+	annotations := map[string]string{
+		AnnotationAuthBridgeMode: ModeWaypoint,
+	}
+
+	mutated, err := m.InjectAuthBridge(ctx, podSpec, "team1", "my-agent", labels, annotations)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mutated {
+		t.Error("waypoint mode should not mutate the pod (returns false)")
+	}
+	if len(podSpec.Containers) != 1 {
+		t.Errorf("expected 1 container (agent only), got %d", len(podSpec.Containers))
+	}
+}
+
+func TestInjectAuthBridge_ProxySidecarMode_InjectsCorrectly(t *testing.T) {
+	m := newTestMutator()
+	ctx := context.Background()
+
+	podSpec := &corev1.PodSpec{
+		ServiceAccountName: "my-agent",
+		Containers: []corev1.Container{
+			{Name: "agent", Image: "my-agent:latest"},
+		},
+	}
+	labels := map[string]string{
+		KagentiTypeLabel: KagentiTypeAgent,
+	}
+	annotations := map[string]string{
+		AnnotationAuthBridgeMode: ModeProxySidecar,
+	}
+
+	mutated, err := m.InjectAuthBridge(ctx, podSpec, "team1", "my-agent", labels, annotations)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !mutated {
+		t.Error("proxy-sidecar mode should mutate the pod")
+	}
+
+	// Should have authbridge-proxy container
+	proxyFound := false
+	for _, c := range podSpec.Containers {
+		if c.Name == AuthBridgeProxyContainerName {
+			proxyFound = true
+			if c.Image != config.CompiledDefaults().Images.AuthBridgeLight {
+				t.Errorf("proxy container image = %q, want authbridge-light", c.Image)
+			}
+		}
+	}
+	if !proxyFound {
+		t.Error("authbridge-proxy container not found")
+	}
+
+	// Should NOT have proxy-init (no iptables in proxy-sidecar mode)
+	for _, c := range podSpec.InitContainers {
+		if c.Name == ProxyInitContainerName {
+			t.Error("proxy-init should not be injected in proxy-sidecar mode")
+		}
+	}
+
+	// Should NOT have envoy-proxy container
+	for _, c := range podSpec.Containers {
+		if c.Name == EnvoyProxyContainerName {
+			t.Error("envoy-proxy should not be injected in proxy-sidecar mode")
+		}
+	}
+
+	// Agent container should have HTTP_PROXY env vars
+	for _, c := range podSpec.Containers {
+		if c.Name == "agent" {
+			httpProxy := ""
+			httpsProxy := ""
+			noProxy := ""
+			for _, env := range c.Env {
+				switch env.Name {
+				case "HTTP_PROXY":
+					httpProxy = env.Value
+				case "HTTPS_PROXY":
+					httpsProxy = env.Value
+				case "NO_PROXY":
+					noProxy = env.Value
+				}
+			}
+			if httpProxy != "http://127.0.0.1:8081" {
+				t.Errorf("HTTP_PROXY = %q, want http://127.0.0.1:8081", httpProxy)
+			}
+			if httpsProxy != "http://127.0.0.1:8081" {
+				t.Errorf("HTTPS_PROXY = %q, want http://127.0.0.1:8081", httpsProxy)
+			}
+			if noProxy != "127.0.0.1,localhost" {
+				t.Errorf("NO_PROXY = %q, want 127.0.0.1,localhost", noProxy)
+			}
+		}
+	}
+}
+
+func TestInjectHTTPProxyEnv_DoesNotDuplicate(t *testing.T) {
+	c := &corev1.Container{
+		Name: "agent",
+		Env: []corev1.EnvVar{
+			{Name: "HTTP_PROXY", Value: "http://existing-proxy:3128"},
+		},
+	}
+
+	injectHTTPProxyEnv(c, 8081)
+
+	count := 0
+	for _, env := range c.Env {
+		if env.Name == "HTTP_PROXY" {
+			count++
+			if env.Value != "http://existing-proxy:3128" {
+				t.Errorf("HTTP_PROXY should keep existing value, got %q", env.Value)
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 HTTP_PROXY env var, got %d", count)
+	}
+
+	// HTTPS_PROXY and NO_PROXY should be added since they didn't exist
+	httpsFound := false
+	noProxyFound := false
+	for _, env := range c.Env {
+		if env.Name == "HTTPS_PROXY" {
+			httpsFound = true
+		}
+		if env.Name == "NO_PROXY" {
+			noProxyFound = true
+		}
+	}
+	if !httpsFound {
+		t.Error("HTTPS_PROXY should be added")
+	}
+	if !noProxyFound {
+		t.Error("NO_PROXY should be added")
+	}
+}


### PR DESCRIPTION
## Summary

Add authbridge deployment mode support with three modes controlled by the `kagenti.io/authbridge-mode` annotation:

| Mode | Image | How it works | Size |
|------|-------|-------------|------|
| `envoy-sidecar` (default) | authbridge-envoy | iptables + Envoy + ext_proc | 140 MB |
| `proxy-sidecar` | authbridge-light | HTTP_PROXY env vars | 29 MB |
| `waypoint` | authbridge-light | Standalone (stub, skips injection) | 29 MB |

## Changes

- Add `AuthBridgeLight` image field to `ImageConfig`
- Update default `EnvoyProxy` image from `authbridge-unified` to `authbridge-envoy`
- Add `AnnotationAuthBridgeMode` annotation and mode constants
- Add `BuildProxySidecarContainer` to container builder
- Mode-aware injection in `pod_mutator.go`:
  - envoy-sidecar: unchanged (iptables + Envoy + ext_proc)
  - proxy-sidecar: inject authbridge-light + HTTP_PROXY/HTTPS_PROXY/NO_PROXY env vars into app containers
  - waypoint: skip injection (log and return)
- Add `injectHTTPProxyEnv` and `envExists` helpers

## Proxy-sidecar mode (from Klaviger pattern)

Based on the [Klaviger](https://github.com/grs/klaviger) sidecar proxy pattern. The app container gets `HTTP_PROXY=http://127.0.0.1:8081` injected, so standard HTTP clients automatically route outbound traffic through authbridge. No iptables or proxy-init needed.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/webhook/injector/...` passes
- [x] `go test ./internal/webhook/config/...` passes
- [ ] E2E: default mode (envoy-sidecar) works unchanged
- [ ] Manual: annotate deployment with `kagenti.io/authbridge-mode: proxy-sidecar`, verify authbridge-light injected with HTTP_PROXY env vars

Depends on kagenti/kagenti-extensions v0.5.0-alpha.4 (authbridge-envoy + authbridge-light images).

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>