### PR TITLE
fix: collision-free port assignment for proxy-sidecar mode

### DIFF
--- a/charts/kagenti-operator/values.yaml
+++ b/charts/kagenti-operator/values.yaml
@@ -139,7 +139,8 @@ featureGates:
 defaults:
   # Container images with version tags
   images:
-    envoyProxy: ghcr.io/kagenti/kagenti-extensions/envoy-with-processor:latest
+    envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:latest
+    authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:latest
     proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:latest
     spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:latest
     clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:latest

--- a/kagenti-operator/docs/authbridge-webhook.md
+++ b/kagenti-operator/docs/authbridge-webhook.md
@@ -2,18 +2,53 @@
 
 The AuthBridge webhook is a Kubernetes mutating admission webhook that injects sidecar containers into agent and tool Pods. It runs as part of the kagenti-operator binary and intercepts Pod CREATE requests to add networking, identity, and registration sidecars.
 
+## Deployment Modes
+
+The webhook supports multiple deployment modes controlled by the `kagenti.io/authbridge-mode` annotation on the workload's pod template. If not set, the default is `envoy-sidecar`.
+
+| Mode | Annotation value | Image | How it works |
+|------|-----------------|-------|-------------|
+| **envoy-sidecar** (default) | `envoy-sidecar` or absent | `authbridge-envoy` (140 MB) | iptables intercepts all traffic → Envoy → ext_proc for auth |
+| **proxy-sidecar** | `proxy-sidecar` | `authbridge-light` (29 MB) | `HTTP_PROXY` env vars route outbound traffic through authbridge |
+| **waypoint** | `waypoint` | N/A | Skips injection (standalone deployment, not a sidecar) |
+
+### envoy-sidecar (default)
+
+Transparent interception via iptables. All inbound/outbound traffic is redirected through Envoy, which delegates auth decisions to the authbridge binary via ext_proc gRPC. The agent is unaware of the proxy.
+
+Containers injected: `proxy-init` (init), `envoy-proxy`, `spiffe-helper`, `kagenti-client-registration`
+
+### proxy-sidecar
+
+Lightweight mode without Envoy or iptables. The webhook:
+
+1. **Steals the agent's port** — the reverse proxy takes over the agent's original port (e.g., `:8000`) for inbound JWT validation
+2. **Moves the agent** — finds a free port and patches the agent's `PORT` env var (e.g., `:8001`)
+3. **Injects `HTTP_PROXY`** — all app containers get `HTTP_PROXY`/`HTTPS_PROXY` env vars pointing to the forward proxy for outbound traffic
+4. Port assignment uses collision detection — scans all container ports to avoid conflicts
+
+Containers injected: `authbridge-proxy`, `spiffe-helper`, `kagenti-client-registration`
+No init containers (no iptables).
+
+The `authbridge-proxy` container receives `REVERSE_PROXY_ADDR`, `REVERSE_PROXY_BACKEND`, and `FORWARD_PROXY_ADDR` env vars with the dynamically assigned ports. These are expanded via `${...}` placeholders in the authbridge config YAML.
+
+### waypoint
+
+Not a sidecar — the waypoint proxy runs as a standalone Deployment. The webhook logs a message and skips injection. Waypoint deployment is managed separately.
+
 ## Sidecar Containers
 
-The webhook can inject up to four containers:
+The webhook can inject up to four containers depending on mode:
 
-| Container | Type | Purpose |
-|-----------|------|---------|
-| `envoy-proxy` | sidecar | Transparent proxy for outbound/inbound traffic with ext-proc filter for token exchange |
-| `proxy-init` | init | iptables rules to redirect traffic through envoy-proxy |
-| `spiffe-helper` | sidecar | Obtains and rotates SPIFFE SVIDs via the SPIRE workload API |
-| `kagenti-client-registration` | sidecar | Registers the workload as an OAuth2 client in Keycloak |
+| Container | Type | Modes | Purpose |
+|-----------|------|-------|---------|
+| `envoy-proxy` | sidecar | envoy-sidecar | Transparent proxy with ext-proc filter for token exchange (uses `authbridge-envoy` image) |
+| `authbridge-proxy` | sidecar | proxy-sidecar | Reverse + forward proxy for JWT validation and token exchange (uses `authbridge-light` image) |
+| `proxy-init` | init | envoy-sidecar | iptables rules to redirect traffic through envoy-proxy |
+| `spiffe-helper` | sidecar | envoy-sidecar, proxy-sidecar | Obtains and rotates SPIFFE SVIDs via the SPIRE workload API |
+| `kagenti-client-registration` | sidecar | envoy-sidecar, proxy-sidecar | Registers the workload as an OAuth2 client in Keycloak |
 
-`proxy-init` always follows `envoy-proxy` — if envoy is skipped, proxy-init is also skipped.
+In envoy-sidecar mode, `proxy-init` always follows `envoy-proxy` — if envoy is skipped, proxy-init is also skipped.
 
 ## Injection Trigger
 

--- a/kagenti-operator/internal/webhook/injector/container_builder.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder.go
@@ -445,6 +445,14 @@ func (b *ContainerBuilder) BuildEnvoyProxyContainerWithSpireOption(spireEnabled 
 // Uses authbridge-light image (no Envoy). The app uses HTTP_PROXY env vars to route
 // outbound traffic through the forward proxy. Inbound traffic goes through the reverse proxy.
 func (b *ContainerBuilder) BuildProxySidecarContainer(spireEnabled bool) corev1.Container {
+	return b.BuildProxySidecarContainerWithPorts(spireEnabled, 8080, 8000, 8081)
+}
+
+// BuildProxySidecarContainerWithPorts creates a proxy-sidecar container with dynamic ports.
+// reverseProxyPort: where the reverse proxy listens (takes over the agent's original port)
+// agentBackendPort: where the agent actually listens (moved to a free port)
+// forwardProxyPort: where the forward proxy listens (HTTP_PROXY target)
+func (b *ContainerBuilder) BuildProxySidecarContainerWithPorts(spireEnabled bool, reverseProxyPort, agentBackendPort, forwardProxyPort int32) corev1.Container {
 	volumeMounts := []corev1.VolumeMount{
 		{
 			Name:      "shared-data",
@@ -467,16 +475,24 @@ func (b *ContainerBuilder) BuildProxySidecarContainer(spireEnabled bool) corev1.
 		Name:            AuthBridgeProxyContainerName,
 		Image:           b.cfg.Images.AuthBridgeLight,
 		ImagePullPolicy: b.cfg.Images.PullPolicy,
-		Args:            []string{"--mode", "proxy-sidecar", "--config", "/etc/authbridge/config.yaml"},
+		Args: []string{
+			"--mode", "proxy-sidecar",
+			"--config", "/etc/authbridge/config.yaml",
+		},
+		Env: []corev1.EnvVar{
+			{Name: "REVERSE_PROXY_ADDR", Value: fmt.Sprintf(":%d", reverseProxyPort)},
+			{Name: "REVERSE_PROXY_BACKEND", Value: fmt.Sprintf("http://127.0.0.1:%d", agentBackendPort)},
+			{Name: "FORWARD_PROXY_ADDR", Value: fmt.Sprintf(":%d", forwardProxyPort)},
+		},
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "reverse-proxy",
-				ContainerPort: 8080,
+				ContainerPort: reverseProxyPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
 			{
 				Name:          "forward-proxy",
-				ContainerPort: 8081,
+				ContainerPort: forwardProxyPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},

--- a/kagenti-operator/internal/webhook/injector/container_builder.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder.go
@@ -382,7 +382,7 @@ func (b *ContainerBuilder) BuildEnvoyProxyContainerWithSpireOption(spireEnabled 
 			ReadOnly:  true,
 		},
 		{
-			Name:      "authbridge-unified-config",
+			Name:      "authbridge-runtime-config",
 			MountPath: "/etc/authbridge",
 			ReadOnly:  true,
 		},
@@ -459,7 +459,7 @@ func (b *ContainerBuilder) BuildProxySidecarContainerWithPorts(spireEnabled bool
 			MountPath: "/shared",
 		},
 		{
-			Name:      "authbridge-unified-config",
+			Name:      "authbridge-runtime-config",
 			MountPath: "/etc/authbridge",
 			ReadOnly:  true,
 		},

--- a/kagenti-operator/internal/webhook/injector/container_builder_test.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder_test.go
@@ -80,7 +80,7 @@ func TestBuildEnvoyProxyContainer_HasAllRequiredMounts(t *testing.T) {
 		"envoy-config":              "/etc/envoy",
 		"shared-data":               "/shared",
 		"svid-output":               "/opt",
-		"authbridge-unified-config": "/etc/authbridge",
+		"authbridge-runtime-config": "/etc/authbridge",
 	}
 
 	mountsByName := make(map[string]string)

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -270,17 +270,95 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 	if authBridgeMode == ModeProxySidecar {
 		// Proxy-sidecar mode: inject lightweight authbridge container + HTTP_PROXY env vars.
 		// No iptables, no proxy-init, no Envoy.
+		//
+		// Port-stealing: the reverse proxy takes over the agent's original port so
+		// the Service doesn't need patching. The agent is moved to a free port.
+		//   Service → :8000 → reverse proxy (validates JWT) → :8002 → agent
+		//   Agent outbound → HTTP_PROXY=127.0.0.1:8081 → forward proxy
+
+		// Collect all ports in use across all containers in the pod.
+		usedPorts := map[int32]bool{}
+		for _, c := range podSpec.Containers {
+			for _, p := range c.Ports {
+				usedPorts[p.ContainerPort] = true
+			}
+		}
+
+		// Find the first app container's port and steal it for the reverse proxy.
+		var originalAgentPort int32
+		var agentContainer *corev1.Container
+		for i := range podSpec.Containers {
+			c := &podSpec.Containers[i]
+			if c.Name == AuthBridgeProxyContainerName ||
+				c.Name == SpiffeHelperContainerName ||
+				c.Name == ClientRegistrationContainerName {
+				continue
+			}
+			if len(c.Ports) > 0 {
+				originalAgentPort = c.Ports[0].ContainerPort
+				agentContainer = c
+				break
+			}
+		}
+
+		if originalAgentPort == 0 {
+			originalAgentPort = 8000
+			mutatorLog.Info("no container port found, using default", "port", originalAgentPort)
+		}
+
+		// Find free ports for the agent and forward proxy.
+		// findFreePort returns the first port >= start that isn't in usedPorts,
+		// and marks it as used. Respects the valid port range (1-65535).
+		findFreePort := func(start int32) int32 {
+			p := start
+			for usedPorts[p] && p < 65535 {
+				p++
+			}
+			usedPorts[p] = true
+			return p
+		}
+
+		// Reserve the original agent port for the reverse proxy
+		usedPorts[originalAgentPort] = true
+
+		newAgentPort := findFreePort(originalAgentPort + 1)
+		forwardProxyPort := findFreePort(8081)
+
+		// Move the agent to the free port.
+		// Most agent frameworks (Python/uvicorn, Node/express, FastAPI) read the
+		// PORT env var to determine the bind address. Go agents that hardcode their
+		// listen port won't be affected by this env var — they must use PORT or
+		// be configured via their own config mechanism.
+		if agentContainer != nil {
+			agentContainer.Ports[0].ContainerPort = newAgentPort
+			setOrAddEnv(agentContainer, "PORT", fmt.Sprintf("%d", newAgentPort))
+			mutatorLog.Info("proxy-sidecar port stealing",
+				"container", agentContainer.Name,
+				"originalPort", originalAgentPort,
+				"movedTo", newAgentPort,
+				"forwardProxyPort", forwardProxyPort)
+		}
+
+		// Inject authbridge-proxy container listening on the original agent port
 		if !containerExists(podSpec.Containers, AuthBridgeProxyContainerName) {
-			podSpec.Containers = append(podSpec.Containers, builder.BuildProxySidecarContainer(spireEnabled))
+			podSpec.Containers = append(podSpec.Containers,
+				builder.BuildProxySidecarContainerWithPorts(
+					spireEnabled,
+					originalAgentPort, // reverse proxy listens here
+					newAgentPort,      // forwards to agent here
+					forwardProxyPort,  // forward proxy listens here
+				))
 		}
 
 		// Inject HTTP_PROXY env vars into all existing app containers
 		for i := range podSpec.Containers {
 			c := &podSpec.Containers[i]
-			if c.Name == AuthBridgeProxyContainerName {
+			if c.Name == AuthBridgeProxyContainerName ||
+				c.Name == SpiffeHelperContainerName ||
+				c.Name == ClientRegistrationContainerName {
 				continue
 			}
-			injectHTTPProxyEnv(c, 8081)
+			injectHTTPProxyEnv(c, forwardProxyPort)
 		}
 
 		// spiffe-helper and client-registration are still injected
@@ -300,7 +378,10 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 
 		mutatorLog.Info("proxy-sidecar mode injection complete",
 			"namespace", namespace, "crName", crName,
-			"image", builder.cfg.Images.AuthBridgeLight)
+			"image", builder.cfg.Images.AuthBridgeLight,
+			"reverseProxyPort", originalAgentPort,
+			"agentPort", newAgentPort,
+			"forwardProxyPort", forwardProxyPort)
 
 		if spireEnabled {
 			ensureFSGroup(podSpec)
@@ -498,6 +579,18 @@ func injectHTTPProxyEnv(c *corev1.Container, forwardProxyPort int32) {
 			c.Env = append(c.Env, env)
 		}
 	}
+}
+
+// setOrAddEnv sets an env var value, or adds it if it doesn't exist.
+func setOrAddEnv(c *corev1.Container, name, value string) {
+	for i := range c.Env {
+		if c.Env[i].Name == name {
+			c.Env[i].Value = value
+			c.Env[i].ValueFrom = nil // clear any ValueFrom
+			return
+		}
+	}
+	c.Env = append(c.Env, corev1.EnvVar{Name: name, Value: value})
 }
 
 // envExists checks if an env var with the given name already exists.

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -380,7 +380,7 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 			podSpec.Containers = append(podSpec.Containers, builder.BuildClientRegistrationContainerWithSpireOption(crName, namespace, spireEnabled))
 		}
 
-		// Inject volumes (shared-data, authbridge-unified-config, spire volumes if enabled)
+		// Inject volumes (shared-data, authbridge-runtime-config, spire volumes if enabled)
 		for i := range requiredVolumes {
 			if !volumeExists(podSpec.Volumes, requiredVolumes[i].Name) {
 				podSpec.Volumes = append(podSpec.Volumes, requiredVolumes[i])

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -305,24 +305,35 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 			originalAgentPort = 8000
 			mutatorLog.Info("no container port found, using default", "port", originalAgentPort)
 		}
+		if agentContainer == nil {
+			mutatorLog.Info("no agent container found to relocate — reverse proxy backend may be unreachable")
+		}
 
-		// Find free ports for the agent and forward proxy.
 		// findFreePort returns the first port >= start that isn't in usedPorts,
-		// and marks it as used. Respects the valid port range (1-65535).
-		findFreePort := func(start int32) int32 {
+		// and marks it as used.
+		findFreePort := func(start int32) (int32, error) {
 			p := start
-			for usedPorts[p] && p < 65535 {
+			for usedPorts[p] && p <= 65535 {
 				p++
 			}
+			if p > 65535 {
+				return 0, fmt.Errorf("no free port available starting from %d", start)
+			}
 			usedPorts[p] = true
-			return p
+			return p, nil
 		}
 
 		// Reserve the original agent port for the reverse proxy
 		usedPorts[originalAgentPort] = true
 
-		newAgentPort := findFreePort(originalAgentPort + 1)
-		forwardProxyPort := findFreePort(8081)
+		newAgentPort, err := findFreePort(originalAgentPort + 1)
+		if err != nil {
+			return false, fmt.Errorf("proxy-sidecar port assignment: %w", err)
+		}
+		forwardProxyPort, err := findFreePort(8081)
+		if err != nil {
+			return false, fmt.Errorf("proxy-sidecar port assignment: %w", err)
+		}
 
 		// Move the agent to the free port.
 		// Most agent frameworks (Python/uvicorn, Node/express, FastAPI) read the

--- a/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
@@ -782,3 +782,185 @@ func TestInjectHTTPProxyEnv_DoesNotDuplicate(t *testing.T) {
 		t.Error("NO_PROXY should be added")
 	}
 }
+
+func TestInjectAuthBridge_ProxySidecarMode_PortCollision(t *testing.T) {
+	m := newTestMutator()
+	ctx := context.Background()
+
+	// Agent uses ports 8000 and 8001 — agent should move to 8002, not 8001
+	podSpec := &corev1.PodSpec{
+		ServiceAccountName: "my-agent",
+		Containers: []corev1.Container{
+			{
+				Name:  "agent",
+				Image: "my-agent:latest",
+				Ports: []corev1.ContainerPort{
+					{Name: "http", ContainerPort: 8000},
+					{Name: "grpc", ContainerPort: 8001},
+				},
+			},
+		},
+	}
+	labels := map[string]string{
+		KagentiTypeLabel: KagentiTypeAgent,
+	}
+	annotations := map[string]string{
+		AnnotationAuthBridgeMode: ModeProxySidecar,
+	}
+
+	mutated, err := m.InjectAuthBridge(ctx, podSpec, "team1", "my-agent", labels, annotations)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !mutated {
+		t.Fatal("expected mutation")
+	}
+
+	// Agent's first port should be moved past 8001 to 8002
+	for _, c := range podSpec.Containers {
+		if c.Name == "agent" {
+			if c.Ports[0].ContainerPort == 8001 {
+				t.Error("agent port should not be 8001 (collision with gRPC port)")
+			}
+			if c.Ports[0].ContainerPort != 8002 {
+				t.Errorf("agent port = %d, want 8002 (first free port after 8000)", c.Ports[0].ContainerPort)
+			}
+			// Second port (gRPC) should be unchanged
+			if c.Ports[1].ContainerPort != 8001 {
+				t.Errorf("gRPC port should remain 8001, got %d", c.Ports[1].ContainerPort)
+			}
+		}
+	}
+
+	// Reverse proxy should be on 8000 (original agent port)
+	for _, c := range podSpec.Containers {
+		if c.Name == AuthBridgeProxyContainerName {
+			for _, p := range c.Ports {
+				if p.Name == "reverse-proxy" && p.ContainerPort != 8000 {
+					t.Errorf("reverse-proxy port = %d, want 8000", p.ContainerPort)
+				}
+			}
+		}
+	}
+}
+
+func TestInjectAuthBridge_ProxySidecarMode_ForwardProxyCollision(t *testing.T) {
+	m := newTestMutator()
+	ctx := context.Background()
+
+	// Agent uses port 8081 — forward proxy should use 8082 instead of default 8081
+	podSpec := &corev1.PodSpec{
+		ServiceAccountName: "my-agent",
+		Containers: []corev1.Container{
+			{
+				Name:  "agent",
+				Image: "my-agent:latest",
+				Ports: []corev1.ContainerPort{
+					{Name: "http", ContainerPort: 8000},
+					{Name: "metrics", ContainerPort: 8081},
+				},
+			},
+		},
+	}
+	labels := map[string]string{
+		KagentiTypeLabel: KagentiTypeAgent,
+	}
+	annotations := map[string]string{
+		AnnotationAuthBridgeMode: ModeProxySidecar,
+	}
+
+	mutated, err := m.InjectAuthBridge(ctx, podSpec, "team1", "my-agent", labels, annotations)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !mutated {
+		t.Fatal("expected mutation")
+	}
+
+	// Forward proxy should NOT be on 8081 (collision with metrics)
+	for _, c := range podSpec.Containers {
+		if c.Name == AuthBridgeProxyContainerName {
+			for _, p := range c.Ports {
+				if p.Name == "forward-proxy" {
+					if p.ContainerPort == 8081 {
+						t.Error("forward-proxy should not be 8081 (collision with agent metrics)")
+					}
+					if p.ContainerPort != 8082 {
+						t.Errorf("forward-proxy port = %d, want 8082", p.ContainerPort)
+					}
+				}
+			}
+		}
+	}
+
+	// HTTP_PROXY should use the actual forward proxy port, not hardcoded 8081
+	for _, c := range podSpec.Containers {
+		if c.Name == "agent" {
+			for _, env := range c.Env {
+				if env.Name == "HTTP_PROXY" {
+					if env.Value == "http://127.0.0.1:8081" {
+						t.Error("HTTP_PROXY should not use 8081 (collides with agent metrics)")
+					}
+					if env.Value != "http://127.0.0.1:8082" {
+						t.Errorf("HTTP_PROXY = %q, want http://127.0.0.1:8082", env.Value)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestSetOrAddEnv_OverwritesExisting(t *testing.T) {
+	c := &corev1.Container{
+		Name: "agent",
+		Env: []corev1.EnvVar{
+			{Name: "PORT", Value: "8000"},
+			{Name: "HOST", Value: "0.0.0.0"},
+		},
+	}
+
+	setOrAddEnv(c, "PORT", "8002")
+
+	count := 0
+	for _, env := range c.Env {
+		if env.Name == "PORT" {
+			count++
+			if env.Value != "8002" {
+				t.Errorf("PORT = %q, want 8002", env.Value)
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 PORT env var, got %d", count)
+	}
+	// HOST should be unchanged
+	for _, env := range c.Env {
+		if env.Name == "HOST" && env.Value != "0.0.0.0" {
+			t.Errorf("HOST should be unchanged, got %q", env.Value)
+		}
+	}
+}
+
+func TestSetOrAddEnv_AddsNew(t *testing.T) {
+	c := &corev1.Container{
+		Name: "agent",
+		Env: []corev1.EnvVar{
+			{Name: "HOST", Value: "0.0.0.0"},
+		},
+	}
+
+	setOrAddEnv(c, "PORT", "8002")
+
+	found := false
+	for _, env := range c.Env {
+		if env.Name == "PORT" && env.Value == "8002" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("PORT env var should be added")
+	}
+	if len(c.Env) != 2 {
+		t.Errorf("expected 2 env vars, got %d", len(c.Env))
+	}
+}

--- a/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
@@ -964,3 +964,67 @@ func TestSetOrAddEnv_AddsNew(t *testing.T) {
 		t.Errorf("expected 2 env vars, got %d", len(c.Env))
 	}
 }
+
+func TestInjectAuthBridge_ProxySidecarMode_NoPorts_UsesDefault(t *testing.T) {
+	m := newTestMutator()
+	ctx := context.Background()
+
+	// Agent container with no ports — should use default 8000
+	podSpec := &corev1.PodSpec{
+		ServiceAccountName: "my-agent",
+		Containers: []corev1.Container{
+			{Name: "agent", Image: "my-agent:latest"},
+		},
+	}
+	labels := map[string]string{
+		KagentiTypeLabel: KagentiTypeAgent,
+	}
+	annotations := map[string]string{
+		AnnotationAuthBridgeMode: ModeProxySidecar,
+	}
+
+	mutated, err := m.InjectAuthBridge(ctx, podSpec, "team1", "my-agent", labels, annotations)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !mutated {
+		t.Fatal("expected mutation")
+	}
+
+	// Reverse proxy should use default port 8000
+	for _, c := range podSpec.Containers {
+		if c.Name == AuthBridgeProxyContainerName {
+			for _, p := range c.Ports {
+				if p.Name == "reverse-proxy" && p.ContainerPort != 8000 {
+					t.Errorf("reverse-proxy port = %d, want 8000 (default)", p.ContainerPort)
+				}
+			}
+		}
+	}
+
+	// Agent should NOT have PORT env var patched (no ports to move)
+	for _, c := range podSpec.Containers {
+		if c.Name == "agent" {
+			for _, env := range c.Env {
+				if env.Name == "PORT" {
+					t.Error("PORT env var should not be set when agent has no ports")
+				}
+			}
+		}
+	}
+
+	// HTTP_PROXY should still be injected
+	httpProxyFound := false
+	for _, c := range podSpec.Containers {
+		if c.Name == "agent" {
+			for _, env := range c.Env {
+				if env.Name == "HTTP_PROXY" {
+					httpProxyFound = true
+				}
+			}
+		}
+	}
+	if !httpProxyFound {
+		t.Error("HTTP_PROXY should be injected even when agent has no ports")
+	}
+}

--- a/kagenti-operator/internal/webhook/injector/volume_builder.go
+++ b/kagenti-operator/internal/webhook/injector/volume_builder.go
@@ -81,11 +81,11 @@ func BuildRequiredVolumes() []corev1.Volume {
 			},
 		},
 		{
-			Name: "authbridge-unified-config",
+			Name: "authbridge-runtime-config",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "authbridge-unified-config",
+						Name: "authbridge-runtime-config",
 					},
 					Optional: ptr.To(true),
 				},
@@ -126,11 +126,11 @@ func BuildRequiredVolumesNoSpire() []corev1.Volume {
 			},
 		},
 		{
-			Name: "authbridge-unified-config",
+			Name: "authbridge-runtime-config",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "authbridge-unified-config",
+						Name: "authbridge-runtime-config",
 					},
 					Optional: ptr.To(true),
 				},
@@ -211,11 +211,11 @@ func BuildResolvedVolumes(spireEnabled bool, envoyConfigMapName string) []corev1
 			},
 		},
 		corev1.Volume{
-			Name: "authbridge-unified-config",
+			Name: "authbridge-runtime-config",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "authbridge-unified-config",
+						Name: "authbridge-runtime-config",
 					},
 					Optional: ptr.To(true),
 				},

--- a/kagenti-operator/internal/webhook/injector/volume_builder_test.go
+++ b/kagenti-operator/internal/webhook/injector/volume_builder_test.go
@@ -23,7 +23,7 @@ import (
 func TestBuildResolvedVolumes_SpireDisabled(t *testing.T) {
 	volumes := BuildResolvedVolumes(false, "")
 
-	// Should have: shared-data, envoy-config, authproxy-routes, authbridge-unified-config
+	// Should have: shared-data, envoy-config, authproxy-routes, authbridge-runtime-config
 	if len(volumes) != 4 {
 		t.Fatalf("expected 4 volumes, got %d", len(volumes))
 	}
@@ -33,7 +33,7 @@ func TestBuildResolvedVolumes_SpireDisabled(t *testing.T) {
 		names[v.Name] = true
 	}
 
-	for _, expected := range []string{"shared-data", "envoy-config", "authproxy-routes", "authbridge-unified-config"} {
+	for _, expected := range []string{"shared-data", "envoy-config", "authproxy-routes", "authbridge-runtime-config"} {
 		if !names[expected] {
 			t.Errorf("missing volume %q", expected)
 		}
@@ -50,7 +50,7 @@ func TestBuildResolvedVolumes_SpireDisabled(t *testing.T) {
 func TestBuildResolvedVolumes_SpireEnabled(t *testing.T) {
 	volumes := BuildResolvedVolumes(true, "")
 
-	// Should have: shared-data, spire-agent-socket, spiffe-helper-config, svid-output, envoy-config, authproxy-routes, authbridge-unified-config
+	// Should have: shared-data, spire-agent-socket, spiffe-helper-config, svid-output, envoy-config, authproxy-routes, authbridge-runtime-config
 	if len(volumes) != 7 {
 		t.Fatalf("expected 7 volumes, got %d", len(volumes))
 	}
@@ -60,7 +60,7 @@ func TestBuildResolvedVolumes_SpireEnabled(t *testing.T) {
 		names[v.Name] = true
 	}
 
-	for _, expected := range []string{"shared-data", "spire-agent-socket", "spiffe-helper-config", "svid-output", "envoy-config", "authproxy-routes", "authbridge-unified-config"} {
+	for _, expected := range []string{"shared-data", "spire-agent-socket", "spiffe-helper-config", "svid-output", "envoy-config", "authproxy-routes", "authbridge-runtime-config"} {
 		if !names[expected] {
 			t.Errorf("missing volume %q", expected)
 		}

--- a/kagenti-operator/test/e2e/README.md
+++ b/kagenti-operator/test/e2e/README.md
@@ -14,7 +14,7 @@ End-to-end tests for the kagenti-operator. The suite runs 20 specs:
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) — `brew install kubectl`
 - Container runtime: **Docker** or **Podman**
 
-The test suite auto-detects Docker vs Podman. No env vars needed. AuthBridge sidecar images (`authbridge-unified`, `proxy-init`, `spiffe-helper`) are pulled from `ghcr.io/kagenti/kagenti-extensions` and loaded into Kind during setup.
+The test suite auto-detects Docker vs Podman. No env vars needed. AuthBridge sidecar images (`authbridge-envoy`, `proxy-init`, `spiffe-helper`) are pulled from `ghcr.io/kagenti/kagenti-extensions` and loaded into Kind during setup.
 
 ## Run
 
@@ -99,7 +99,7 @@ BeforeSuite (once per suite)
 ├── Install Prometheus Operator v0.77.1 (metrics/ServiceMonitor CRDs)
 ├── Install CertManager v1.16.3 (webhook TLS certificates)
 ├── Build & load agentcard-signer image into Kind
-├── Pull & load AuthBridge sidecar images (authbridge-unified, proxy-init, spiffe-helper)
+├── Pull & load AuthBridge sidecar images (authbridge-envoy, proxy-init, spiffe-helper)
 └── Install SPIRE via Helm (spire-crds v0.5.0 + spire v0.28.3)
 
 BeforeAll (per Describe block)

--- a/kagenti-operator/test/e2e/e2e_suite_test.go
+++ b/kagenti-operator/test/e2e/e2e_suite_test.go
@@ -55,7 +55,8 @@ var (
 
 	// sidecarImages are the AuthBridge sidecar images to pull and load into Kind
 	sidecarImages = []string{
-		"ghcr.io/kagenti/kagenti-extensions/authbridge-unified:latest",
+		"ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:latest",
+		"ghcr.io/kagenti/kagenti-extensions/authbridge-light:latest",
 		"ghcr.io/kagenti/kagenti-extensions/proxy-init:latest",
 		"ghcr.io/kagenti/kagenti-extensions/spiffe-helper:latest",
 	}

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -447,7 +447,7 @@ var _ = Describe("AuthBridge Injection E2E", Ordered, func() {
 				expectedVolumes := []string{
 					"shared-data", "spire-agent-socket", "spiffe-helper-config",
 					"svid-output", "envoy-config", "authproxy-routes",
-					"authbridge-unified-config",
+					"authbridge-runtime-config",
 				}
 				for _, vol := range expectedVolumes {
 					g.Expect(volumes).To(ContainSubstring(vol), "expected volume %s", vol)

--- a/kagenti-operator/test/e2e/fixtures.go
+++ b/kagenti-operator/test/e2e/fixtures.go
@@ -808,7 +808,7 @@ spec:
 // --- AuthBridge Injection E2E fixtures ---
 
 // authBridgeConfigMapFixture returns YAML for the 3 ConfigMaps required by
-// the auth bridge webhook: authbridge-runtime-config, spiffe-helper-config, envoy-config.
+// the auth bridge webhook: authbridge-config, authbridge-runtime-config, spiffe-helper-config, envoy-config.
 // Only the mandatory keys are set (ISSUER, KEYCLOAK_URL, KEYCLOAK_REALM, TOKEN_URL,
 // DEFAULT_OUTBOUND_POLICY). The operator reads additional optional keys
 // (EXPECTED_AUDIENCE, TARGET_AUDIENCE, SPIRE_ENABLED, etc.) which default to empty.
@@ -816,7 +816,7 @@ func authBridgeConfigMapFixture() string {
 	return `apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: authbridge-runtime-config
+  name: authbridge-config
   namespace: ` + authBridgeTestNamespace + `
 data:
   ISSUER: "https://keycloak.example.com/realms/test"

--- a/kagenti-operator/test/e2e/fixtures.go
+++ b/kagenti-operator/test/e2e/fixtures.go
@@ -807,7 +807,7 @@ spec:
 
 // --- AuthBridge Injection E2E fixtures ---
 
-// authBridgeConfigMapFixture returns YAML for the 3 ConfigMaps required by
+// authBridgeConfigMapFixture returns YAML for the 4 ConfigMaps required by
 // the auth bridge webhook: authbridge-config, authbridge-runtime-config, spiffe-helper-config, envoy-config.
 // Only the mandatory keys are set (ISSUER, KEYCLOAK_URL, KEYCLOAK_REALM, TOKEN_URL,
 // DEFAULT_OUTBOUND_POLICY). The operator reads additional optional keys

--- a/kagenti-operator/test/e2e/fixtures.go
+++ b/kagenti-operator/test/e2e/fixtures.go
@@ -808,7 +808,7 @@ spec:
 // --- AuthBridge Injection E2E fixtures ---
 
 // authBridgeConfigMapFixture returns YAML for the 3 ConfigMaps required by
-// the auth bridge webhook: authbridge-config, spiffe-helper-config, envoy-config.
+// the auth bridge webhook: authbridge-runtime-config, spiffe-helper-config, envoy-config.
 // Only the mandatory keys are set (ISSUER, KEYCLOAK_URL, KEYCLOAK_REALM, TOKEN_URL,
 // DEFAULT_OUTBOUND_POLICY). The operator reads additional optional keys
 // (EXPECTED_AUDIENCE, TARGET_AUDIENCE, SPIRE_ENABLED, etc.) which default to empty.
@@ -816,7 +816,7 @@ func authBridgeConfigMapFixture() string {
 	return `apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: authbridge-config
+  name: authbridge-runtime-config
   namespace: ` + authBridgeTestNamespace + `
 data:
   ISSUER: "https://keycloak.example.com/realms/test"
@@ -901,7 +901,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: authbridge-unified-config
+  name: authbridge-runtime-config
   namespace: ` + authBridgeTestNamespace + `
 data:
   config.yaml: |


### PR DESCRIPTION
## Summary

In proxy-sidecar mode, inbound traffic must go through the authbridge reverse proxy for JWT validation. Without iptables interception, the Service targetPort determines whether traffic hits the reverse proxy or goes directly to the agent.

The webhook now uses **port-stealing**: the reverse proxy takes over the agent's original port (e.g., `:8000`), and the agent is moved to a free port. This way the Service targetPort stays correct without any Service patching.

## Problem

When deploying an agent with `kagenti.io/authbridge-mode: proxy-sidecar`, the hardcoded port assignments (8080 reverse proxy, 8081 forward proxy) could collide with ports already in use by the agent, causing bind failures at runtime.

## Fix

The webhook now performs collision-free port assignment:

1. Collects all ports in use across all pod containers
2. Steals the agent's first port for the reverse proxy (so the Service doesn't need patching)
3. Finds the first free port for the agent (starting from original+1)
4. Finds the first free port for the forward proxy (starting from 8081)
5. Injects REVERSE_PROXY_ADDR, REVERSE_PROXY_BACKEND, FORWARD_PROXY_ADDR env vars into the authbridge-proxy container
6. Injects HTTP_PROXY/HTTPS_PROXY with the actual forward proxy port into app containers
7. Patches the agent's PORT env var to bind to the new port

If no free port is available (port exhaustion), the webhook rejects the pod with a clear admission error.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/webhook/injector/...` passes
- [ ] E2E: deploy agent with proxy-sidecar mode, verify inbound auth logs show `inbound authorized`

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
