### PR TITLE
fix: Proxy-sidecar reinvocation check and routes volume mount

### DIFF
--- a/kagenti-operator/internal/webhook/injector/container_builder.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder.go
@@ -463,6 +463,11 @@ func (b *ContainerBuilder) BuildProxySidecarContainerWithPorts(spireEnabled bool
 			MountPath: "/etc/authbridge",
 			ReadOnly:  true,
 		},
+		{
+			Name:      AuthproxyRoutesConfigMapName,
+			MountPath: "/etc/authproxy",
+			ReadOnly:  true,
+		},
 	}
 	if spireEnabled {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{

--- a/kagenti-operator/internal/webhook/v1alpha1/authbridge_webhook.go
+++ b/kagenti-operator/internal/webhook/v1alpha1/authbridge_webhook.go
@@ -174,6 +174,7 @@ func (w *AuthBridgeWebhook) isAlreadyInjected(podSpec *corev1.PodSpec) bool {
 	// containerExists/volumeExists checks for idempotency).
 	for i := range podSpec.Containers {
 		if podSpec.Containers[i].Name == injector.EnvoyProxyContainerName ||
+			podSpec.Containers[i].Name == injector.AuthBridgeProxyContainerName ||
 			podSpec.Containers[i].Name == injector.SpiffeHelperContainerName ||
 			podSpec.Containers[i].Name == injector.ClientRegistrationContainerName ||
 			podSpec.Containers[i].Name == injector.AuthBridgeContainerName {


### PR DESCRIPTION
## Summary

- Add `AuthBridgeProxyContainerName` to `isAlreadyInjected` check in the webhook handler
- Add `authproxy-routes` volume mount to `BuildProxySidecarContainerWithPorts`

## Bugs found during end-to-end testing

**1. Reinvocation gap**: `isAlreadyInjected` checked for envoy-proxy, spiffe-helper, client-registration, and authbridge containers — but not authbridge-proxy. If spiffe-helper is disabled, webhook reinvocation would not recognize the proxy-sidecar container and could double-inject.

**2. Missing routes volume**: The proxy-sidecar container only mounted shared-data, authbridge-runtime-config, and svid-output. The authproxy-routes ConfigMap (`/etc/authproxy/routes.yaml`) was not mounted, so file-based route loading was broken. Inline routes via `routes.rules` in the ConfigMap worked as a workaround.

## Test plan

- [x] `go build` — passes
- [x] `go test ./internal/webhook/injector/` — passes
- [x] `golangci-lint` — 0 issues
- [ ] E2E: deploy with proxy-sidecar mode + authproxy-routes ConfigMap, verify routes are loaded from file

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>