### PR TITLE
docs: add setup-kagenti.sh as the recommended OCP installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,27 @@ The operator runs three controllers:
 
 ### Prerequisites
 
-- Kubernetes cluster (v1.28+)
+- Kubernetes cluster (v1.28+) or OpenShift (v4.19+)
 - kubectl configured to access your cluster
 
 ### Install the Operator
 
-Using Helm:
+**Option A — OpenShift (recommended for OCP)**
+
+Use [`scripts/ocp/setup-kagenti.sh`](https://github.com/kagenti/kagenti/blob/main/scripts/ocp/setup-kagenti.sh) from the [kagenti](https://github.com/kagenti/kagenti) repo. It handles RBAC, SCCs, and Helm installation in one step.
+
+By default the script installs the released operator version pinned as a chart dependency in the `kagenti` repo's `charts/kagenti/Chart.yaml`. For development with a local build of this operator, two flags let you override that:
+
+```bash
+# Use a local chart and/or a custom operator image instead of the released version
+./scripts/ocp/setup-kagenti.sh \
+  --operator-repo /path/to/kagenti-operator \
+  --operator-image quay.io/<your-org>/kagenti-operator:dev
+```
+
+`--operator-repo` accepts a local clone of this repository and substitutes its `charts/kagenti-operator` chart in place of the pinned dependency. `--operator-image` overrides the container image the chart pulls.
+
+**Option B — Plain Kubernetes (Helm)**
 
 ```bash
 # Install the operator using OCI chart

--- a/kagenti-operator/GETTING_STARTED.md
+++ b/kagenti-operator/GETTING_STARTED.md
@@ -1,6 +1,6 @@
 # Getting Started with Kagenti Operator
 
-> **Note**: This guide assumes you have already installed the Kagenti platform using the [Kagenti installer](https://github.com/kagenti/kagenti/blob/main/deployments/ansible/README.md).
+> **Note**: This guide assumes you have already installed the Kagenti platform on your cluster. For OpenShift, use [`scripts/ocp/setup-kagenti.sh`](https://github.com/kagenti/kagenti/blob/main/scripts/ocp/setup-kagenti.sh) — the recommended installer for OCP deployments. For plain Kubernetes, install the operator directly via Helm (see the [Quick Start](../README.md#quick-start) in the root README).
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
Updates installation docs in the kagenti-operator repo to reflect that `scripts/ocp/setup-kagenti.sh` is now the recommended way to install Kagenti on OpenShift, replacing the Ansible installer reference. Also documents the `--operator-repo` and `--operator-image` flags for developers working on the operator itself.

## Changes
- `README.md` — added Option A (OCP) and Option B (plain Kubernetes) install paths in Quick Start, with OCP prerequisite version (v4.19+) and dev override flags documented
- `kagenti-operator/GETTING_STARTED.md` — replaced the Ansible installer link with a note pointing OCP users to `setup-kagenti.sh` and plain Kubernetes users to the root README

## Test Plan
- [ ] Verify all links in updated docs resolve correctly
- [ ] Confirm `--operator-repo` and `--operator-image` flags work as described against a local operator build on OCP 4.19+

## Related
https://github.com/kagenti/kagenti/pull/1418 