### PR TITLE
fix: Add allow_mode_override to ext_proc filters in envoy template

### DIFF
--- a/kagenti-operator/internal/webhook/injector/envoy.yaml.tmpl
+++ b/kagenti-operator/internal/webhook/injector/envoy.yaml.tmpl
@@ -42,6 +42,7 @@ static_resources:
                 envoy_grpc:
                   cluster_name: ext_proc_cluster
                 timeout: 30s
+              allow_mode_override: true
               processing_mode:
                 request_header_mode: SEND
                 response_header_mode: SKIP
@@ -91,6 +92,7 @@ static_resources:
                 envoy_grpc:
                   cluster_name: ext_proc_cluster
                 timeout: 30s
+              allow_mode_override: true
               processing_mode:
                 request_header_mode: SEND
                 response_header_mode: SKIP


### PR DESCRIPTION
## Summary

- Add `allow_mode_override: true` to both outbound and inbound ext_proc filters in the envoy.yaml.tmpl template
- Required for plugins that declare `BodyAccess: true` (e.g., mcp-parser) to dynamically request request bodies from Envoy via `ModeOverride`
- Without this flag, Envoy silently ignores the ModeOverride and never forwards the body, causing "Spurious response message" warnings and broken MCP tool calls

## Context

Companion to kagenti/kagenti-extensions#362 which fixes the authbridge ext_proc server to:
1. Use correct body-phase response types (`ProcessingResponse_RequestBody`)
2. Skip body buffering for bodyless methods (GET/HEAD/OPTIONS/DELETE)

Both PRs are needed for mcp-parser (and future body-access plugins) to work correctly.

## Test plan

- [x] Existing `envoy_template_test.go` passes (checks port values, not ext_proc fields)
- [x] Verified end-to-end on Kind: weather agent outbound MCP `tools/call` parsed by mcp-parser after manual ConfigMap patch with same change
- [ ] CI tests pass

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>