### PR TITLE
feat: Generate per-agent ConfigMap for authbridge at injection time

### DIFF
--- a/charts/kagenti-operator/templates/rbac/role.yaml
+++ b/charts/kagenti-operator/templates/rbac/role.yaml
@@ -13,6 +13,7 @@ rules:
   - create
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/charts/kagenti-operator/templates/rbac/role.yaml
+++ b/charts/kagenti-operator/templates/rbac/role.yaml
@@ -102,6 +102,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - statefulsets/finalizers
+  verbs:
+  - update
+- apiGroups:
   - mlflow.opendatahub.io
   resources:
   - mlflows

--- a/charts/kagenti-operator/templates/rbac/role.yaml
+++ b/charts/kagenti-operator/templates/rbac/role.yaml
@@ -9,13 +9,20 @@ rules:
   - ""
   resources:
   - configmaps
-  - namespaces
-  - services
   verbs:
   - create
   - get
   - list
   - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - ""

--- a/charts/kagenti-operator/templates/rbac/role.yaml
+++ b/charts/kagenti-operator/templates/rbac/role.yaml
@@ -12,8 +12,10 @@ rules:
   - namespaces
   - services
   verbs:
+  - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - ""

--- a/kagenti-operator/cmd/main.go
+++ b/kagenti-operator/cmd/main.go
@@ -415,6 +415,7 @@ func main() {
 	if authBridgeWebhooksEnabled() {
 		podMutator := injector.NewPodMutator(
 			mgr.GetClient(),
+			mgr.GetScheme(),
 			enableClientRegistration,
 			configLoader.Get,
 			featureGateLoader.Get,

--- a/kagenti-operator/cmd/main.go
+++ b/kagenti-operator/cmd/main.go
@@ -416,7 +416,6 @@ func main() {
 		podMutator := injector.NewPodMutator(
 			mgr.GetClient(),
 			mgr.GetAPIReader(),
-			mgr.GetScheme(),
 			enableClientRegistration,
 			configLoader.Get,
 			featureGateLoader.Get,

--- a/kagenti-operator/cmd/main.go
+++ b/kagenti-operator/cmd/main.go
@@ -415,6 +415,7 @@ func main() {
 	if authBridgeWebhooksEnabled() {
 		podMutator := injector.NewPodMutator(
 			mgr.GetClient(),
+			mgr.GetAPIReader(),
 			mgr.GetScheme(),
 			enableClientRegistration,
 			configLoader.Get,

--- a/kagenti-operator/config/rbac/role.yaml
+++ b/kagenti-operator/config/rbac/role.yaml
@@ -8,13 +8,20 @@ rules:
   - ""
   resources:
   - configmaps
-  - namespaces
-  - services
   verbs:
   - create
   - get
   - list
   - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - ""

--- a/kagenti-operator/config/rbac/role.yaml
+++ b/kagenti-operator/config/rbac/role.yaml
@@ -17,19 +17,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   - services
   verbs:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
 - apiGroups:
   - ""
   resources:
@@ -100,6 +100,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - statefulsets/finalizers
+  verbs:
+  - update
+- apiGroups:
   - mlflow.opendatahub.io
   resources:
   - mlflows
@@ -107,13 +114,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments/finalizers
-  - statefulsets/finalizers
-  verbs:
-  - update
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/kagenti-operator/config/rbac/role.yaml
+++ b/kagenti-operator/config/rbac/role.yaml
@@ -11,8 +11,10 @@ rules:
   - namespaces
   - services
   verbs:
+  - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - ""

--- a/kagenti-operator/config/rbac/role.yaml
+++ b/kagenti-operator/config/rbac/role.yaml
@@ -8,10 +8,12 @@ rules:
   - ""
   resources:
   - configmaps
+  - secrets
   verbs:
   - create
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:
@@ -35,17 +37,6 @@ rules:
   resources:
   - pods
   verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
   - get
   - list
   - patch

--- a/kagenti-operator/internal/webhook/injector/constants.go
+++ b/kagenti-operator/internal/webhook/injector/constants.go
@@ -25,6 +25,6 @@ const (
 	AuthBridgeProxyContainerName = "authbridge-proxy"
 
 	// Identity type constants
-	IdentityTypeSpiffe       = "spiffe"
+	IdentityTypeSpiffe         = "spiffe"
 	ClientAuthTypeFederatedJWT = "federated-jwt"
 )

--- a/kagenti-operator/internal/webhook/injector/constants.go
+++ b/kagenti-operator/internal/webhook/injector/constants.go
@@ -23,4 +23,8 @@ const (
 
 	// Container name for proxy-sidecar mode
 	AuthBridgeProxyContainerName = "authbridge-proxy"
+
+	// Identity type constants
+	IdentityTypeSpiffe       = "spiffe"
+	ClientAuthTypeFederatedJWT = "federated-jwt"
 )

--- a/kagenti-operator/internal/webhook/injector/container_builder.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder.go
@@ -476,13 +476,7 @@ func (b *ContainerBuilder) BuildProxySidecarContainerWithPorts(spireEnabled bool
 		Image:           b.cfg.Images.AuthBridgeLight,
 		ImagePullPolicy: b.cfg.Images.PullPolicy,
 		Args: []string{
-			"--mode", "proxy-sidecar",
 			"--config", "/etc/authbridge/config.yaml",
-		},
-		Env: []corev1.EnvVar{
-			{Name: "REVERSE_PROXY_ADDR", Value: fmt.Sprintf(":%d", reverseProxyPort)},
-			{Name: "REVERSE_PROXY_BACKEND", Value: fmt.Sprintf("http://127.0.0.1:%d", agentBackendPort)},
-			{Name: "FORWARD_PROXY_ADDR", Value: fmt.Sprintf(":%d", forwardProxyPort)},
 		},
 		Ports: []corev1.ContainerPort{
 			{

--- a/kagenti-operator/internal/webhook/injector/container_builder_test.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder_test.go
@@ -714,9 +714,9 @@ func TestBuildProxySidecarContainer_SpireDisabled(t *testing.T) {
 		t.Errorf("image = %q, want %q", container.Image, config.CompiledDefaults().Images.AuthBridgeLight)
 	}
 
-	// Should have --mode proxy-sidecar --config args
-	if len(container.Args) < 4 || container.Args[0] != "--mode" || container.Args[1] != "proxy-sidecar" {
-		t.Errorf("args = %v, want [--mode proxy-sidecar --config ...]", container.Args)
+	// Should have --config args (mode comes from per-agent ConfigMap, not CLI)
+	if len(container.Args) < 2 || container.Args[0] != "--config" {
+		t.Errorf("args = %v, want [--config /etc/authbridge/config.yaml]", container.Args)
 	}
 
 	// Should have reverse-proxy and forward-proxy ports

--- a/kagenti-operator/internal/webhook/injector/namespace_config.go
+++ b/kagenti-operator/internal/webhook/injector/namespace_config.go
@@ -28,11 +28,12 @@ var nsConfigLog = logf.Log.WithName("namespace-config")
 
 // Well-known ConfigMap/Secret names in the target namespace.
 const (
-	AuthBridgeConfigMapName      = "authbridge-config"
-	KeycloakAdminSecretName      = "keycloak-admin-secret"
-	SpiffeHelperConfigMapName    = "spiffe-helper-config"
-	EnvoyConfigMapName           = "envoy-config"
-	AuthproxyRoutesConfigMapName = "authproxy-routes"
+	AuthBridgeConfigMapName        = "authbridge-config"
+	AuthBridgeRuntimeConfigMapName = "authbridge-runtime-config"
+	KeycloakAdminSecretName        = "keycloak-admin-secret"
+	SpiffeHelperConfigMapName      = "spiffe-helper-config"
+	EnvoyConfigMapName             = "envoy-config"
+	AuthproxyRoutesConfigMapName   = "authproxy-routes"
 )
 
 // NamespaceConfig holds resolved values from namespace ConfigMaps/Secrets.
@@ -60,6 +61,9 @@ type NamespaceConfig struct {
 
 	// From "authproxy-routes" ConfigMap
 	AuthproxyRoutesYAML string // raw routes.yaml content
+
+	// From "authbridge-runtime-config" ConfigMap
+	AuthBridgeRuntimeYAML string // raw config.yaml for unified authbridge binary
 }
 
 // ReadNamespaceConfig reads the well-known ConfigMaps/Secrets from the target
@@ -110,6 +114,13 @@ func ReadNamespaceConfig(ctx context.Context, c client.Reader, namespace string)
 		nsConfigLog.V(1).Info("ConfigMap not found", "name", AuthproxyRoutesConfigMapName, "namespace", namespace, "error", err)
 	} else {
 		cfg.AuthproxyRoutesYAML = cm.Data["routes.yaml"]
+	}
+
+	// Read "authbridge-runtime-config" ConfigMap (YAML config for unified authbridge binary)
+	if cm, err := getConfigMap(ctx, c, namespace, AuthBridgeRuntimeConfigMapName); err != nil {
+		nsConfigLog.V(1).Info("ConfigMap not found", "name", AuthBridgeRuntimeConfigMapName, "namespace", namespace, "error", err)
+	} else {
+		cfg.AuthBridgeRuntimeYAML = cm.Data["config.yaml"]
 	}
 
 	return cfg, nil

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -667,9 +667,15 @@ func (m *PodMutator) ensurePerAgentConfigMap(
 		}
 		// Does not exist — create
 		if createErr := m.Client.Create(ctx, cm); createErr != nil {
-			return "", fmt.Errorf("failed to create ConfigMap %s/%s: %w", namespace, cmName, createErr)
+			if apierrors.IsAlreadyExists(createErr) {
+				// Race: another pod's admission created it between our Get and Create.
+				mutatorLog.Info("Per-agent ConfigMap created by concurrent admission", "namespace", namespace, "name", cmName)
+			} else {
+				return "", fmt.Errorf("failed to create ConfigMap %s/%s: %w", namespace, cmName, createErr)
+			}
+		} else {
+			mutatorLog.Info("Created per-agent ConfigMap", "namespace", namespace, "name", cmName, "mode", mode)
 		}
-		mutatorLog.Info("Created per-agent ConfigMap", "namespace", namespace, "name", cmName, "mode", mode)
 	} else {
 		// Exists — update if managed by us
 		if existing.Labels[managedByLabel] != managedByValue {

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -102,6 +102,8 @@ func NewPodMutator(
 	}
 }
 
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=create;get;list;update;watch
+
 // InjectAuthBridge evaluates the multi-layer precedence chain and conditionally injects sidecars.
 //
 //nolint:gocyclo // sequential injection steps form a single logical pipeline

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -407,7 +407,9 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 			podSpec.Containers = append(podSpec.Containers, builder.BuildClientRegistrationContainerWithSpireOption(crName, namespace, spireEnabled))
 		}
 
-		// Inject volumes — use per-agent ConfigMap name for authbridge config
+		// Inject volumes — use per-agent ConfigMap name for authbridge config.
+		// requiredVolumes is always set above (resolved or legacy path) before
+		// the mode switch, so it is never nil here.
 		proxyVolumes := overrideAuthBridgeConfigMapInVolumes(requiredVolumes, perAgentCMName)
 		for i := range proxyVolumes {
 			if !volumeExists(podSpec.Volumes, proxyVolumes[i].Name) {
@@ -692,7 +694,9 @@ func (m *PodMutator) buildOwnerReference(ctx context.Context, namespace, crName 
 			WithAPIVersion("apps/v1").
 			WithKind("Deployment").
 			WithName(deploy.Name).
-			WithUID(deploy.UID)
+			WithUID(deploy.UID).
+			WithController(true).
+			WithBlockOwnerDeletion(true)
 	}
 
 	// Try StatefulSet
@@ -702,7 +706,9 @@ func (m *PodMutator) buildOwnerReference(ctx context.Context, namespace, crName 
 			WithAPIVersion("apps/v1").
 			WithKind("StatefulSet").
 			WithName(sts.Name).
-			WithUID(sts.UID)
+			WithUID(sts.UID).
+			WithController(true).
+			WithBlockOwnerDeletion(true)
 	}
 
 	mutatorLog.V(1).Info("Could not find owner workload for per-agent ConfigMap, skipping OwnerReference",

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -27,8 +27,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	applyconfigscorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	applyconfigsmetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 )
@@ -644,28 +645,17 @@ func (m *PodMutator) ensurePerAgentConfigMap(
 
 	// Server-side apply: atomic create-or-update in a single API call.
 	// No race condition — concurrent pod admissions safely converge.
-	cm := &corev1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "ConfigMap",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cmName,
-			Namespace: namespace,
-			Labels: map[string]string{
-				managedByLabel: managedByValue,
-			},
-		},
-		Data: map[string]string{
-			"config.yaml": string(data),
-		},
-	}
+	cmApply := applyconfigscorev1.ConfigMap(cmName, namespace).
+		WithLabels(map[string]string{managedByLabel: managedByValue}).
+		WithData(map[string]string{"config.yaml": string(data)})
 
 	// Set OwnerReference to the owning Deployment or StatefulSet so the
 	// ConfigMap is garbage-collected when the workload is deleted.
-	m.setOwnerReferenceFromWorkload(ctx, namespace, crName, cm)
+	if ownerRef := m.buildOwnerReference(ctx, namespace, crName); ownerRef != nil {
+		cmApply = cmApply.WithOwnerReferences(ownerRef)
+	}
 
-	if err := m.Client.Patch(ctx, cm, client.Apply, client.FieldOwner("kagenti-webhook"), client.ForceOwnership); err != nil {
+	if err := m.Client.Apply(ctx, cmApply, client.FieldOwner("kagenti-webhook"), client.ForceOwnership); err != nil {
 		return "", fmt.Errorf("failed to apply per-agent ConfigMap %s/%s: %w", namespace, cmName, err)
 	}
 	mutatorLog.Info("Applied per-agent ConfigMap", "namespace", namespace, "name", cmName, "mode", mode)
@@ -673,36 +663,33 @@ func (m *PodMutator) ensurePerAgentConfigMap(
 	return cmName, nil
 }
 
-// setOwnerReferenceFromWorkload looks up the Deployment or StatefulSet that
-// owns the pod being created and sets it as an OwnerReference on the ConfigMap.
-// This enables garbage collection when the workload is deleted.
-// Best-effort: if the owner cannot be found, the ConfigMap is created without
-// an OwnerReference (the managedByLabel still identifies it for manual cleanup).
-func (m *PodMutator) setOwnerReferenceFromWorkload(ctx context.Context, namespace, crName string, cm *corev1.ConfigMap) {
-	if m.Scheme == nil {
-		return
-	}
-
+// buildOwnerReference looks up the Deployment or StatefulSet that owns the
+// pod being created and returns an OwnerReference apply configuration.
+// Returns nil if the workload cannot be found (best-effort).
+func (m *PodMutator) buildOwnerReference(ctx context.Context, namespace, crName string) *applyconfigsmetav1.OwnerReferenceApplyConfiguration {
 	// Try Deployment first (most common)
 	deploy := &appsv1.Deployment{}
 	if err := m.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: crName}, deploy); err == nil {
-		if refErr := controllerutil.SetOwnerReference(deploy, cm, m.Scheme); refErr != nil {
-			mutatorLog.V(1).Info("Failed to set OwnerReference from Deployment", "error", refErr)
-		}
-		return
+		return applyconfigsmetav1.OwnerReference().
+			WithAPIVersion("apps/v1").
+			WithKind("Deployment").
+			WithName(deploy.Name).
+			WithUID(deploy.UID)
 	}
 
 	// Try StatefulSet
 	sts := &appsv1.StatefulSet{}
 	if err := m.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: crName}, sts); err == nil {
-		if refErr := controllerutil.SetOwnerReference(sts, cm, m.Scheme); refErr != nil {
-			mutatorLog.V(1).Info("Failed to set OwnerReference from StatefulSet", "error", refErr)
-		}
-		return
+		return applyconfigsmetav1.OwnerReference().
+			WithAPIVersion("apps/v1").
+			WithKind("StatefulSet").
+			WithName(sts.Name).
+			WithUID(sts.UID)
 	}
 
 	mutatorLog.V(1).Info("Could not find owner workload for per-agent ConfigMap, skipping OwnerReference",
 		"namespace", namespace, "crName", crName)
+	return nil
 }
 
 func containerExists(containers []corev1.Container, name string) bool {

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -676,7 +676,7 @@ func (m *PodMutator) ensurePerAgentConfigMap(
 			return cmName, nil
 		}
 		existing.Data = cm.Data
-		existing.OwnerReferences = cm.OwnerReferences
+		m.setOwnerReferenceFromWorkload(ctx, namespace, crName, existing)
 		if updateErr := m.Client.Update(ctx, existing); updateErr != nil {
 			return "", fmt.Errorf("failed to update ConfigMap %s/%s: %w", namespace, cmName, updateErr)
 		}

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -619,8 +619,8 @@ func (m *PodMutator) ensurePerAgentConfigMap(
 			"client_id_file":     "/shared/client-id.txt",
 			"client_secret_file": "/shared/client-secret.txt",
 		}
-		if nsConfig.ClientAuthType == "federated-jwt" {
-			identity["type"] = "spiffe"
+		if nsConfig.ClientAuthType == ClientAuthTypeFederatedJWT {
+			identity["type"] = IdentityTypeSpiffe
 			identity["jwt_svid_path"] = "/opt/jwt_svid.token"
 		} else {
 			identity["type"] = nsConfig.ClientAuthType

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	applyconfigscorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	applyconfigsmetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -81,7 +80,6 @@ const (
 type PodMutator struct {
 	Client                   client.Client
 	APIReader                client.Reader // uncached reader for cross-namespace ConfigMap reads
-	Scheme                   *runtime.Scheme
 	EnableClientRegistration bool
 	// Getter functions for hot-reloadable config (used by precedence evaluator)
 	GetPlatformConfig func() *config.PlatformConfig
@@ -91,7 +89,6 @@ type PodMutator struct {
 func NewPodMutator(
 	c client.Client,
 	apiReader client.Reader,
-	scheme *runtime.Scheme,
 	enableClientRegistration bool,
 	getPlatformConfig func() *config.PlatformConfig,
 	getFeatureGates func() *config.FeatureGates,
@@ -99,7 +96,6 @@ func NewPodMutator(
 	return &PodMutator{
 		Client:                   c,
 		APIReader:                apiReader,
-		Scheme:                   scheme,
 		EnableClientRegistration: enableClientRegistration,
 		GetPlatformConfig:        getPlatformConfig,
 		GetFeatureGates:          getFeatureGates,

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -683,7 +683,9 @@ func (m *PodMutator) ensurePerAgentConfigMap(
 // pod being created and returns an OwnerReference apply configuration.
 // Returns nil if the workload cannot be found (best-effort).
 func (m *PodMutator) buildOwnerReference(ctx context.Context, namespace, crName string) *applyconfigsmetav1.OwnerReferenceApplyConfiguration {
-	// Try Deployment first (most common)
+	// Uses the cached client (not APIReader) because Deployments/StatefulSets
+	// are in the manager's default cache scope, unlike ConfigMaps which need
+	// the uncached APIReader for agent namespaces.
 	deploy := &appsv1.Deployment{}
 	if err := m.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: crName}, deploy); err == nil {
 		return applyconfigsmetav1.OwnerReference().

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/yaml"
 )
 
 var mutatorLog = logf.Log.WithName("pod-mutator")
@@ -216,22 +217,21 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 	var builder *ContainerBuilder
 	var requiredVolumes []corev1.Volume
 
-	if currentGates.PerWorkloadConfigResolution {
-		// Resolved path: read namespace config and build literal env vars
-		var nsConfig *NamespaceConfig
-		var err error
-		mutatorLog.V(1).Info("reading namespace config per-workload", "namespace", namespace)
-		nsConfig, err = ReadNamespaceConfig(ctx, m.Client, namespace)
-		if err != nil {
-			mutatorLog.Error(err, "failed to read namespace config, using empty defaults",
-				"namespace", namespace)
-			nsConfig = &NamespaceConfig{}
-		}
+	// Always read namespace config — needed for per-agent ConfigMap generation
+	// regardless of the per-workload config resolution feature gate.
+	nsConfig, nsConfigErr := ReadNamespaceConfig(ctx, m.Client, namespace)
+	if nsConfigErr != nil {
+		mutatorLog.Error(nsConfigErr, "failed to read namespace config, using empty defaults",
+			"namespace", namespace)
+		nsConfig = &NamespaceConfig{}
+	}
 
+	if currentGates.PerWorkloadConfigResolution {
+		// Resolved path: build literal env vars from namespace config
 		// arOverrides was already read above as a gate check.
 		resolved := ResolveConfig(currentConfig, nsConfig, arOverrides)
 		builder = NewResolvedContainerBuilder(resolved)
-		requiredVolumes = BuildResolvedVolumes(spireEnabled, "")
+		requiredVolumes = BuildResolvedVolumes(spireEnabled, "", "")
 
 		mutatorLog.Info("Using resolved config path",
 			"namespace", namespace, "crName", crName,
@@ -350,6 +350,18 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 				"forwardProxyPort", forwardProxyPort)
 		}
 
+		// Create per-agent ConfigMap with proxy-sidecar listener addresses
+		perAgentCMName, err := m.ensurePerAgentConfigMap(ctx, namespace, crName,
+			ModeProxySidecar, nsConfig.AuthBridgeRuntimeYAML, nsConfig,
+			map[string]string{
+				"reverse_proxy_addr":    fmt.Sprintf(":%d", originalAgentPort),
+				"reverse_proxy_backend": fmt.Sprintf("http://127.0.0.1:%d", newAgentPort),
+				"forward_proxy_addr":    fmt.Sprintf(":%d", forwardProxyPort),
+			})
+		if err != nil {
+			return false, fmt.Errorf("proxy-sidecar per-agent ConfigMap: %w", err)
+		}
+
 		// Inject authbridge-proxy container listening on the original agent port
 		if !containerExists(podSpec.Containers, AuthBridgeProxyContainerName) {
 			podSpec.Containers = append(podSpec.Containers,
@@ -380,16 +392,18 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 			podSpec.Containers = append(podSpec.Containers, builder.BuildClientRegistrationContainerWithSpireOption(crName, namespace, spireEnabled))
 		}
 
-		// Inject volumes (shared-data, authbridge-runtime-config, spire volumes if enabled)
-		for i := range requiredVolumes {
-			if !volumeExists(podSpec.Volumes, requiredVolumes[i].Name) {
-				podSpec.Volumes = append(podSpec.Volumes, requiredVolumes[i])
+		// Inject volumes — use per-agent ConfigMap name for authbridge config
+		proxyVolumes := overrideAuthBridgeConfigMapInVolumes(requiredVolumes, perAgentCMName)
+		for i := range proxyVolumes {
+			if !volumeExists(podSpec.Volumes, proxyVolumes[i].Name) {
+				podSpec.Volumes = append(podSpec.Volumes, proxyVolumes[i])
 			}
 		}
 
 		mutatorLog.Info("proxy-sidecar mode injection complete",
 			"namespace", namespace, "crName", crName,
 			"image", builder.cfg.Images.AuthBridgeLight,
+			"perAgentConfigMap", perAgentCMName,
 			"reverseProxyPort", originalAgentPort,
 			"agentPort", newAgentPort,
 			"forwardProxyPort", forwardProxyPort)
@@ -403,6 +417,16 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 	// ========================================
 	// Envoy-sidecar mode (default)
 	// ========================================
+
+	// Create per-agent ConfigMap for envoy-sidecar mode (no listener overrides)
+	perAgentCMName, err := m.ensurePerAgentConfigMap(ctx, namespace, crName,
+		ModeEnvoySidecar, nsConfig.AuthBridgeRuntimeYAML, nsConfig, nil)
+	if err != nil {
+		return false, fmt.Errorf("envoy-sidecar per-agent ConfigMap: %w", err)
+	}
+
+	// Override authbridge volume to point at per-agent ConfigMap
+	requiredVolumes = overrideAuthBridgeConfigMapInVolumes(requiredVolumes, perAgentCMName)
 
 	// Conditionally inject sidecars based on precedence decisions.
 	// Two modes controlled by the combinedSidecar feature gate:
@@ -506,6 +530,149 @@ func (m *PodMutator) ensureServiceAccount(ctx context.Context, namespace, name s
 	}
 	mutatorLog.Info("Created ServiceAccount", "namespace", namespace, "name", name)
 	return nil
+}
+
+// perAgentConfigMapName returns the ConfigMap name for a specific agent's authbridge config.
+func perAgentConfigMapName(crName string) string {
+	return "authbridge-config-" + crName
+}
+
+// ensurePerAgentConfigMap creates or updates a per-agent ConfigMap that merges the
+// namespace-level authbridge-runtime-config with per-agent overrides (mode, listener
+// addresses). The authbridge sidecar mounts this instead of the shared ConfigMap.
+//
+// If baseYAML is empty (namespace has no authbridge-runtime-config), a minimal config
+// is generated from the NamespaceConfig fields.
+func (m *PodMutator) ensurePerAgentConfigMap(
+	ctx context.Context,
+	namespace, crName, mode string,
+	baseYAML string,
+	nsConfig *NamespaceConfig,
+	listenerOverrides map[string]string,
+) (string, error) {
+	cmName := perAgentConfigMapName(crName)
+
+	// Parse the base YAML into a generic map
+	cfg := make(map[string]interface{})
+	if baseYAML != "" {
+		if err := yaml.Unmarshal([]byte(baseYAML), &cfg); err != nil {
+			mutatorLog.Error(err, "failed to parse authbridge-runtime-config, using empty base",
+				"namespace", namespace, "crName", crName)
+			cfg = make(map[string]interface{})
+		}
+	}
+
+	// If the base was empty or missing key fields, populate from NamespaceConfig
+	if cfg["inbound"] == nil && nsConfig != nil {
+		inbound := map[string]interface{}{}
+		if nsConfig.Issuer != "" {
+			inbound["issuer"] = nsConfig.Issuer
+		}
+		if len(inbound) > 0 {
+			cfg["inbound"] = inbound
+		}
+	}
+	if cfg["outbound"] == nil && nsConfig != nil {
+		outbound := map[string]interface{}{}
+		if nsConfig.KeycloakURL != "" {
+			outbound["keycloak_url"] = nsConfig.KeycloakURL
+		}
+		if nsConfig.KeycloakRealm != "" {
+			outbound["keycloak_realm"] = nsConfig.KeycloakRealm
+		}
+		if nsConfig.DefaultOutboundPolicy != "" {
+			outbound["default_policy"] = nsConfig.DefaultOutboundPolicy
+		}
+		if len(outbound) > 0 {
+			cfg["outbound"] = outbound
+		}
+	}
+	if cfg["identity"] == nil && nsConfig != nil {
+		identity := map[string]interface{}{}
+		authType := nsConfig.ClientAuthType
+		if authType == "federated-jwt" {
+			identity["type"] = "spiffe"
+			identity["jwt_svid_path"] = "/opt/jwt_svid.token"
+		} else if authType != "" {
+			identity["type"] = authType
+		}
+		identity["client_id_file"] = "/shared/client-id.txt"
+		identity["client_secret_file"] = "/shared/client-secret.txt"
+		if len(identity) > 0 {
+			cfg["identity"] = identity
+		}
+	}
+	if cfg["bypass"] == nil {
+		cfg["bypass"] = map[string]interface{}{
+			"inbound_paths": []string{
+				"/.well-known/*",
+				"/healthz",
+				"/readyz",
+				"/livez",
+			},
+		}
+	}
+
+	// Override mode
+	cfg["mode"] = mode
+
+	// Merge listener overrides
+	if len(listenerOverrides) > 0 {
+		listener, _ := cfg["listener"].(map[string]interface{})
+		if listener == nil {
+			listener = make(map[string]interface{})
+		}
+		for k, v := range listenerOverrides {
+			listener[k] = v
+		}
+		cfg["listener"] = listener
+	}
+
+	// Marshal back to YAML
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal per-agent config for %s/%s: %w", namespace, crName, err)
+	}
+
+	// Create or update the ConfigMap
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				managedByLabel: managedByValue,
+			},
+		},
+		Data: map[string]string{
+			"config.yaml": string(data),
+		},
+	}
+
+	existing := &corev1.ConfigMap{}
+	if getErr := m.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: cmName}, existing); getErr != nil {
+		if !apierrors.IsNotFound(getErr) {
+			return "", fmt.Errorf("failed to check ConfigMap %s/%s: %w", namespace, cmName, getErr)
+		}
+		// Does not exist — create
+		if createErr := m.Client.Create(ctx, cm); createErr != nil {
+			return "", fmt.Errorf("failed to create ConfigMap %s/%s: %w", namespace, cmName, createErr)
+		}
+		mutatorLog.Info("Created per-agent ConfigMap", "namespace", namespace, "name", cmName, "mode", mode)
+	} else {
+		// Exists — update if managed by us
+		if existing.Labels[managedByLabel] != managedByValue {
+			mutatorLog.Info("WARNING: per-agent ConfigMap exists but is not managed by webhook, skipping update",
+				"namespace", namespace, "name", cmName)
+			return cmName, nil
+		}
+		existing.Data = cm.Data
+		if updateErr := m.Client.Update(ctx, existing); updateErr != nil {
+			return "", fmt.Errorf("failed to update ConfigMap %s/%s: %w", namespace, cmName, updateErr)
+		}
+		mutatorLog.Info("Updated per-agent ConfigMap", "namespace", namespace, "name", cmName, "mode", mode)
+	}
+
+	return cmName, nil
 }
 
 func containerExists(containers []corev1.Container, name string) bool {

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -418,15 +418,17 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 	// Envoy-sidecar mode (default)
 	// ========================================
 
-	// Create per-agent ConfigMap for envoy-sidecar mode (no listener overrides)
-	perAgentCMName, err := m.ensurePerAgentConfigMap(ctx, namespace, crName,
-		ModeEnvoySidecar, nsConfig.AuthBridgeRuntimeYAML, nsConfig, nil)
-	if err != nil {
-		return false, fmt.Errorf("envoy-sidecar per-agent ConfigMap: %w", err)
+	// Create per-agent ConfigMap for envoy-sidecar mode (no listener overrides).
+	// Skip when combinedSidecar is enabled — that container uses env vars directly
+	// and does not mount authbridge-runtime-config.
+	if !currentGates.CombinedSidecar {
+		perAgentCMName, err := m.ensurePerAgentConfigMap(ctx, namespace, crName,
+			ModeEnvoySidecar, nsConfig.AuthBridgeRuntimeYAML, nsConfig, nil)
+		if err != nil {
+			return false, fmt.Errorf("envoy-sidecar per-agent ConfigMap: %w", err)
+		}
+		requiredVolumes = overrideAuthBridgeConfigMapInVolumes(requiredVolumes, perAgentCMName)
 	}
-
-	// Override authbridge volume to point at per-agent ConfigMap
-	requiredVolumes = overrideAuthBridgeConfigMapInVolumes(requiredVolumes, perAgentCMName)
 
 	// Conditionally inject sidecars based on precedence decisions.
 	// Two modes controlled by the combinedSidecar feature gate:
@@ -587,20 +589,18 @@ func (m *PodMutator) ensurePerAgentConfigMap(
 			cfg["outbound"] = outbound
 		}
 	}
-	if cfg["identity"] == nil && nsConfig != nil {
-		identity := map[string]interface{}{}
-		authType := nsConfig.ClientAuthType
-		if authType == "federated-jwt" {
+	if cfg["identity"] == nil && nsConfig != nil && nsConfig.ClientAuthType != "" {
+		identity := map[string]interface{}{
+			"client_id_file":     "/shared/client-id.txt",
+			"client_secret_file": "/shared/client-secret.txt",
+		}
+		if nsConfig.ClientAuthType == "federated-jwt" {
 			identity["type"] = "spiffe"
 			identity["jwt_svid_path"] = "/opt/jwt_svid.token"
-		} else if authType != "" {
-			identity["type"] = authType
+		} else {
+			identity["type"] = nsConfig.ClientAuthType
 		}
-		identity["client_id_file"] = "/shared/client-id.txt"
-		identity["client_secret_file"] = "/shared/client-secret.txt"
-		if len(identity) > 0 {
-			cfg["identity"] = identity
-		}
+		cfg["identity"] = identity
 	}
 	if cfg["bypass"] == nil {
 		cfg["bypass"] = map[string]interface{}{

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -80,6 +80,7 @@ const (
 
 type PodMutator struct {
 	Client                   client.Client
+	APIReader                client.Reader // uncached reader for cross-namespace ConfigMap reads
 	Scheme                   *runtime.Scheme
 	EnableClientRegistration bool
 	// Getter functions for hot-reloadable config (used by precedence evaluator)
@@ -88,14 +89,16 @@ type PodMutator struct {
 }
 
 func NewPodMutator(
-	client client.Client,
+	c client.Client,
+	apiReader client.Reader,
 	scheme *runtime.Scheme,
 	enableClientRegistration bool,
 	getPlatformConfig func() *config.PlatformConfig,
 	getFeatureGates func() *config.FeatureGates,
 ) *PodMutator {
 	return &PodMutator{
-		Client:                   client,
+		Client:                   c,
+		APIReader:                apiReader,
 		Scheme:                   scheme,
 		EnableClientRegistration: enableClientRegistration,
 		GetPlatformConfig:        getPlatformConfig,
@@ -228,7 +231,10 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 
 	// Always read namespace config — needed for per-agent ConfigMap generation
 	// regardless of the per-workload config resolution feature gate.
-	nsConfig, nsConfigErr := ReadNamespaceConfig(ctx, m.Client, namespace)
+	// Use the uncached APIReader so ConfigMaps in agent namespaces (which may
+	// not be in the manager's cache scope) are readable.
+	reader := m.apiReader()
+	nsConfig, nsConfigErr := ReadNamespaceConfig(ctx, reader, namespace)
 	if nsConfigErr != nil {
 		mutatorLog.Error(nsConfigErr, "failed to read namespace config, using empty defaults",
 			"namespace", namespace)
@@ -541,6 +547,16 @@ func (m *PodMutator) ensureServiceAccount(ctx context.Context, namespace, name s
 	}
 	mutatorLog.Info("Created ServiceAccount", "namespace", namespace, "name", name)
 	return nil
+}
+
+// apiReader returns the uncached API reader if available, otherwise falls back
+// to the cached client. This ensures ConfigMap reads work in namespaces that
+// are outside the manager's cache scope.
+func (m *PodMutator) apiReader() client.Reader {
+	if m.APIReader != nil {
+		return m.APIReader
+	}
+	return m.Client
 }
 
 // perAgentConfigMapName returns the ConfigMap name for a specific agent's authbridge config.

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -246,7 +246,7 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 		// arOverrides was already read above as a gate check.
 		resolved := ResolveConfig(currentConfig, nsConfig, arOverrides)
 		builder = NewResolvedContainerBuilder(resolved)
-		requiredVolumes = BuildResolvedVolumes(spireEnabled, "", "")
+		requiredVolumes = BuildResolvedVolumes(spireEnabled, "")
 
 		mutatorLog.Info("Using resolved config path",
 			"namespace", namespace, "crName", crName,
@@ -586,7 +586,7 @@ func (m *PodMutator) ensurePerAgentConfigMap(
 	if baseYAML != "" {
 		if err := yaml.Unmarshal([]byte(baseYAML), &cfg); err != nil {
 			mutatorLog.Error(err, "failed to parse authbridge-runtime-config, using empty base",
-				"namespace", namespace, "crName", crName)
+				"namespace", namespace, "crName", crName, "baseYAMLLen", len(baseYAML))
 			cfg = make(map[string]interface{})
 		}
 	}
@@ -688,6 +688,9 @@ func (m *PodMutator) buildOwnerReference(ctx context.Context, namespace, crName 
 	// Uses the cached client (not APIReader) because Deployments/StatefulSets
 	// are in the manager's default cache scope, unlike ConfigMaps which need
 	// the uncached APIReader for agent namespaces.
+	// Note: on the very first pod admission for a new Deployment, the informer
+	// may not have synced yet, producing a ConfigMap without OwnerReference.
+	// SSA re-convergence on subsequent pod admissions will add it.
 	deploy := &appsv1.Deployment{}
 	if err := m.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: crName}, deploy); err == nil {
 		return applyconfigsmetav1.OwnerReference().

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -642,8 +642,13 @@ func (m *PodMutator) ensurePerAgentConfigMap(
 		return "", fmt.Errorf("failed to marshal per-agent config for %s/%s: %w", namespace, crName, err)
 	}
 
-	// Create or update the ConfigMap
+	// Server-side apply: atomic create-or-update in a single API call.
+	// No race condition — concurrent pod admissions safely converge.
 	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmName,
 			Namespace: namespace,
@@ -660,36 +665,10 @@ func (m *PodMutator) ensurePerAgentConfigMap(
 	// ConfigMap is garbage-collected when the workload is deleted.
 	m.setOwnerReferenceFromWorkload(ctx, namespace, crName, cm)
 
-	existing := &corev1.ConfigMap{}
-	if getErr := m.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: cmName}, existing); getErr != nil {
-		if !apierrors.IsNotFound(getErr) {
-			return "", fmt.Errorf("failed to check ConfigMap %s/%s: %w", namespace, cmName, getErr)
-		}
-		// Does not exist — create
-		if createErr := m.Client.Create(ctx, cm); createErr != nil {
-			if apierrors.IsAlreadyExists(createErr) {
-				// Race: another pod's admission created it between our Get and Create.
-				mutatorLog.Info("Per-agent ConfigMap created by concurrent admission", "namespace", namespace, "name", cmName)
-			} else {
-				return "", fmt.Errorf("failed to create ConfigMap %s/%s: %w", namespace, cmName, createErr)
-			}
-		} else {
-			mutatorLog.Info("Created per-agent ConfigMap", "namespace", namespace, "name", cmName, "mode", mode)
-		}
-	} else {
-		// Exists — update if managed by us
-		if existing.Labels[managedByLabel] != managedByValue {
-			mutatorLog.Info("WARNING: per-agent ConfigMap exists but is not managed by webhook, skipping update",
-				"namespace", namespace, "name", cmName)
-			return cmName, nil
-		}
-		existing.Data = cm.Data
-		m.setOwnerReferenceFromWorkload(ctx, namespace, crName, existing)
-		if updateErr := m.Client.Update(ctx, existing); updateErr != nil {
-			return "", fmt.Errorf("failed to update ConfigMap %s/%s: %w", namespace, cmName, updateErr)
-		}
-		mutatorLog.Info("Updated per-agent ConfigMap", "namespace", namespace, "name", cmName, "mode", mode)
+	if err := m.Client.Patch(ctx, cm, client.Apply, client.FieldOwner("kagenti-webhook"), client.ForceOwnership); err != nil {
+		return "", fmt.Errorf("failed to apply per-agent ConfigMap %s/%s: %w", namespace, cmName, err)
 	}
+	mutatorLog.Info("Applied per-agent ConfigMap", "namespace", namespace, "name", cmName, "mode", mode)
 
 	return cmName, nil
 }

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -103,7 +103,7 @@ func NewPodMutator(
 	}
 }
 
-// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=create;get;list;update;watch
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=create;get;list;patch;update;watch
 
 // InjectAuthBridge evaluates the multi-layer precedence chain and conditionally injects sidecars.
 //

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -22,10 +22,13 @@ import (
 	"strings"
 
 	"github.com/kagenti/operator/internal/webhook/config"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 )
@@ -76,6 +79,7 @@ const (
 
 type PodMutator struct {
 	Client                   client.Client
+	Scheme                   *runtime.Scheme
 	EnableClientRegistration bool
 	// Getter functions for hot-reloadable config (used by precedence evaluator)
 	GetPlatformConfig func() *config.PlatformConfig
@@ -84,12 +88,14 @@ type PodMutator struct {
 
 func NewPodMutator(
 	client client.Client,
+	scheme *runtime.Scheme,
 	enableClientRegistration bool,
 	getPlatformConfig func() *config.PlatformConfig,
 	getFeatureGates func() *config.FeatureGates,
 ) *PodMutator {
 	return &PodMutator{
 		Client:                   client,
+		Scheme:                   scheme,
 		EnableClientRegistration: enableClientRegistration,
 		GetPlatformConfig:        getPlatformConfig,
 		GetFeatureGates:          getFeatureGates,
@@ -648,6 +654,10 @@ func (m *PodMutator) ensurePerAgentConfigMap(
 		},
 	}
 
+	// Set OwnerReference to the owning Deployment or StatefulSet so the
+	// ConfigMap is garbage-collected when the workload is deleted.
+	m.setOwnerReferenceFromWorkload(ctx, namespace, crName, cm)
+
 	existing := &corev1.ConfigMap{}
 	if getErr := m.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: cmName}, existing); getErr != nil {
 		if !apierrors.IsNotFound(getErr) {
@@ -666,6 +676,7 @@ func (m *PodMutator) ensurePerAgentConfigMap(
 			return cmName, nil
 		}
 		existing.Data = cm.Data
+		existing.OwnerReferences = cm.OwnerReferences
 		if updateErr := m.Client.Update(ctx, existing); updateErr != nil {
 			return "", fmt.Errorf("failed to update ConfigMap %s/%s: %w", namespace, cmName, updateErr)
 		}
@@ -673,6 +684,38 @@ func (m *PodMutator) ensurePerAgentConfigMap(
 	}
 
 	return cmName, nil
+}
+
+// setOwnerReferenceFromWorkload looks up the Deployment or StatefulSet that
+// owns the pod being created and sets it as an OwnerReference on the ConfigMap.
+// This enables garbage collection when the workload is deleted.
+// Best-effort: if the owner cannot be found, the ConfigMap is created without
+// an OwnerReference (the managedByLabel still identifies it for manual cleanup).
+func (m *PodMutator) setOwnerReferenceFromWorkload(ctx context.Context, namespace, crName string, cm *corev1.ConfigMap) {
+	if m.Scheme == nil {
+		return
+	}
+
+	// Try Deployment first (most common)
+	deploy := &appsv1.Deployment{}
+	if err := m.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: crName}, deploy); err == nil {
+		if refErr := controllerutil.SetOwnerReference(deploy, cm, m.Scheme); refErr != nil {
+			mutatorLog.V(1).Info("Failed to set OwnerReference from Deployment", "error", refErr)
+		}
+		return
+	}
+
+	// Try StatefulSet
+	sts := &appsv1.StatefulSet{}
+	if err := m.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: crName}, sts); err == nil {
+		if refErr := controllerutil.SetOwnerReference(sts, cm, m.Scheme); refErr != nil {
+			mutatorLog.V(1).Info("Failed to set OwnerReference from StatefulSet", "error", refErr)
+		}
+		return
+	}
+
+	mutatorLog.V(1).Info("Could not find owner workload for per-agent ConfigMap, skipping OwnerReference",
+		"namespace", namespace, "crName", crName)
 }
 
 func containerExists(containers []corev1.Container, name string) bool {

--- a/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
@@ -58,6 +58,7 @@ func newTestMutator(objs ...client.Object) *PodMutator {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 	return &PodMutator{
 		Client:                   fakeClient,
+		APIReader:                fakeClient,
 		Scheme:                   scheme,
 		EnableClientRegistration: true,
 		GetPlatformConfig:        config.CompiledDefaults,

--- a/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
@@ -59,7 +59,6 @@ func newTestMutator(objs ...client.Object) *PodMutator {
 	return &PodMutator{
 		Client:                   fakeClient,
 		APIReader:                fakeClient,
-		Scheme:                   scheme,
 		EnableClientRegistration: true,
 		GetPlatformConfig:        config.CompiledDefaults,
 		GetFeatureGates:          config.DefaultFeatureGates,

--- a/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
@@ -1239,7 +1239,9 @@ func TestEnsurePerAgentConfigMap_ExistingCM_OwnedByWebhook_Updated(t *testing.T)
 	}
 }
 
-func TestEnsurePerAgentConfigMap_ExistingCM_NotOwnedByWebhook_Skipped(t *testing.T) {
+func TestEnsurePerAgentConfigMap_ExistingCM_OverwrittenBySSA(t *testing.T) {
+	// Server-side apply with ForceOwnership overwrites regardless of
+	// previous ownership — the webhook always converges to desired state.
 	existingCM := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "authbridge-config-my-agent",
@@ -1252,7 +1254,7 @@ func TestEnsurePerAgentConfigMap_ExistingCM_NotOwnedByWebhook_Skipped(t *testing
 	ctx := context.Background()
 
 	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "my-agent",
-		ModeEnvoySidecar, "", &NamespaceConfig{}, nil)
+		ModeEnvoySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1260,11 +1262,11 @@ func TestEnsurePerAgentConfigMap_ExistingCM_NotOwnedByWebhook_Skipped(t *testing
 		t.Errorf("cmName = %q, want authbridge-config-my-agent", cmName)
 	}
 
-	// Data should NOT be updated
+	// SSA overwrites — mode should be updated
 	cm := fetchConfigMap(t, m, "team1", "authbridge-config-my-agent")
 	cfg := parseConfigYAML(t, cm)
-	if cfg["mode"] != "user-managed" {
-		t.Errorf("mode = %v, should be unchanged (user-managed)", cfg["mode"])
+	if cfg["mode"] != ModeEnvoySidecar {
+		t.Errorf("mode = %v, want %s (SSA should overwrite)", cfg["mode"], ModeEnvoySidecar)
 	}
 }
 

--- a/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
@@ -1156,7 +1156,7 @@ bypass:
 	}
 
 	identity, _ := cfg["identity"].(map[string]interface{})
-	if identity["type"] != "spiffe" {
+	if identity["type"] != IdentityTypeSpiffe {
 		t.Errorf("identity.type = %v, should be preserved from base YAML", identity["type"])
 	}
 
@@ -1366,7 +1366,7 @@ func TestEnsurePerAgentConfigMap_FederatedJWT_MapsToSpiffe(t *testing.T) {
 	if identity == nil {
 		t.Fatal("expected identity section")
 	}
-	if identity["type"] != "spiffe" {
+	if identity["type"] != IdentityTypeSpiffe {
 		t.Errorf("identity.type = %v, want spiffe (federated-jwt should map to spiffe)", identity["type"])
 	}
 	if identity["jwt_svid_path"] != "/opt/jwt_svid.token" {

--- a/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
@@ -22,11 +22,14 @@ import (
 
 	agentv1alpha1 "github.com/kagenti/operator/api/v1alpha1"
 	"github.com/kagenti/operator/internal/webhook/config"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	sigsyaml "sigs.k8s.io/yaml"
 )
 
 // newAgentRuntime creates a minimal AgentRuntime CR targeting the given workload name.
@@ -50,10 +53,12 @@ func newAgentRuntime(namespace, targetName string) *agentv1alpha1.AgentRuntime {
 func newTestMutator(objs ...client.Object) *PodMutator {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
 	_ = agentv1alpha1.AddToScheme(scheme)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 	return &PodMutator{
 		Client:                   fakeClient,
+		Scheme:                   scheme,
 		EnableClientRegistration: true,
 		GetPlatformConfig:        config.CompiledDefaults,
 		GetFeatureGates:          config.DefaultFeatureGates,
@@ -1026,5 +1031,310 @@ func TestInjectAuthBridge_ProxySidecarMode_NoPorts_UsesDefault(t *testing.T) {
 	}
 	if !httpProxyFound {
 		t.Error("HTTP_PROXY should be injected even when agent has no ports")
+	}
+}
+
+// --- ensurePerAgentConfigMap tests ---
+
+// helper to get a ConfigMap from the fake client
+func fetchConfigMap(t *testing.T, m *PodMutator, namespace, name string) *corev1.ConfigMap {
+	t.Helper()
+	cm := &corev1.ConfigMap{}
+	if err := m.Client.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: name}, cm); err != nil {
+		t.Fatalf("failed to get ConfigMap %s/%s: %v", namespace, name, err)
+	}
+	return cm
+}
+
+// helper to parse config.yaml from a ConfigMap into a map
+func parseConfigYAML(t *testing.T, cm *corev1.ConfigMap) map[string]interface{} {
+	t.Helper()
+	raw, ok := cm.Data["config.yaml"]
+	if !ok {
+		t.Fatal("ConfigMap missing config.yaml key")
+	}
+	var cfg map[string]interface{}
+	if err := sigsyaml.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatalf("failed to parse config.yaml: %v", err)
+	}
+	return cfg
+}
+
+func TestEnsurePerAgentConfigMap_EmptyBaseYAML_FallbackFromNsConfig(t *testing.T) {
+	m := newTestMutator()
+	ctx := context.Background()
+
+	nsConfig := &NamespaceConfig{
+		Issuer:                "http://keycloak:8080/realms/kagenti",
+		KeycloakURL:           "http://keycloak:8080",
+		KeycloakRealm:         "kagenti",
+		DefaultOutboundPolicy: "passthrough",
+		ClientAuthType:        "client-secret",
+	}
+
+	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "weather-service",
+		ModeProxySidecar, "", nsConfig, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmName != "authbridge-config-weather-service" {
+		t.Errorf("cmName = %q, want authbridge-config-weather-service", cmName)
+	}
+
+	cm := fetchConfigMap(t, m, "team1", cmName)
+	cfg := parseConfigYAML(t, cm)
+
+	if cfg["mode"] != ModeProxySidecar {
+		t.Errorf("mode = %v, want %s", cfg["mode"], ModeProxySidecar)
+	}
+
+	inbound, _ := cfg["inbound"].(map[string]interface{})
+	if inbound == nil || inbound["issuer"] != "http://keycloak:8080/realms/kagenti" {
+		t.Errorf("inbound.issuer = %v, want http://keycloak:8080/realms/kagenti", inbound)
+	}
+
+	outbound, _ := cfg["outbound"].(map[string]interface{})
+	if outbound == nil || outbound["keycloak_url"] != "http://keycloak:8080" {
+		t.Errorf("outbound.keycloak_url = %v, want http://keycloak:8080", outbound)
+	}
+
+	identity, _ := cfg["identity"].(map[string]interface{})
+	if identity == nil || identity["type"] != "client-secret" {
+		t.Errorf("identity.type = %v, want client-secret", identity)
+	}
+
+	if cfg["bypass"] == nil {
+		t.Error("expected default bypass paths")
+	}
+
+	// managedBy label
+	if cm.Labels[managedByLabel] != managedByValue {
+		t.Errorf("managedBy label = %q, want %q", cm.Labels[managedByLabel], managedByValue)
+	}
+}
+
+func TestEnsurePerAgentConfigMap_BaseYAML_PreservesExistingFields(t *testing.T) {
+	m := newTestMutator()
+	ctx := context.Background()
+
+	baseYAML := `
+mode: envoy-sidecar
+inbound:
+  issuer: "http://custom-issuer"
+outbound:
+  keycloak_url: "http://custom-keycloak:8080"
+  keycloak_realm: "custom-realm"
+identity:
+  type: spiffe
+  jwt_svid_path: "/opt/jwt_svid.token"
+  client_id_file: "/shared/client-id.txt"
+  client_secret_file: "/shared/client-secret.txt"
+bypass:
+  inbound_paths:
+    - "/custom-path"
+`
+
+	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "my-agent",
+		ModeEnvoySidecar, baseYAML, &NamespaceConfig{}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cm := fetchConfigMap(t, m, "team1", cmName)
+	cfg := parseConfigYAML(t, cm)
+
+	// Mode overridden
+	if cfg["mode"] != ModeEnvoySidecar {
+		t.Errorf("mode = %v, want %s", cfg["mode"], ModeEnvoySidecar)
+	}
+
+	// Existing fields preserved (not overwritten by fallback)
+	inbound, _ := cfg["inbound"].(map[string]interface{})
+	if inbound["issuer"] != "http://custom-issuer" {
+		t.Errorf("inbound.issuer = %v, should be preserved from base YAML", inbound["issuer"])
+	}
+
+	identity, _ := cfg["identity"].(map[string]interface{})
+	if identity["type"] != "spiffe" {
+		t.Errorf("identity.type = %v, should be preserved from base YAML", identity["type"])
+	}
+
+	bypass, _ := cfg["bypass"].(map[string]interface{})
+	paths, _ := bypass["inbound_paths"].([]interface{})
+	if len(paths) != 1 || paths[0] != "/custom-path" {
+		t.Errorf("bypass paths = %v, should be preserved from base YAML", paths)
+	}
+}
+
+func TestEnsurePerAgentConfigMap_ListenerOverrides_Merged(t *testing.T) {
+	m := newTestMutator()
+	ctx := context.Background()
+
+	baseYAML := `
+mode: envoy-sidecar
+inbound:
+  issuer: "http://issuer"
+outbound:
+  keycloak_url: "http://keycloak:8080"
+  keycloak_realm: "kagenti"
+identity:
+  type: client-secret
+  client_id_file: "/shared/client-id.txt"
+  client_secret_file: "/shared/client-secret.txt"
+`
+
+	overrides := map[string]string{
+		"reverse_proxy_addr":    ":8000",
+		"reverse_proxy_backend": "http://127.0.0.1:8002",
+		"forward_proxy_addr":    ":8081",
+	}
+
+	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "my-agent",
+		ModeProxySidecar, baseYAML, &NamespaceConfig{}, overrides)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cm := fetchConfigMap(t, m, "team1", cmName)
+	cfg := parseConfigYAML(t, cm)
+
+	listener, _ := cfg["listener"].(map[string]interface{})
+	if listener == nil {
+		t.Fatal("expected listener section in config")
+	}
+	if listener["reverse_proxy_addr"] != ":8000" {
+		t.Errorf("reverse_proxy_addr = %v, want :8000", listener["reverse_proxy_addr"])
+	}
+	if listener["reverse_proxy_backend"] != "http://127.0.0.1:8002" {
+		t.Errorf("reverse_proxy_backend = %v, want http://127.0.0.1:8002", listener["reverse_proxy_backend"])
+	}
+	if listener["forward_proxy_addr"] != ":8081" {
+		t.Errorf("forward_proxy_addr = %v, want :8081", listener["forward_proxy_addr"])
+	}
+}
+
+func TestEnsurePerAgentConfigMap_ExistingCM_OwnedByWebhook_Updated(t *testing.T) {
+	existingCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "authbridge-config-my-agent",
+			Namespace: "team1",
+			Labels:    map[string]string{managedByLabel: managedByValue},
+		},
+		Data: map[string]string{"config.yaml": "mode: old-mode\n"},
+	}
+	m := newTestMutator(existingCM)
+	ctx := context.Background()
+
+	_, err := m.ensurePerAgentConfigMap(ctx, "team1", "my-agent",
+		ModeEnvoySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cm := fetchConfigMap(t, m, "team1", "authbridge-config-my-agent")
+	cfg := parseConfigYAML(t, cm)
+
+	if cfg["mode"] != ModeEnvoySidecar {
+		t.Errorf("mode = %v, want %s (should have been updated)", cfg["mode"], ModeEnvoySidecar)
+	}
+}
+
+func TestEnsurePerAgentConfigMap_ExistingCM_NotOwnedByWebhook_Skipped(t *testing.T) {
+	existingCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "authbridge-config-my-agent",
+			Namespace: "team1",
+			Labels:    map[string]string{"some-other": "label"},
+		},
+		Data: map[string]string{"config.yaml": "mode: user-managed\n"},
+	}
+	m := newTestMutator(existingCM)
+	ctx := context.Background()
+
+	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "my-agent",
+		ModeEnvoySidecar, "", &NamespaceConfig{}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmName != "authbridge-config-my-agent" {
+		t.Errorf("cmName = %q, want authbridge-config-my-agent", cmName)
+	}
+
+	// Data should NOT be updated
+	cm := fetchConfigMap(t, m, "team1", "authbridge-config-my-agent")
+	cfg := parseConfigYAML(t, cm)
+	if cfg["mode"] != "user-managed" {
+		t.Errorf("mode = %v, should be unchanged (user-managed)", cfg["mode"])
+	}
+}
+
+func TestEnsurePerAgentConfigMap_OwnerReference_SetFromDeployment(t *testing.T) {
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "weather-service",
+			Namespace: "team1",
+			UID:       types.UID("deploy-uid-123"),
+		},
+	}
+	m := newTestMutator(deploy)
+	ctx := context.Background()
+
+	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "weather-service",
+		ModeEnvoySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cm := fetchConfigMap(t, m, "team1", cmName)
+	if len(cm.OwnerReferences) == 0 {
+		t.Fatal("expected OwnerReference on ConfigMap")
+	}
+	ref := cm.OwnerReferences[0]
+	if ref.Kind != "Deployment" || ref.Name != "weather-service" || ref.UID != "deploy-uid-123" {
+		t.Errorf("OwnerReference = %+v, want Deployment/weather-service/deploy-uid-123", ref)
+	}
+}
+
+func TestEnsurePerAgentConfigMap_OwnerReference_SetFromStatefulSet(t *testing.T) {
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-stateful-agent",
+			Namespace: "team1",
+			UID:       types.UID("sts-uid-456"),
+		},
+	}
+	m := newTestMutator(sts)
+	ctx := context.Background()
+
+	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "my-stateful-agent",
+		ModeEnvoySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cm := fetchConfigMap(t, m, "team1", cmName)
+	if len(cm.OwnerReferences) == 0 {
+		t.Fatal("expected OwnerReference on ConfigMap")
+	}
+	ref := cm.OwnerReferences[0]
+	if ref.Kind != "StatefulSet" || ref.Name != "my-stateful-agent" || ref.UID != "sts-uid-456" {
+		t.Errorf("OwnerReference = %+v, want StatefulSet/my-stateful-agent/sts-uid-456", ref)
+	}
+}
+
+func TestEnsurePerAgentConfigMap_OwnerReference_NoWorkload_Skipped(t *testing.T) {
+	// No Deployment or StatefulSet — bare pod
+	m := newTestMutator()
+	ctx := context.Background()
+
+	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "bare-pod-agent",
+		ModeEnvoySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cm := fetchConfigMap(t, m, "team1", cmName)
+	if len(cm.OwnerReferences) != 0 {
+		t.Errorf("expected no OwnerReference for bare pod, got %+v", cm.OwnerReferences)
 	}
 }

--- a/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
@@ -1341,3 +1341,38 @@ func TestEnsurePerAgentConfigMap_OwnerReference_NoWorkload_Skipped(t *testing.T)
 		t.Errorf("expected no OwnerReference for bare pod, got %+v", cm.OwnerReferences)
 	}
 }
+
+func TestEnsurePerAgentConfigMap_FederatedJWT_MapsToSpiffe(t *testing.T) {
+	m := newTestMutator()
+	ctx := context.Background()
+
+	nsConfig := &NamespaceConfig{
+		Issuer:         "http://keycloak:8080/realms/kagenti",
+		KeycloakURL:    "http://keycloak:8080",
+		KeycloakRealm:  "kagenti",
+		ClientAuthType: "federated-jwt",
+	}
+
+	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "spiffe-agent",
+		ModeEnvoySidecar, "", nsConfig, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cm := fetchConfigMap(t, m, "team1", cmName)
+	cfg := parseConfigYAML(t, cm)
+
+	identity, _ := cfg["identity"].(map[string]interface{})
+	if identity == nil {
+		t.Fatal("expected identity section")
+	}
+	if identity["type"] != "spiffe" {
+		t.Errorf("identity.type = %v, want spiffe (federated-jwt should map to spiffe)", identity["type"])
+	}
+	if identity["jwt_svid_path"] != "/opt/jwt_svid.token" {
+		t.Errorf("identity.jwt_svid_path = %v, want /opt/jwt_svid.token", identity["jwt_svid_path"])
+	}
+	if identity["client_id_file"] != "/shared/client-id.txt" {
+		t.Errorf("identity.client_id_file = %v, want /shared/client-id.txt", identity["client_id_file"])
+	}
+}

--- a/kagenti-operator/internal/webhook/injector/resolved_config.go
+++ b/kagenti-operator/internal/webhook/injector/resolved_config.go
@@ -51,6 +51,9 @@ type ResolvedConfig struct {
 	EnvoyYAML           string // empty = use template
 	AuthproxyRoutesYAML string
 
+	// AuthBridge runtime config — from namespace "authbridge-runtime-config" ConfigMap
+	AuthBridgeRuntimeYAML string // raw config.yaml (base for per-agent ConfigMap)
+
 	// Observability — from AgentRuntime .spec.trace (optional)
 	TraceEndpoint     string
 	TraceProtocol     string   // "grpc" or "http"
@@ -89,6 +92,7 @@ func ResolveConfig(platform *config.PlatformConfig, ns *NamespaceConfig, ar *Age
 		SpiffeHelperConf:           ns.SpiffeHelperConf,
 		EnvoyYAML:                  ns.EnvoyYAML,
 		AuthproxyRoutesYAML:        ns.AuthproxyRoutesYAML,
+		AuthBridgeRuntimeYAML:      ns.AuthBridgeRuntimeYAML,
 	}
 
 	// Apply AgentRuntime overrides (highest precedence)

--- a/kagenti-operator/internal/webhook/injector/volume_builder.go
+++ b/kagenti-operator/internal/webhook/injector/volume_builder.go
@@ -142,14 +142,12 @@ func BuildRequiredVolumesNoSpire() []corev1.Volume {
 // BuildResolvedVolumes creates volumes using resolved config values.
 // When a resolved envoy config name is provided, the envoy-config volume
 // references that ConfigMap instead of the default "envoy-config" one.
-// When authbridgeConfigMapName is non-empty, the authbridge-runtime-config
-// volume references that per-agent ConfigMap instead of the shared one.
-func BuildResolvedVolumes(spireEnabled bool, envoyConfigMapName, authbridgeConfigMapName string) []corev1.Volume {
+// The authbridge-runtime-config volume always references the shared namespace
+// ConfigMap; use overrideAuthBridgeConfigMapInVolumes to point it at a
+// per-agent ConfigMap after volume creation.
+func BuildResolvedVolumes(spireEnabled bool, envoyConfigMapName string) []corev1.Volume {
 	if envoyConfigMapName == "" {
 		envoyConfigMapName = EnvoyConfigMapName
-	}
-	if authbridgeConfigMapName == "" {
-		authbridgeConfigMapName = AuthBridgeRuntimeConfigMapName
 	}
 
 	volumes := []corev1.Volume{
@@ -219,7 +217,7 @@ func BuildResolvedVolumes(spireEnabled bool, envoyConfigMapName, authbridgeConfi
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: authbridgeConfigMapName,
+						Name: AuthBridgeRuntimeConfigMapName,
 					},
 					Optional: ptr.To(true),
 				},

--- a/kagenti-operator/internal/webhook/injector/volume_builder.go
+++ b/kagenti-operator/internal/webhook/injector/volume_builder.go
@@ -142,10 +142,14 @@ func BuildRequiredVolumesNoSpire() []corev1.Volume {
 // BuildResolvedVolumes creates volumes using resolved config values.
 // When a resolved envoy config name is provided, the envoy-config volume
 // references that ConfigMap instead of the default "envoy-config" one.
-// This enables per-workload envoy configs created at admission time.
-func BuildResolvedVolumes(spireEnabled bool, envoyConfigMapName string) []corev1.Volume {
+// When authbridgeConfigMapName is non-empty, the authbridge-runtime-config
+// volume references that per-agent ConfigMap instead of the shared one.
+func BuildResolvedVolumes(spireEnabled bool, envoyConfigMapName, authbridgeConfigMapName string) []corev1.Volume {
 	if envoyConfigMapName == "" {
 		envoyConfigMapName = EnvoyConfigMapName
+	}
+	if authbridgeConfigMapName == "" {
+		authbridgeConfigMapName = AuthBridgeRuntimeConfigMapName
 	}
 
 	volumes := []corev1.Volume{
@@ -215,7 +219,7 @@ func BuildResolvedVolumes(spireEnabled bool, envoyConfigMapName string) []corev1
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "authbridge-runtime-config",
+						Name: authbridgeConfigMapName,
 					},
 					Optional: ptr.To(true),
 				},
@@ -224,4 +228,21 @@ func BuildResolvedVolumes(spireEnabled bool, envoyConfigMapName string) []corev1
 	)
 
 	return volumes
+}
+
+// overrideAuthBridgeConfigMapInVolumes returns a copy of the volume list with
+// the authbridge-runtime-config volume pointing at the given ConfigMap name.
+// This is used to redirect the volume mount to a per-agent ConfigMap.
+func overrideAuthBridgeConfigMapInVolumes(volumes []corev1.Volume, cmName string) []corev1.Volume {
+	result := make([]corev1.Volume, len(volumes))
+	copy(result, volumes)
+	for i := range result {
+		if result[i].Name == "authbridge-runtime-config" && result[i].ConfigMap != nil {
+			// Deep copy the ConfigMapVolumeSource to avoid mutating the original
+			cmCopy := *result[i].ConfigMap
+			cmCopy.LocalObjectReference.Name = cmName
+			result[i].ConfigMap = &cmCopy
+		}
+	}
+	return result
 }

--- a/kagenti-operator/internal/webhook/injector/volume_builder.go
+++ b/kagenti-operator/internal/webhook/injector/volume_builder.go
@@ -237,10 +237,10 @@ func overrideAuthBridgeConfigMapInVolumes(volumes []corev1.Volume, cmName string
 	result := make([]corev1.Volume, len(volumes))
 	copy(result, volumes)
 	for i := range result {
-		if result[i].Name == "authbridge-runtime-config" && result[i].ConfigMap != nil {
+		if result[i].Name == AuthBridgeRuntimeConfigMapName && result[i].ConfigMap != nil {
 			// Deep copy the ConfigMapVolumeSource to avoid mutating the original
 			cmCopy := *result[i].ConfigMap
-			cmCopy.LocalObjectReference.Name = cmName
+			cmCopy.Name = cmName
 			result[i].ConfigMap = &cmCopy
 		}
 	}

--- a/kagenti-operator/internal/webhook/injector/volume_builder_test.go
+++ b/kagenti-operator/internal/webhook/injector/volume_builder_test.go
@@ -105,8 +105,8 @@ func TestBuildResolvedVolumes_CustomAuthBridgeConfigMapName(t *testing.T) {
 	volumes := BuildResolvedVolumes(false, "", "authbridge-config-weather-service")
 
 	for _, v := range volumes {
-		if v.Name == "authbridge-runtime-config" {
-			name := v.VolumeSource.ConfigMap.LocalObjectReference.Name
+		if v.Name == AuthBridgeRuntimeConfigMapName {
+			name := v.ConfigMap.Name
 			if name != "authbridge-config-weather-service" {
 				t.Errorf("authbridge-runtime-config ConfigMap name = %q, want %q", name, "authbridge-config-weather-service")
 			}
@@ -122,19 +122,19 @@ func TestOverrideAuthBridgeConfigMapInVolumes(t *testing.T) {
 
 	// Original should be unchanged
 	for _, v := range original {
-		if v.Name == "authbridge-runtime-config" && v.ConfigMap != nil {
-			if v.ConfigMap.LocalObjectReference.Name != AuthBridgeRuntimeConfigMapName {
-				t.Errorf("original was mutated: got %q", v.ConfigMap.LocalObjectReference.Name)
+		if v.Name == AuthBridgeRuntimeConfigMapName && v.ConfigMap != nil {
+			if v.ConfigMap.Name != AuthBridgeRuntimeConfigMapName {
+				t.Errorf("original was mutated: got %q", v.ConfigMap.Name)
 			}
 		}
 	}
 
 	// Overridden should have the new name
 	for _, v := range overridden {
-		if v.Name == "authbridge-runtime-config" && v.ConfigMap != nil {
-			if v.ConfigMap.LocalObjectReference.Name != "authbridge-config-my-agent" {
+		if v.Name == AuthBridgeRuntimeConfigMapName && v.ConfigMap != nil {
+			if v.ConfigMap.Name != "authbridge-config-my-agent" {
 				t.Errorf("override failed: got %q, want %q",
-					v.ConfigMap.LocalObjectReference.Name, "authbridge-config-my-agent")
+					v.ConfigMap.Name, "authbridge-config-my-agent")
 			}
 			return
 		}

--- a/kagenti-operator/internal/webhook/injector/volume_builder_test.go
+++ b/kagenti-operator/internal/webhook/injector/volume_builder_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestBuildResolvedVolumes_SpireDisabled(t *testing.T) {
-	volumes := BuildResolvedVolumes(false, "", "")
+	volumes := BuildResolvedVolumes(false, "")
 
 	// Should have: shared-data, envoy-config, authproxy-routes, authbridge-runtime-config
 	if len(volumes) != 4 {
@@ -48,7 +48,7 @@ func TestBuildResolvedVolumes_SpireDisabled(t *testing.T) {
 }
 
 func TestBuildResolvedVolumes_SpireEnabled(t *testing.T) {
-	volumes := BuildResolvedVolumes(true, "", "")
+	volumes := BuildResolvedVolumes(true, "")
 
 	// Should have: shared-data, spire-agent-socket, spiffe-helper-config, svid-output, envoy-config, authproxy-routes, authbridge-runtime-config
 	if len(volumes) != 7 {
@@ -68,7 +68,7 @@ func TestBuildResolvedVolumes_SpireEnabled(t *testing.T) {
 }
 
 func TestBuildResolvedVolumes_CustomEnvoyConfigMapName(t *testing.T) {
-	volumes := BuildResolvedVolumes(false, "my-custom-envoy", "")
+	volumes := BuildResolvedVolumes(false, "my-custom-envoy")
 
 	var envoyVolume *string
 	for _, v := range volumes {
@@ -87,7 +87,7 @@ func TestBuildResolvedVolumes_CustomEnvoyConfigMapName(t *testing.T) {
 }
 
 func TestBuildResolvedVolumes_DefaultEnvoyConfigMapName(t *testing.T) {
-	volumes := BuildResolvedVolumes(false, "", "")
+	volumes := BuildResolvedVolumes(false, "")
 
 	for _, v := range volumes {
 		if v.Name == "envoy-config" {
@@ -101,14 +101,14 @@ func TestBuildResolvedVolumes_DefaultEnvoyConfigMapName(t *testing.T) {
 	t.Fatal("envoy-config volume not found")
 }
 
-func TestBuildResolvedVolumes_CustomAuthBridgeConfigMapName(t *testing.T) {
-	volumes := BuildResolvedVolumes(false, "", "authbridge-config-weather-service")
+func TestBuildResolvedVolumes_AuthBridgeDefaultsToSharedCM(t *testing.T) {
+	volumes := BuildResolvedVolumes(false, "")
 
 	for _, v := range volumes {
 		if v.Name == AuthBridgeRuntimeConfigMapName {
 			name := v.ConfigMap.Name
-			if name != "authbridge-config-weather-service" {
-				t.Errorf("authbridge-runtime-config ConfigMap name = %q, want %q", name, "authbridge-config-weather-service")
+			if name != AuthBridgeRuntimeConfigMapName {
+				t.Errorf("authbridge-runtime-config ConfigMap name = %q, want %q", name, AuthBridgeRuntimeConfigMapName)
 			}
 			return
 		}

--- a/kagenti-operator/internal/webhook/injector/volume_builder_test.go
+++ b/kagenti-operator/internal/webhook/injector/volume_builder_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestBuildResolvedVolumes_SpireDisabled(t *testing.T) {
-	volumes := BuildResolvedVolumes(false, "")
+	volumes := BuildResolvedVolumes(false, "", "")
 
 	// Should have: shared-data, envoy-config, authproxy-routes, authbridge-runtime-config
 	if len(volumes) != 4 {
@@ -48,7 +48,7 @@ func TestBuildResolvedVolumes_SpireDisabled(t *testing.T) {
 }
 
 func TestBuildResolvedVolumes_SpireEnabled(t *testing.T) {
-	volumes := BuildResolvedVolumes(true, "")
+	volumes := BuildResolvedVolumes(true, "", "")
 
 	// Should have: shared-data, spire-agent-socket, spiffe-helper-config, svid-output, envoy-config, authproxy-routes, authbridge-runtime-config
 	if len(volumes) != 7 {
@@ -68,7 +68,7 @@ func TestBuildResolvedVolumes_SpireEnabled(t *testing.T) {
 }
 
 func TestBuildResolvedVolumes_CustomEnvoyConfigMapName(t *testing.T) {
-	volumes := BuildResolvedVolumes(false, "my-custom-envoy")
+	volumes := BuildResolvedVolumes(false, "my-custom-envoy", "")
 
 	var envoyVolume *string
 	for _, v := range volumes {
@@ -87,7 +87,7 @@ func TestBuildResolvedVolumes_CustomEnvoyConfigMapName(t *testing.T) {
 }
 
 func TestBuildResolvedVolumes_DefaultEnvoyConfigMapName(t *testing.T) {
-	volumes := BuildResolvedVolumes(false, "")
+	volumes := BuildResolvedVolumes(false, "", "")
 
 	for _, v := range volumes {
 		if v.Name == "envoy-config" {
@@ -99,4 +99,45 @@ func TestBuildResolvedVolumes_DefaultEnvoyConfigMapName(t *testing.T) {
 		}
 	}
 	t.Fatal("envoy-config volume not found")
+}
+
+func TestBuildResolvedVolumes_CustomAuthBridgeConfigMapName(t *testing.T) {
+	volumes := BuildResolvedVolumes(false, "", "authbridge-config-weather-service")
+
+	for _, v := range volumes {
+		if v.Name == "authbridge-runtime-config" {
+			name := v.VolumeSource.ConfigMap.LocalObjectReference.Name
+			if name != "authbridge-config-weather-service" {
+				t.Errorf("authbridge-runtime-config ConfigMap name = %q, want %q", name, "authbridge-config-weather-service")
+			}
+			return
+		}
+	}
+	t.Fatal("authbridge-runtime-config volume not found")
+}
+
+func TestOverrideAuthBridgeConfigMapInVolumes(t *testing.T) {
+	original := BuildRequiredVolumes()
+	overridden := overrideAuthBridgeConfigMapInVolumes(original, "authbridge-config-my-agent")
+
+	// Original should be unchanged
+	for _, v := range original {
+		if v.Name == "authbridge-runtime-config" && v.ConfigMap != nil {
+			if v.ConfigMap.LocalObjectReference.Name != AuthBridgeRuntimeConfigMapName {
+				t.Errorf("original was mutated: got %q", v.ConfigMap.LocalObjectReference.Name)
+			}
+		}
+	}
+
+	// Overridden should have the new name
+	for _, v := range overridden {
+		if v.Name == "authbridge-runtime-config" && v.ConfigMap != nil {
+			if v.ConfigMap.LocalObjectReference.Name != "authbridge-config-my-agent" {
+				t.Errorf("override failed: got %q, want %q",
+					v.ConfigMap.LocalObjectReference.Name, "authbridge-config-my-agent")
+			}
+			return
+		}
+	}
+	t.Fatal("authbridge-runtime-config volume not found in overridden volumes")
 }

--- a/kagenti-operator/internal/webhook/v1alpha1/authbridge_webhook.go
+++ b/kagenti-operator/internal/webhook/v1alpha1/authbridge_webhook.go
@@ -39,7 +39,8 @@ type AuthBridgeWebhook struct {
 }
 
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;create;update
-// +kubebuilder:rbac:groups=core,resources=namespaces;secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 
 // SetupAuthBridgeWebhookWithManager registers the authbridge webhook with the manager
 func SetupAuthBridgeWebhookWithManager(mgr ctrl.Manager, mutator *injector.PodMutator) error {

--- a/kagenti-operator/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/kagenti-operator/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -123,6 +123,7 @@ var _ = BeforeSuite(func() {
 	// Create pod mutator for tests
 	podMutator := injector.NewPodMutator(
 		k8sClient,
+		mgr.GetScheme(),
 		true,
 		func() *config.PlatformConfig { return config.CompiledDefaults() },
 		func() *config.FeatureGates { return config.DefaultFeatureGates() },

--- a/kagenti-operator/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/kagenti-operator/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -124,7 +124,6 @@ var _ = BeforeSuite(func() {
 	podMutator := injector.NewPodMutator(
 		k8sClient,
 		k8sClient,
-		mgr.GetScheme(),
 		true,
 		func() *config.PlatformConfig { return config.CompiledDefaults() },
 		func() *config.FeatureGates { return config.DefaultFeatureGates() },

--- a/kagenti-operator/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/kagenti-operator/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -123,6 +123,7 @@ var _ = BeforeSuite(func() {
 	// Create pod mutator for tests
 	podMutator := injector.NewPodMutator(
 		k8sClient,
+		k8sClient,
 		mgr.GetScheme(),
 		true,
 		func() *config.PlatformConfig { return config.CompiledDefaults() },

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -589,9 +589,11 @@ var _ = Describe("AuthBridge Injection E2E", Ordered, func() {
 			} else {
 				_, _ = fmt.Fprintf(GinkgoWriter, "=== per-agent ConfigMap not found: %v ===\n", diagErr)
 			}
+			statusJSONPath := "{range .status.containerStatuses[*]}" +
+				"{.name}: ready={.ready} restarts={.restartCount} state={.state}{\"\\n\"}{end}"
 			diagCmd = exec.Command("kubectl", "get", "pod", podName,
 				"-n", authBridgeTestNamespace,
-				"-o", "jsonpath={range .status.containerStatuses[*]}{.name}: ready={.ready} restarts={.restartCount} state={.state}{\"\\n\"}{end}")
+				"-o", "jsonpath="+statusJSONPath)
 			if statuses, diagErr := utils.Run(diagCmd); diagErr == nil {
 				_, _ = fmt.Fprintf(GinkgoWriter, "=== container statuses ===\n%s\n", statuses)
 			}

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -563,11 +563,7 @@ var _ = Describe("AuthBridge Injection E2E", Ordered, func() {
 				g.Expect(output).To(Equal("true"), "envoy-proxy container not ready")
 			}, 3*time.Minute, 2*time.Second).Should(Succeed())
 
-			// Verify envoy admin is responding. The request originates from the echo
-			// container (non-proxy UID) so proxy-init iptables redirect it through
-			// envoy's outbound listener, which forwards to the original destination
-			// 127.0.0.1:9901 (envoy admin). The response is genuinely from envoy admin.
-			By("hitting envoy admin interface from the echo container")
+			By("getting pod name")
 			var podName string
 			cmd := exec.Command("kubectl", "get", "pods",
 				"-l", "app.kubernetes.io/name=authbridge-agent",
@@ -577,6 +573,34 @@ var _ = Describe("AuthBridge Injection E2E", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			podName = strings.TrimSpace(podName)
 
+			By("collecting diagnostic logs before envoy admin test")
+			diagCmd := exec.Command("kubectl", "logs", podName,
+				"-n", authBridgeTestNamespace,
+				"-c", "envoy-proxy", "--tail=30")
+			if envoyLogs, diagErr := utils.Run(diagCmd); diagErr == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "=== envoy-proxy logs (last 30) ===\n%s\n", envoyLogs)
+			}
+			diagCmd = exec.Command("kubectl", "get", "configmap",
+				"authbridge-config-authbridge-agent",
+				"-n", authBridgeTestNamespace,
+				"-o", "jsonpath={.data.config\\.yaml}")
+			if cmData, diagErr := utils.Run(diagCmd); diagErr == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "=== per-agent ConfigMap ===\n%s\n", cmData)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "=== per-agent ConfigMap not found: %v ===\n", diagErr)
+			}
+			diagCmd = exec.Command("kubectl", "get", "pod", podName,
+				"-n", authBridgeTestNamespace,
+				"-o", "jsonpath={range .status.containerStatuses[*]}{.name}: ready={.ready} restarts={.restartCount} state={.state}{\"\\n\"}{end}")
+			if statuses, diagErr := utils.Run(diagCmd); diagErr == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "=== container statuses ===\n%s\n", statuses)
+			}
+
+			// Verify envoy admin is responding. The request originates from the echo
+			// container (non-proxy UID) so proxy-init iptables redirect it through
+			// envoy's outbound listener, which forwards to the original destination
+			// 127.0.0.1:9901 (envoy admin). The response is genuinely from envoy admin.
+			By("hitting envoy admin interface from the echo container")
 			cmd = exec.Command("kubectl", "exec", podName,
 				"-n", authBridgeTestNamespace,
 				"-c", "echo",

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -581,7 +581,7 @@ var _ = Describe("AuthBridge Injection E2E", Ordered, func() {
 				_, _ = fmt.Fprintf(GinkgoWriter, "=== envoy-proxy logs (last 30) ===\n%s\n", envoyLogs)
 			}
 			diagCmd = exec.Command("kubectl", "get", "configmap",
-				"authbridge-config-authbridge-agent",
+				authBridgeAgentCMName,
 				"-n", authBridgeTestNamespace,
 				"-o", "jsonpath={.data.config\\.yaml}")
 			if cmData, diagErr := utils.Run(diagCmd); diagErr == nil {

--- a/kagenti-operator/test/e2e/fixtures.go
+++ b/kagenti-operator/test/e2e/fixtures.go
@@ -18,6 +18,8 @@ package e2e
 
 const testNamespace = "e2e-agentcard-test"
 const authBridgeTestNamespace = "e2e-authbridge-test"
+const authBridgeAgentName = "authbridge-agent"
+const authBridgeAgentCMName = "authbridge-config-" + authBridgeAgentName
 
 // echoAgentFixture returns YAML for echo-agent Deployment + Service (used by S1, S3).
 func echoAgentFixture() string {


### PR DESCRIPTION
## Summary

- Operator creates a per-agent ConfigMap (`authbridge-config-<name>`) at pod injection time
- Reads the namespace-level `authbridge-runtime-config`, merges in mode + per-agent listener addresses
- Authbridge sidecar mounts the per-agent ConfigMap instead of the shared one
- Removes `REVERSE_PROXY_ADDR`, `REVERSE_PROXY_BACKEND`, `FORWARD_PROXY_ADDR` env vars and `--mode` flag from the proxy-sidecar container (all now in the per-agent ConfigMap)

## Context

Listener addresses are per-agent (port-stealing assigns dynamic ports) but the shared ConfigMap is per-namespace. Previously we used `${ENV_VAR}` placeholders in the shared ConfigMap, which broke validation when env vars were unset in other modes.

The three-layer ConfigMap flow:
1. **Helm** creates `authbridge-runtime-config` per namespace (defaults)
2. **Backend** creates `authbridge-runtime-config` for runtime namespaces (same defaults)
3. **Operator** reads it at injection, merges per-agent config, writes `authbridge-config-<agent>`

## Files changed

| File | Change |
|------|--------|
| `namespace_config.go` | Read `authbridge-runtime-config` ConfigMap |
| `resolved_config.go` | Propagate `AuthBridgeRuntimeYAML` |
| `pod_mutator.go` | `ensurePerAgentConfigMap()` + call sites for both modes |
| `volume_builder.go` | Parameterize authbridge ConfigMap name, `overrideAuthBridgeConfigMapInVolumes` |
| `container_builder.go` | Remove listener env vars and `--mode` from proxy-sidecar |
| `*_test.go` | Updated tests for new behavior |

## Test plan

- [x] `go test ./internal/webhook/injector/` — all pass
- [x] `go vet` — clean
- [x] `gofmt` — clean
- [ ] E2E: deploy agent with default mode → per-agent ConfigMap with `mode: envoy-sidecar`
- [ ] E2E: deploy with `kagenti.io/authbridge-mode=proxy-sidecar` → per-agent ConfigMap with listener addresses

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>