### PR TITLE
feat: add Sandbox workload support to AgentRuntime controller

### DIFF
--- a/charts/kagenti-operator/templates/rbac/role.yaml
+++ b/charts/kagenti-operator/templates/rbac/role.yaml
@@ -91,6 +91,24 @@ rules:
   - patch
   - update
 - apiGroups:
+  - agents.x-k8s.io
+  resources:
+  - sandboxes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - agents.x-k8s.io
+  resources:
+  - sandboxes/scale
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/kagenti-operator/config/rbac/role.yaml
+++ b/kagenti-operator/config/rbac/role.yaml
@@ -80,6 +80,24 @@ rules:
   - patch
   - update
 - apiGroups:
+  - agents.x-k8s.io
+  resources:
+  - sandboxes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - agents.x-k8s.io
+  resources:
+  - sandboxes/scale
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/kagenti-operator/internal/controller/agentruntime_controller.go
+++ b/kagenti-operator/internal/controller/agentruntime_controller.go
@@ -49,6 +49,11 @@ const (
 	// AnnotationConfigHash is the annotation applied to PodTemplateSpec to trigger rolling updates.
 	AnnotationConfigHash = "kagenti.io/config-hash"
 
+	// AnnotationRestartPending marks a Sandbox that was scaled to 0 and needs
+	// to be scaled back to 1 on the next reconcile cycle. Two-phase restart
+	// avoids a race with the Sandbox controller's pod-name annotation.
+	AnnotationRestartPending = "kagenti.io/restart-pending"
+
 	// Condition types for AgentRuntime status.
 	ConditionTypeReady          = "Ready"
 	ConditionTypeTargetResolved = "TargetResolved"
@@ -121,6 +126,13 @@ func (r *AgentRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	r.setCondition(rt, ConditionTypeTargetResolved, metav1.ConditionTrue, "TargetFound",
 		fmt.Sprintf("%s %s resolved", rt.Spec.TargetRef.Kind, rt.Spec.TargetRef.Name))
+
+	// 4.1. Complete two-phase Sandbox restart if pending.
+	if rt.Spec.TargetRef.Kind == "Sandbox" {
+		if result, done, err := r.completeSandboxRestart(ctx, rt); done {
+			return result, err
+		}
+	}
 
 	// 4.5. Ensure required authbridge ConfigMaps exist in the namespace.
 	// Copies templates from kagenti-system if missing, matching the backend's
@@ -293,64 +305,94 @@ func (r *AgentRuntimeReconciler) applyWorkloadConfig(ctx context.Context, rt *ag
 	}
 
 	// Sandbox pods don't restart on podTemplate changes (upstream limitation).
-	// Trigger a restart by scaling replicas 0 → 1 when config actually changed.
+	// Phase 1: scale to 0 and mark restart-pending. Phase 2 runs on the next
+	// reconcile (triggered by the Sandbox watch) to clear stale annotations
+	// and scale back to 1. Two-phase avoids a race with the Sandbox controller.
 	if ref.Kind == "Sandbox" && configHashChanged {
-		if err := r.restartSandbox(ctx, key); err != nil {
-			return fmt.Errorf("sandbox restart failed: %w", err)
+		if err := r.beginSandboxRestart(ctx, key); err != nil {
+			return fmt.Errorf("sandbox restart (phase 1) failed: %w", err)
 		}
 	}
 
 	return nil
 }
 
-// restartSandbox performs a scale 0→1 cycle to restart a Sandbox pod.
-// Sandbox pods don't roll out on podTemplate changes, so this is the
-// workaround for applying config changes that require a pod restart.
-func (r *AgentRuntimeReconciler) restartSandbox(ctx context.Context, key types.NamespacedName) error {
+// beginSandboxRestart is phase 1 of a two-phase Sandbox restart.
+// It scales the Sandbox to 0 replicas and sets the restart-pending annotation.
+// Phase 2 (completeSandboxRestart) runs on the next reconcile to clear the
+// stale pod-name annotation and scale back to 1.
+func (r *AgentRuntimeReconciler) beginSandboxRestart(ctx context.Context, key types.NamespacedName) error {
 	logger := log.FromContext(ctx)
-	logger.Info("Restarting Sandbox via scale 0→1", "sandbox", key.Name)
+	logger.Info("Sandbox restart phase 1: scaling to 0", "sandbox", key.Name)
 
-	patchScale := func(replicas int64) error {
-		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			obj := &unstructured.Unstructured{}
-			obj.SetGroupVersionKind(sandboxGVK)
-			if err := r.Get(ctx, key, obj); err != nil {
-				return err
-			}
-			if err := unstructured.SetNestedField(obj.Object, replicas, "spec", "replicas"); err != nil {
-				return err
-			}
-			return r.Update(ctx, obj)
-		})
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(sandboxGVK)
+		if err := r.Get(ctx, key, obj); err != nil {
+			return err
+		}
+		if err := unstructured.SetNestedField(obj.Object, int64(0), "spec", "replicas"); err != nil {
+			return err
+		}
+		annotations := obj.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[AnnotationRestartPending] = "true"
+		obj.SetAnnotations(annotations)
+		return r.Update(ctx, obj)
+	})
+}
+
+// completeSandboxRestart is phase 2 of a two-phase Sandbox restart.
+// It checks for the restart-pending annotation on a Sandbox with replicas=0,
+// clears the stale pod-name annotation, removes restart-pending, and scales
+// back to 1. Returns (result, true, err) if it handled the restart, or
+// (_, false, nil) if no restart was pending.
+func (r *AgentRuntimeReconciler) completeSandboxRestart(ctx context.Context, rt *agentv1alpha1.AgentRuntime) (ctrl.Result, bool, error) {
+	logger := log.FromContext(ctx)
+	ref := rt.Spec.TargetRef
+	key := types.NamespacedName{Name: ref.Name, Namespace: rt.Namespace}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(sandboxGVK)
+	if err := r.Get(ctx, key, obj); err != nil {
+		return ctrl.Result{}, false, nil
 	}
 
-	if err := patchScale(0); err != nil {
-		return fmt.Errorf("scale to 0: %w", err)
+	annotations := obj.GetAnnotations()
+	if annotations[AnnotationRestartPending] != "true" {
+		return ctrl.Result{}, false, nil
 	}
 
-	// The Sandbox controller tracks the adopted pod via an annotation.
-	// Clear it so the controller creates a fresh pod on scale-up.
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	logger.Info("Sandbox restart phase 2: clearing pod-name and scaling to 1", "sandbox", key.Name)
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		obj := &unstructured.Unstructured{}
 		obj.SetGroupVersionKind(sandboxGVK)
 		if err := r.Get(ctx, key, obj); err != nil {
 			return err
 		}
 		annotations := obj.GetAnnotations()
-		if annotations != nil {
-			delete(annotations, "agents.x-k8s.io/pod-name")
-			obj.SetAnnotations(annotations)
-			return r.Update(ctx, obj)
+		delete(annotations, "agents.x-k8s.io/pod-name")
+		delete(annotations, AnnotationRestartPending)
+		obj.SetAnnotations(annotations)
+		if err := unstructured.SetNestedField(obj.Object, int64(1), "spec", "replicas"); err != nil {
+			return err
 		}
-		return nil
-	}); err != nil {
-		logger.Info("Failed to clear pod-name annotation, proceeding with scale-up", "error", err)
+		return r.Update(ctx, obj)
+	})
+	if err != nil {
+		logger.Error(err, "Sandbox restart phase 2 failed, will retry")
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, true, nil
 	}
 
-	if err := patchScale(1); err != nil {
-		return fmt.Errorf("scale to 1: %w", err)
+	if r.Recorder != nil {
+		r.Recorder.Event(rt, corev1.EventTypeNormal, "SandboxRestarted",
+			fmt.Sprintf("Sandbox %s restarted via scale 0→1", ref.Name))
 	}
-	return nil
+
+	return ctrl.Result{RequeueAfter: 5 * time.Second}, true, nil
 }
 
 // countConfiguredPods counts pods that have the kagenti.io/type label matching the runtime type.

--- a/kagenti-operator/internal/controller/agentruntime_controller.go
+++ b/kagenti-operator/internal/controller/agentruntime_controller.go
@@ -311,20 +311,42 @@ func (r *AgentRuntimeReconciler) restartSandbox(ctx context.Context, key types.N
 	logger.Info("Restarting Sandbox via scale 0→1", "sandbox", key.Name)
 
 	patchScale := func(replicas int64) error {
-		obj := &unstructured.Unstructured{}
-		obj.SetGroupVersionKind(sandboxGVK)
-		if err := r.Get(ctx, key, obj); err != nil {
-			return err
-		}
-		if err := unstructured.SetNestedField(obj.Object, replicas, "spec", "replicas"); err != nil {
-			return err
-		}
-		return r.Update(ctx, obj)
+		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			obj := &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(sandboxGVK)
+			if err := r.Get(ctx, key, obj); err != nil {
+				return err
+			}
+			if err := unstructured.SetNestedField(obj.Object, replicas, "spec", "replicas"); err != nil {
+				return err
+			}
+			return r.Update(ctx, obj)
+		})
 	}
 
 	if err := patchScale(0); err != nil {
 		return fmt.Errorf("scale to 0: %w", err)
 	}
+
+	// The Sandbox controller tracks the adopted pod via an annotation.
+	// Clear it so the controller creates a fresh pod on scale-up.
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(sandboxGVK)
+		if err := r.Get(ctx, key, obj); err != nil {
+			return err
+		}
+		annotations := obj.GetAnnotations()
+		if annotations != nil {
+			delete(annotations, "agents.x-k8s.io/pod-name")
+			obj.SetAnnotations(annotations)
+			return r.Update(ctx, obj)
+		}
+		return nil
+	}); err != nil {
+		logger.Info("Failed to clear pod-name annotation, proceeding with scale-up", "error", err)
+	}
+
 	if err := patchScale(1); err != nil {
 		return fmt.Errorf("scale to 1: %w", err)
 	}

--- a/kagenti-operator/internal/controller/agentruntime_controller.go
+++ b/kagenti-operator/internal/controller/agentruntime_controller.go
@@ -31,6 +31,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -685,12 +687,27 @@ func (r *AgentRuntimeReconciler) mapConfigMapToAgentRuntimes(ctx context.Context
 	return r.mapNamespaceConfigMapToAgentRuntimes(ctx, obj)
 }
 
+// SandboxCRDExists checks whether the agent-sandbox CRD is installed on the cluster.
+func SandboxCRDExists(cfg *rest.Config) bool {
+	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return false
+	}
+	resources, err := dc.ServerResourcesForGroupVersion("agents.x-k8s.io/v1alpha1")
+	if err != nil {
+		return false
+	}
+	for _, r := range resources.APIResources {
+		if r.Kind == KindSandbox {
+			return true
+		}
+	}
+	return false
+}
+
 // SetupWithManager registers the AgentRuntime controller with the manager.
 func (r *AgentRuntimeReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	sandboxObj := &unstructured.Unstructured{}
-	sandboxObj.SetGroupVersionKind(sandboxGVK)
-
-	return ctrl.NewControllerManagedBy(mgr).
+	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&agentv1alpha1.AgentRuntime{}).
 		Watches(
 			&appsv1.Deployment{},
@@ -701,13 +718,20 @@ func (r *AgentRuntimeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.mapWorkloadToAgentRuntime("apps/v1", "StatefulSet")),
 		).
 		Watches(
-			sandboxObj,
-			handler.EnqueueRequestsFromMapFunc(r.mapWorkloadToAgentRuntime("agents.x-k8s.io/v1alpha1", KindSandbox)),
-		).
-		Watches(
 			&corev1.ConfigMap{},
 			handler.EnqueueRequestsFromMapFunc(r.mapConfigMapToAgentRuntimes),
-		).
+		)
+
+	if SandboxCRDExists(mgr.GetConfig()) {
+		sandboxObj := &unstructured.Unstructured{}
+		sandboxObj.SetGroupVersionKind(sandboxGVK)
+		builder = builder.Watches(
+			sandboxObj,
+			handler.EnqueueRequestsFromMapFunc(r.mapWorkloadToAgentRuntime("agents.x-k8s.io/v1alpha1", KindSandbox)),
+		)
+	}
+
+	return builder.
 		Named("agentruntime").
 		Complete(r)
 }

--- a/kagenti-operator/internal/controller/agentruntime_controller.go
+++ b/kagenti-operator/internal/controller/agentruntime_controller.go
@@ -27,6 +27,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -54,6 +55,12 @@ const (
 	ConditionTypeConfigResolved = "ConfigResolved"
 )
 
+var sandboxGVK = schema.GroupVersionKind{
+	Group:   "agents.x-k8s.io",
+	Version: "v1alpha1",
+	Kind:    "Sandbox",
+}
+
 // AgentRuntimeReconciler reconciles AgentRuntime objects.
 type AgentRuntimeReconciler struct {
 	client.Client
@@ -67,6 +74,8 @@ type AgentRuntimeReconciler struct {
 // +kubebuilder:rbac:groups=agent.kagenti.dev,resources=agentruntimes/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes/scale,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
@@ -221,7 +230,9 @@ func (r *AgentRuntimeReconciler) applyWorkloadConfig(ctx context.Context, rt *ag
 
 	key := types.NamespacedName{Name: ref.Name, Namespace: rt.Namespace}
 
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	var configHashChanged bool
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		if err := r.Get(ctx, key, acc.obj); err != nil {
 			return err
 		}
@@ -239,6 +250,10 @@ func (r *AgentRuntimeReconciler) applyWorkloadConfig(ctx context.Context, rt *ag
 		if alreadyConfigured {
 			return nil
 		}
+
+		// Track whether config-hash actually changed (for Sandbox rollout)
+		previousHash := currentPodAnnotations[AnnotationConfigHash]
+		configHashChanged = previousHash != "" && previousHash != configHash
 
 		// Apply labels to workload metadata
 		workloadLabels := acc.obj.GetLabels()
@@ -273,6 +288,47 @@ func (r *AgentRuntimeReconciler) applyWorkloadConfig(ctx context.Context, rt *ag
 
 		return r.Update(ctx, acc.obj)
 	})
+	if err != nil {
+		return err
+	}
+
+	// Sandbox pods don't restart on podTemplate changes (upstream limitation).
+	// Trigger a restart by scaling replicas 0 → 1 when config actually changed.
+	if ref.Kind == "Sandbox" && configHashChanged {
+		if err := r.restartSandbox(ctx, key); err != nil {
+			return fmt.Errorf("sandbox restart failed: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// restartSandbox performs a scale 0→1 cycle to restart a Sandbox pod.
+// Sandbox pods don't roll out on podTemplate changes, so this is the
+// workaround for applying config changes that require a pod restart.
+func (r *AgentRuntimeReconciler) restartSandbox(ctx context.Context, key types.NamespacedName) error {
+	logger := log.FromContext(ctx)
+	logger.Info("Restarting Sandbox via scale 0→1", "sandbox", key.Name)
+
+	patchScale := func(replicas int64) error {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(sandboxGVK)
+		if err := r.Get(ctx, key, obj); err != nil {
+			return err
+		}
+		if err := unstructured.SetNestedField(obj.Object, replicas, "spec", "replicas"); err != nil {
+			return err
+		}
+		return r.Update(ctx, obj)
+	}
+
+	if err := patchScale(0); err != nil {
+		return fmt.Errorf("scale to 0: %w", err)
+	}
+	if err := patchScale(1); err != nil {
+		return fmt.Errorf("scale to 1: %w", err)
+	}
+	return nil
 }
 
 // countConfiguredPods counts pods that have the kagenti.io/type label matching the runtime type.
@@ -297,7 +353,8 @@ func (r *AgentRuntimeReconciler) countConfiguredPods(ctx context.Context, rt *ag
 
 // isPodOwnedByWorkload checks if a pod is transitively owned by the named workload.
 // For Deployments: Pod → ReplicaSet (<deployment>-<pod-template-hash>) → Deployment.
-// We match the deployment name as the prefix before the last "-".
+// For StatefulSets: Pod is directly owned by the StatefulSet.
+// For Sandboxes: Pod is directly owned by the Sandbox CR.
 func isPodOwnedByWorkload(pod *corev1.Pod, workloadName string) bool {
 	for _, ref := range pod.OwnerReferences {
 		if ref.Kind == "ReplicaSet" {
@@ -308,6 +365,9 @@ func isPodOwnedByWorkload(pod *corev1.Pod, workloadName string) bool {
 			}
 		}
 		if ref.Kind == "StatefulSet" && ref.Name == workloadName {
+			return true
+		}
+		if ref.Kind == "Sandbox" && ref.Name == workloadName {
 			return true
 		}
 	}
@@ -557,6 +617,9 @@ func (r *AgentRuntimeReconciler) mapConfigMapToAgentRuntimes(ctx context.Context
 
 // SetupWithManager registers the AgentRuntime controller with the manager.
 func (r *AgentRuntimeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	sandboxObj := &unstructured.Unstructured{}
+	sandboxObj.SetGroupVersionKind(sandboxGVK)
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&agentv1alpha1.AgentRuntime{}).
 		Watches(
@@ -566,6 +629,10 @@ func (r *AgentRuntimeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&appsv1.StatefulSet{},
 			handler.EnqueueRequestsFromMapFunc(r.mapWorkloadToAgentRuntime("apps/v1", "StatefulSet")),
+		).
+		Watches(
+			sandboxObj,
+			handler.EnqueueRequestsFromMapFunc(r.mapWorkloadToAgentRuntime("agents.x-k8s.io/v1alpha1", "Sandbox")),
 		).
 		Watches(
 			&corev1.ConfigMap{},
@@ -617,6 +684,30 @@ func newRuntimePodTemplateAccessor(kind string) (*runtimePodTemplateAccessor, bo
 			},
 			setPodAnnotations: func(o client.Object, a map[string]string) {
 				o.(*appsv1.StatefulSet).Spec.Template.Annotations = a
+			},
+		}, true
+	case "Sandbox":
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(sandboxGVK)
+		return &runtimePodTemplateAccessor{
+			obj: u,
+			getPodLabels: func(o client.Object) map[string]string {
+				u := o.(*unstructured.Unstructured)
+				labels, _, _ := unstructured.NestedStringMap(u.Object, "spec", "podTemplate", "metadata", "labels")
+				return labels
+			},
+			setPodLabels: func(o client.Object, l map[string]string) {
+				u := o.(*unstructured.Unstructured)
+				_ = unstructured.SetNestedStringMap(u.Object, l, "spec", "podTemplate", "metadata", "labels")
+			},
+			getPodAnnotations: func(o client.Object) map[string]string {
+				u := o.(*unstructured.Unstructured)
+				annotations, _, _ := unstructured.NestedStringMap(u.Object, "spec", "podTemplate", "metadata", "annotations")
+				return annotations
+			},
+			setPodAnnotations: func(o client.Object, a map[string]string) {
+				u := o.(*unstructured.Unstructured)
+				_ = unstructured.SetNestedStringMap(u.Object, a, "spec", "podTemplate", "metadata", "annotations")
 			},
 		}, true
 	default:

--- a/kagenti-operator/internal/controller/agentruntime_controller.go
+++ b/kagenti-operator/internal/controller/agentruntime_controller.go
@@ -58,12 +58,18 @@ const (
 	ConditionTypeReady          = "Ready"
 	ConditionTypeTargetResolved = "TargetResolved"
 	ConditionTypeConfigResolved = "ConfigResolved"
+
+	// KindSandbox is the workload kind for agent-sandbox CRs.
+	KindSandbox = "Sandbox"
+
+	// AnnotationRestartPendingValue is the value set on AnnotationRestartPending.
+	AnnotationRestartPendingValue = "true"
 )
 
 var sandboxGVK = schema.GroupVersionKind{
 	Group:   "agents.x-k8s.io",
 	Version: "v1alpha1",
-	Kind:    "Sandbox",
+	Kind:    KindSandbox,
 }
 
 // AgentRuntimeReconciler reconciles AgentRuntime objects.
@@ -128,7 +134,7 @@ func (r *AgentRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		fmt.Sprintf("%s %s resolved", rt.Spec.TargetRef.Kind, rt.Spec.TargetRef.Name))
 
 	// 4.1. Complete two-phase Sandbox restart if pending.
-	if rt.Spec.TargetRef.Kind == "Sandbox" {
+	if rt.Spec.TargetRef.Kind == KindSandbox {
 		if result, done, err := r.completeSandboxRestart(ctx, rt); done {
 			return result, err
 		}
@@ -308,7 +314,7 @@ func (r *AgentRuntimeReconciler) applyWorkloadConfig(ctx context.Context, rt *ag
 	// Phase 1: scale to 0 and mark restart-pending. Phase 2 runs on the next
 	// reconcile (triggered by the Sandbox watch) to clear stale annotations
 	// and scale back to 1. Two-phase avoids a race with the Sandbox controller.
-	if ref.Kind == "Sandbox" && configHashChanged {
+	if ref.Kind == KindSandbox && configHashChanged {
 		if err := r.beginSandboxRestart(ctx, key); err != nil {
 			return fmt.Errorf("sandbox restart (phase 1) failed: %w", err)
 		}
@@ -338,7 +344,7 @@ func (r *AgentRuntimeReconciler) beginSandboxRestart(ctx context.Context, key ty
 		if annotations == nil {
 			annotations = make(map[string]string)
 		}
-		annotations[AnnotationRestartPending] = "true"
+		annotations[AnnotationRestartPending] = AnnotationRestartPendingValue
 		obj.SetAnnotations(annotations)
 		return r.Update(ctx, obj)
 	})
@@ -361,7 +367,7 @@ func (r *AgentRuntimeReconciler) completeSandboxRestart(ctx context.Context, rt 
 	}
 
 	annotations := obj.GetAnnotations()
-	if annotations[AnnotationRestartPending] != "true" {
+	if annotations[AnnotationRestartPending] != AnnotationRestartPendingValue {
 		return ctrl.Result{}, false, nil
 	}
 
@@ -384,7 +390,7 @@ func (r *AgentRuntimeReconciler) completeSandboxRestart(ctx context.Context, rt 
 	})
 	if err != nil {
 		logger.Error(err, "Sandbox restart phase 2 failed, will retry")
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, true, nil
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, true, err
 	}
 
 	if r.Recorder != nil {
@@ -431,7 +437,7 @@ func isPodOwnedByWorkload(pod *corev1.Pod, workloadName string) bool {
 		if ref.Kind == "StatefulSet" && ref.Name == workloadName {
 			return true
 		}
-		if ref.Kind == "Sandbox" && ref.Name == workloadName {
+		if ref.Kind == KindSandbox && ref.Name == workloadName {
 			return true
 		}
 	}
@@ -696,7 +702,7 @@ func (r *AgentRuntimeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		Watches(
 			sandboxObj,
-			handler.EnqueueRequestsFromMapFunc(r.mapWorkloadToAgentRuntime("agents.x-k8s.io/v1alpha1", "Sandbox")),
+			handler.EnqueueRequestsFromMapFunc(r.mapWorkloadToAgentRuntime("agents.x-k8s.io/v1alpha1", KindSandbox)),
 		).
 		Watches(
 			&corev1.ConfigMap{},
@@ -750,7 +756,7 @@ func newRuntimePodTemplateAccessor(kind string) (*runtimePodTemplateAccessor, bo
 				o.(*appsv1.StatefulSet).Spec.Template.Annotations = a
 			},
 		}, true
-	case "Sandbox":
+	case KindSandbox:
 		u := &unstructured.Unstructured{}
 		u.SetGroupVersionKind(sandboxGVK)
 		return &runtimePodTemplateAccessor{

--- a/kagenti-operator/internal/controller/agentruntime_controller_test.go
+++ b/kagenti-operator/internal/controller/agentruntime_controller_test.go
@@ -24,6 +24,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
@@ -635,6 +636,143 @@ var _ = Describe("AgentRuntime Controller", func() {
 				Expect(cm.Data["config.yaml"]).To(Equal("template-" + name))
 				Expect(cm.Labels[LabelManagedBy]).To(Equal(LabelManagedByValue))
 			}
+		})
+	})
+
+	Context("Sandbox workload support", func() {
+		It("should create a Sandbox accessor that reads/writes pod template labels and annotations", func() {
+			acc, ok := newRuntimePodTemplateAccessor("Sandbox")
+			Expect(ok).To(BeTrue())
+			Expect(acc).NotTo(BeNil())
+
+			u := acc.obj.(*unstructured.Unstructured)
+			u.Object = map[string]interface{}{
+				"apiVersion": "agents.x-k8s.io/v1alpha1",
+				"kind":       "Sandbox",
+				"metadata": map[string]interface{}{
+					"name":      "test-sandbox",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{
+					"podTemplate": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels":      map[string]interface{}{"app": "my-agent"},
+							"annotations": map[string]interface{}{"existing": "value"},
+						},
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{"name": "agent", "image": "test:latest"},
+							},
+						},
+					},
+				},
+			}
+
+			// Read existing labels
+			labels := acc.getPodLabels(acc.obj)
+			Expect(labels).To(HaveKeyWithValue("app", "my-agent"))
+
+			// Write new labels
+			labels["kagenti.io/type"] = "agent"
+			acc.setPodLabels(acc.obj, labels)
+
+			// Verify labels were set
+			updatedLabels := acc.getPodLabels(acc.obj)
+			Expect(updatedLabels).To(HaveKeyWithValue("kagenti.io/type", "agent"))
+			Expect(updatedLabels).To(HaveKeyWithValue("app", "my-agent"))
+
+			// Read existing annotations
+			annotations := acc.getPodAnnotations(acc.obj)
+			Expect(annotations).To(HaveKeyWithValue("existing", "value"))
+
+			// Write new annotations
+			annotations[AnnotationConfigHash] = "abc123"
+			acc.setPodAnnotations(acc.obj, annotations)
+
+			// Verify annotations were set
+			updatedAnnotations := acc.getPodAnnotations(acc.obj)
+			Expect(updatedAnnotations).To(HaveKeyWithValue(AnnotationConfigHash, "abc123"))
+			Expect(updatedAnnotations).To(HaveKeyWithValue("existing", "value"))
+		})
+
+		It("should handle Sandbox with no existing pod template metadata", func() {
+			acc, ok := newRuntimePodTemplateAccessor("Sandbox")
+			Expect(ok).To(BeTrue())
+
+			u := acc.obj.(*unstructured.Unstructured)
+			u.Object = map[string]interface{}{
+				"apiVersion": "agents.x-k8s.io/v1alpha1",
+				"kind":       "Sandbox",
+				"metadata": map[string]interface{}{
+					"name":      "test-sandbox-empty",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{
+					"podTemplate": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{"name": "agent", "image": "test:latest"},
+							},
+						},
+					},
+				},
+			}
+
+			// Labels should be nil when no metadata.labels exists
+			labels := acc.getPodLabels(acc.obj)
+			Expect(labels).To(BeNil())
+
+			// Setting labels should work even without existing metadata
+			acc.setPodLabels(acc.obj, map[string]string{"kagenti.io/type": "agent"})
+			labels = acc.getPodLabels(acc.obj)
+			Expect(labels).To(HaveKeyWithValue("kagenti.io/type", "agent"))
+
+			// Annotations should be nil when no metadata.annotations exists
+			annotations := acc.getPodAnnotations(acc.obj)
+			Expect(annotations).To(BeNil())
+
+			// Setting annotations should work
+			acc.setPodAnnotations(acc.obj, map[string]string{AnnotationConfigHash: "hash123"})
+			annotations = acc.getPodAnnotations(acc.obj)
+			Expect(annotations).To(HaveKeyWithValue(AnnotationConfigHash, "hash123"))
+		})
+
+		It("isPodOwnedByWorkload should match Sandbox-owned pods", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-sandbox-pod",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "agents.x-k8s.io/v1alpha1",
+							Kind:       "Sandbox",
+							Name:       "my-sandbox",
+						},
+					},
+				},
+			}
+
+			Expect(isPodOwnedByWorkload(pod, "my-sandbox")).To(BeTrue())
+			Expect(isPodOwnedByWorkload(pod, "other-sandbox")).To(BeFalse())
+		})
+
+		It("isPodOwnedByWorkload should not match Sandbox name against ReplicaSet ownership", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deploy-pod",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "apps/v1",
+							Kind:       "ReplicaSet",
+							Name:       "my-sandbox-abc123",
+						},
+					},
+				},
+			}
+
+			// This matches "my-sandbox" as a Deployment (ReplicaSet prefix match)
+			Expect(isPodOwnedByWorkload(pod, "my-sandbox")).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- Add Sandbox workload support to AgentRuntime controller (unstructured accessor, pod ownership check, RBAC, watch)
- Implement two-phase Sandbox restart for config-driven pod rollout
- Phase 1: scale to 0 + set `kagenti.io/restart-pending` annotation
- Phase 2 (next reconcile): clear `agents.x-k8s.io/pod-name` annotation + remove restart-pending + scale to 1

## Why two-phase restart

The Sandbox controller (kubernetes-sigs/agent-sandbox) tracks its pod via `agents.x-k8s.io/pod-name` annotation. A single-step scale 0→1 causes a race condition where the Sandbox controller enters a stuck error loop because the annotation still points to the deleted pod. The two-phase approach separates scale-down and annotation-clear into different reconciliation windows, avoiding the race with the controller's informer cache.

Upstream issue: kubernetes-sigs/agent-sandbox#581 (pods don't roll out on podTemplate changes)

## Commits

- `3745e25` — initial Sandbox workload support (accessor, ownership check, RBAC, watch)
- `7e22310` — handle Sandbox controller conflicts during restart
- `068ce26` — two-phase restart implementation

## Test plan

- [x] Deploy operator to Kind cluster with Sandbox workload
- [x] Create AgentRuntime with `targetRef.kind: Sandbox`
- [x] Verify config-hash applied to `spec.podTemplate.metadata.annotations`
- [x] Modify watched ConfigMap → verify Phase 1 + Phase 2 in operator logs
- [x] Verify new pod created with updated config
- [x] Verify operator quiescent after restart (no reconcile loop)

Tested end-to-end on Kind cluster with agent-sandbox controller v0.3.10+fix.

Epic: kagenti/kagenti#1155
Companion PR: kagenti/kagenti#1412

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>