### PR TITLE
fix: Auto-create authbridge ConfigMaps in agent namespaces from templates

### DIFF
--- a/kagenti-operator/cmd/main.go
+++ b/kagenti-operator/cmd/main.go
@@ -359,9 +359,10 @@ func main() {
 	}
 
 	if err = (&controller.AgentRuntimeReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("agentruntime-controller"),
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Scheme:    mgr.GetScheme(),
+		Recorder:  mgr.GetEventRecorderFor("agentruntime-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AgentRuntime")
 		os.Exit(1)

--- a/kagenti-operator/internal/controller/agentruntime_controller.go
+++ b/kagenti-operator/internal/controller/agentruntime_controller.go
@@ -57,8 +57,9 @@ const (
 // AgentRuntimeReconciler reconciles AgentRuntime objects.
 type AgentRuntimeReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
+	Scheme    *runtime.Scheme
+	Recorder  record.EventRecorder
+	APIReader client.Reader // uncached reader for cross-namespace ConfigMap reads
 }
 
 // +kubebuilder:rbac:groups=agent.kagenti.dev,resources=agentruntimes,verbs=get;list;watch;create;update;patch;delete
@@ -66,7 +67,7 @@ type AgentRuntimeReconciler struct {
 // +kubebuilder:rbac:groups=agent.kagenti.dev,resources=agentruntimes/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
@@ -111,6 +112,16 @@ func (r *AgentRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	r.setCondition(rt, ConditionTypeTargetResolved, metav1.ConditionTrue, "TargetFound",
 		fmt.Sprintf("%s %s resolved", rt.Spec.TargetRef.Kind, rt.Spec.TargetRef.Name))
+
+	// 4.5. Ensure required authbridge ConfigMaps exist in the namespace.
+	// Copies templates from kagenti-system if missing, matching the backend's
+	// _ensure_authbridge_configmaps() semantics (create-if-not-exists).
+	if err := r.ensureNamespaceConfigMaps(ctx, rt.Namespace); err != nil {
+		logger.Error(err, "Failed to ensure namespace ConfigMaps")
+		if r.Recorder != nil {
+			r.Recorder.Event(rt, corev1.EventTypeWarning, "ConfigMapEnsureError", err.Error())
+		}
+	}
 
 	// 5. Compute config hash from merged configuration (cluster → namespace → CR)
 	configResult, err := ComputeConfigHash(ctx, r.Client, rt.Namespace, &rt.Spec)
@@ -388,6 +399,73 @@ func (r *AgentRuntimeReconciler) setCondition(rt *agentv1alpha1.AgentRuntime, co
 		Reason:             reason,
 		Message:            message,
 	})
+}
+
+// templateConfigMapNames lists the well-known ConfigMaps that authbridge sidecars
+// require. The Helm chart and backend API create these in agent namespaces; the
+// operator copies templates from kagenti-system for namespaces created by other
+// means (GitOps, manual kubectl).
+var templateConfigMapNames = []string{
+	"authbridge-config",
+	"authbridge-runtime-config",
+	"envoy-config",
+	"spiffe-helper-config",
+}
+
+// ensureNamespaceConfigMaps copies template ConfigMaps from kagenti-system to the
+// target namespace if they don't already exist. This mirrors the backend's
+// ensure_configmap() semantics: create-if-not-exists, preserving user customizations.
+func (r *AgentRuntimeReconciler) ensureNamespaceConfigMaps(ctx context.Context, namespace string) error {
+	logger := log.FromContext(ctx)
+	reader := r.uncachedReader()
+
+	for _, name := range templateConfigMapNames {
+		existing := &corev1.ConfigMap{}
+		err := reader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, existing)
+		if err == nil {
+			continue
+		}
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to check ConfigMap %s/%s: %w", namespace, name, err)
+		}
+
+		template := &corev1.ConfigMap{}
+		templateKey := client.ObjectKey{Namespace: ClusterDefaultsNamespace, Name: name}
+		if err := reader.Get(ctx, templateKey, template); err != nil {
+			if apierrors.IsNotFound(err) {
+				logger.V(1).Info("Template ConfigMap not found in kagenti-system, skipping",
+					"name", name)
+				continue
+			}
+			return fmt.Errorf("failed to read template ConfigMap %s/%s: %w", ClusterDefaultsNamespace, name, err)
+		}
+
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels: map[string]string{
+					LabelManagedBy: LabelManagedByValue,
+				},
+			},
+			Data: template.Data,
+		}
+		if err := r.Create(ctx, cm); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				continue
+			}
+			return fmt.Errorf("failed to create ConfigMap %s/%s: %w", namespace, name, err)
+		}
+		logger.Info("Created ConfigMap from template", "namespace", namespace, "name", name)
+	}
+	return nil
+}
+
+func (r *AgentRuntimeReconciler) uncachedReader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
 }
 
 // mapWorkloadToAgentRuntime maps workload events to AgentRuntime reconcile requests.

--- a/kagenti-operator/internal/controller/agentruntime_controller_test.go
+++ b/kagenti-operator/internal/controller/agentruntime_controller_test.go
@@ -86,8 +86,9 @@ var _ = Describe("AgentRuntime Controller", func() {
 
 	newReconciler := func() *AgentRuntimeReconciler {
 		return &AgentRuntimeReconciler{
-			Client: k8sClient,
-			Scheme: scheme.Scheme,
+			Client:    k8sClient,
+			APIReader: k8sClient,
+			Scheme:    scheme.Scheme,
 		}
 	}
 
@@ -505,6 +506,135 @@ var _ = Describe("AgentRuntime Controller", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(ctrl.Result{}))
+		})
+	})
+
+	Context("When ensuring namespace ConfigMaps", func() {
+		const cmTestNS = "cm-test-ns"
+
+		BeforeEach(func() {
+			// Create the kagenti-system namespace for templates
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ClusterDefaultsNamespace}}
+			_ = k8sClient.Create(ctx, ns)
+
+			// Create the test namespace
+			testNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cmTestNS}}
+			_ = k8sClient.Create(ctx, testNS)
+		})
+
+		AfterEach(func() {
+			for _, name := range templateConfigMapNames {
+				cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ClusterDefaultsNamespace}}
+				_ = k8sClient.Delete(ctx, cm)
+				cm = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: cmTestNS}}
+				_ = k8sClient.Delete(ctx, cm)
+			}
+		})
+
+		It("should create missing ConfigMaps from templates", func() {
+			// Create template ConfigMaps in kagenti-system
+			for _, name := range templateConfigMapNames {
+				cm := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: ClusterDefaultsNamespace,
+					},
+					Data: map[string]string{"config.yaml": "template-content-" + name},
+				}
+				Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+			}
+
+			r := newReconciler()
+			Expect(r.ensureNamespaceConfigMaps(ctx, cmTestNS)).To(Succeed())
+
+			for _, name := range templateConfigMapNames {
+				created := &corev1.ConfigMap{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: cmTestNS}, created)).To(Succeed())
+				Expect(created.Data["config.yaml"]).To(Equal("template-content-" + name))
+				Expect(created.Labels[LabelManagedBy]).To(Equal(LabelManagedByValue))
+			}
+		})
+
+		It("should skip ConfigMaps that already exist", func() {
+			// Create template in kagenti-system
+			template := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "authbridge-config",
+					Namespace: ClusterDefaultsNamespace,
+				},
+				Data: map[string]string{"KEYCLOAK_URL": "http://template-url"},
+			}
+			Expect(k8sClient.Create(ctx, template)).To(Succeed())
+
+			// Pre-create in target namespace with custom content
+			existing := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "authbridge-config",
+					Namespace: cmTestNS,
+				},
+				Data: map[string]string{"KEYCLOAK_URL": "http://custom-url"},
+			}
+			Expect(k8sClient.Create(ctx, existing)).To(Succeed())
+
+			r := newReconciler()
+			Expect(r.ensureNamespaceConfigMaps(ctx, cmTestNS)).To(Succeed())
+
+			// Verify custom content was preserved
+			result := &corev1.ConfigMap{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "authbridge-config", Namespace: cmTestNS}, result)).To(Succeed())
+			Expect(result.Data["KEYCLOAK_URL"]).To(Equal("http://custom-url"))
+		})
+
+		It("should skip gracefully when templates are missing", func() {
+			r := newReconciler()
+			Expect(r.ensureNamespaceConfigMaps(ctx, cmTestNS)).To(Succeed())
+
+			// Verify no ConfigMaps were created
+			for _, name := range templateConfigMapNames {
+				cm := &corev1.ConfigMap{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: cmTestNS}, cm)
+				Expect(err).To(HaveOccurred())
+			}
+		})
+
+		It("should only create missing ConfigMaps when some already exist", func() {
+			// Create all templates in kagenti-system
+			for _, name := range templateConfigMapNames {
+				cm := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: ClusterDefaultsNamespace,
+					},
+					Data: map[string]string{"config.yaml": "template-" + name},
+				}
+				Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+			}
+
+			// Pre-create only authbridge-config in target namespace
+			existing := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "authbridge-config",
+					Namespace: cmTestNS,
+				},
+				Data: map[string]string{"KEYCLOAK_URL": "http://existing"},
+			}
+			Expect(k8sClient.Create(ctx, existing)).To(Succeed())
+
+			r := newReconciler()
+			Expect(r.ensureNamespaceConfigMaps(ctx, cmTestNS)).To(Succeed())
+
+			// authbridge-config should keep its original content
+			abCfg := &corev1.ConfigMap{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "authbridge-config", Namespace: cmTestNS}, abCfg)).To(Succeed())
+			Expect(abCfg.Data["KEYCLOAK_URL"]).To(Equal("http://existing"))
+
+			// The other 3 should be created from templates
+			for _, name := range []string{"authbridge-runtime-config", "envoy-config", "spiffe-helper-config"} {
+				cm := &corev1.ConfigMap{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: cmTestNS}, cm)).To(Succeed())
+				Expect(cm.Data["config.yaml"]).To(Equal("template-" + name))
+				Expect(cm.Labels[LabelManagedBy]).To(Equal(LabelManagedByValue))
+			}
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- AgentRuntime controller now copies 4 template ConfigMaps (`authbridge-config`, `authbridge-runtime-config`, `envoy-config`, `spiffe-helper-config`) from `kagenti-system` to agent namespaces during reconciliation
- Create-if-not-exists semantics — existing ConfigMaps (user/Helm/backend-created) are never overwritten
- Templates are read via uncached APIReader (same pattern as `ClientRegistrationReconciler` and `PodMutator`)
- Non-fatal: if template creation fails, reconciliation continues and the webhook/kubelet surfaces the error at pod time

## Merge order

> **Merge the Helm chart PR first:** https://github.com/kagenti/kagenti/pull/1350
>
> That PR creates the template ConfigMaps in `kagenti-system`. This operator PR copies them to agent namespaces. The operator gracefully no-ops when templates are absent (logs at V(1) and skips), so merging in either order is safe — but the fix only works once both are in.

Fixes https://github.com/kagenti/kagenti/issues/1336 (part 2 of 2)

## Changes

| File | Change |
|------|--------|
| `internal/controller/agentruntime_controller.go` | Add `APIReader` field, `ensureNamespaceConfigMaps()`, RBAC annotation update |
| `cmd/main.go` | Wire `APIReader: mgr.GetAPIReader()` |
| `internal/controller/agentruntime_controller_test.go` | 4 test cases (create from templates, skip existing, skip when no templates, partial creation) |

## Test plan

- [x] All 155 controller tests pass
- [x] All webhook/injector tests pass
- [x] `go build ./...` succeeds
- [ ] Manual E2E: create namespace without ConfigMaps, deploy AgentRuntime, verify ConfigMaps appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)