### PR TITLE
fix: use plain strings for Keycloak client attributes in update payload

### DIFF
--- a/kagenti-operator/internal/keycloak/admin.go
+++ b/kagenti-operator/internal/keycloak/admin.go
@@ -411,7 +411,7 @@ func mergeDesiredClientIntoMap(m map[string]interface{}, desired *keycloakClient
 		m["attributes"] = attrs
 	}
 	for k, v := range desired.Attributes {
-		attrs[k] = []interface{}{v}
+		attrs[k] = v
 	}
 }
 

--- a/kagenti-operator/internal/keycloak/admin_test.go
+++ b/kagenti-operator/internal/keycloak/admin_test.go
@@ -105,8 +105,8 @@ func TestAdmin_RegisterOrFetchClient_updatesDrift(t *testing.T) {
 			if attrs == nil {
 				t.Fatal("expected attributes in PUT body")
 			}
-			ex, _ := attrs["standard.token.exchange.enabled"].([]interface{})
-			if len(ex) != 1 || ex[0] != "true" {
+			ex, _ := attrs["standard.token.exchange.enabled"].(string)
+			if ex != "true" {
 				t.Fatalf("expected token exchange true in PUT, got %#v", attrs["standard.token.exchange.enabled"])
 			}
 			w.WriteHeader(http.StatusNoContent)


### PR DESCRIPTION
## Summary

- `mergeDesiredClientIntoMap` was wrapping attribute values in `[]interface{}` arrays (e.g. `["false"]` instead of `"false"`)
- Keycloak Admin API rejects this with `400: Cannot parse the JSON` on PUT
- This caused operator-managed client registration to silently fail for all workloads when the Keycloak client already existed and needed an update
- Credential secrets were never created, leaving pods stuck in `Init:0/1` waiting for volume mounts

## Root Cause

In `internal/keycloak/admin.go`, `mergeDesiredClientIntoMap` line 414:

```go
// Before (broken):
attrs[k] = []interface{}{v}

// After (fixed):
attrs[k] = v
```

## How it was found

Discovered while testing PR #321 on an OpenShift cluster. The operator authenticated to Keycloak successfully but every client update returned `400 "Cannot parse the JSON"`. Reproduced by manually PUTting the same payload to the Keycloak Admin API — array-wrapped attributes fail, plain string attributes succeed.

## Test plan

- [x] `go test ./internal/keycloak/...` — all 11 tests pass (updated `TestAdmin_RegisterOrFetchClient_updatesDrift`)
- [x] Verified on live OpenShift cluster: client registration succeeds, credential secrets created, pods start