### PR TITLE
test: add Auth Bridge authentication flow tests

### DIFF
--- a/kagenti-operator/internal/controller/clientregistration_controller_test.go
+++ b/kagenti-operator/internal/controller/clientregistration_controller_test.go
@@ -17,6 +17,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
 	agentv1alpha1 "github.com/kagenti/operator/api/v1alpha1"
+	"github.com/kagenti/operator/internal/keycloak/testidp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -388,4 +389,70 @@ func TestClientRegistrationReconciler_Reconcile(t *testing.T) {
 			t.Fatalf("client-secret: %q", clientSecret)
 		}
 	})
+}
+
+// TestClientRegistration_EndToEnd_CredentialsAuthenticate validates the full chain:
+// reconciler registers a Keycloak client via the testidp, creates the K8s Secret,
+// and the stored credentials can successfully obtain a workload token.
+func TestClientRegistration_EndToEnd_CredentialsAuthenticate(t *testing.T) {
+	idp := testidp.Start(t, testidp.WithAdminCredentials("admin", "secret"))
+
+	scheme := clientRegistrationTestScheme(t)
+	dep := testDeploymentForClientReg()
+	ctx := context.Background()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{
+		Namespace: clientRegistrationTestNamespace,
+		Name:      clientRegistrationTestDeploymentName,
+	}}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		clusterFeatureGatesConfigMap(true),
+		dep,
+		authbridgeConfigMapForTest(clientRegistrationTestNamespace, idp.URL()),
+		keycloakAdminSecretForTest(clientRegistrationTestNamespace),
+	).Build()
+
+	r := &ClientRegistrationReconciler{Client: c, Scheme: scheme}
+	res, err := r.Reconcile(ctx, req)
+	if err != nil || res != (ctrl.Result{}) {
+		t.Fatalf("Reconcile: result=%v err=%v", res, err)
+	}
+
+	// Read the credentials from the K8s Secret the reconciler created
+	secretName := keycloakClientCredentialsSecretName(clientRegistrationTestNamespace, clientRegistrationTestDeploymentName)
+	sec := &corev1.Secret{}
+	if err := c.Get(ctx, types.NamespacedName{
+		Namespace: clientRegistrationTestNamespace,
+		Name:      secretName,
+	}, sec); err != nil {
+		t.Fatalf("get credentials secret: %v", err)
+	}
+
+	clientID := string(sec.Data["client-id.txt"])
+	if clientID == "" && sec.StringData != nil {
+		clientID = sec.StringData["client-id.txt"]
+	}
+	clientSecret := string(sec.Data["client-secret.txt"])
+	if clientSecret == "" && sec.StringData != nil {
+		clientSecret = sec.StringData["client-secret.txt"]
+	}
+	if clientID == "" || clientSecret == "" {
+		t.Fatalf("expected non-empty credentials in secret, got id=%q secret=%q", clientID, clientSecret)
+	}
+
+	// Use those credentials to obtain a workload token from the testidp
+	token, err := idp.RequestWorkloadToken(clientID, clientSecret)
+	if err != nil {
+		t.Fatalf("workload token request with reconciler-created credentials: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty access token")
+	}
+
+	// Validate that the token is recognized as valid
+	if gotClientID, valid := idp.ValidateToken(token); !valid {
+		t.Fatal("token should be valid immediately after issuance")
+	} else if gotClientID != clientID {
+		t.Fatalf("token clientID=%q, want %q", gotClientID, clientID)
+	}
 }

--- a/kagenti-operator/internal/keycloak/authflow_test.go
+++ b/kagenti-operator/internal/keycloak/authflow_test.go
@@ -1,0 +1,255 @@
+package keycloak
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kagenti/operator/internal/keycloak/testidp"
+)
+
+// TestAuthFlow_TokenAcquisition validates the full operator-to-workload auth flow:
+// admin registers a client via the Keycloak admin API, then a workload uses the
+// resulting credentials to obtain an access token via client_credentials grant.
+func TestAuthFlow_TokenAcquisition(t *testing.T) {
+	idp := testidp.Start(t)
+
+	a := Admin{BaseURL: idp.URL(), HTTPClient: idp.Client()}
+	clientID := "test-ns/my-workload"
+
+	internalID, secret, err := a.RegisterOrFetchClient(context.Background(), "admin", "admin", ClientRegistrationParams{
+		Realm:      "kagenti",
+		ClientID:   clientID,
+		ClientName: clientID,
+	})
+	if err != nil {
+		t.Fatalf("RegisterOrFetchClient: %v", err)
+	}
+	if internalID == "" {
+		t.Fatal("expected non-empty internal ID")
+	}
+
+	token, err := idp.RequestWorkloadToken(clientID, secret)
+	if err != nil {
+		t.Fatalf("workload token request: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty access token")
+	}
+
+	// Verify the token is recognized as valid by the IdP
+	if _, valid := idp.ValidateToken(token); !valid {
+		t.Fatal("token should be valid immediately after issuance")
+	}
+}
+
+// TestAuthFlow_TokenAcquisition_InvalidCredentials ensures the fake IdP rejects
+// bad client credentials the same way a real Keycloak would.
+func TestAuthFlow_TokenAcquisition_InvalidCredentials(t *testing.T) {
+	idp := testidp.Start(t)
+	idp.RegisterClient("my-client", "correct-secret")
+
+	_, err := idp.RequestWorkloadToken("my-client", "wrong-secret")
+	if err == nil {
+		t.Fatal("expected error for invalid credentials")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Fatalf("expected 401 in error, got: %v", err)
+	}
+}
+
+// TestAuthFlow_PolicyEnforcement validates that a proxy enforcing bearer token auth
+// (modeled after Envoy's ext_authz pattern) correctly allows/rejects requests.
+func TestAuthFlow_PolicyEnforcement(t *testing.T) {
+	idp := testidp.Start(t)
+	idp.RegisterClient("test-ns/agent", "agent-secret")
+
+	token, err := idp.RequestWorkloadToken("test-ns/agent", "agent-secret")
+	if err != nil {
+		t.Fatalf("token request: %v", err)
+	}
+
+	// Build a minimal "enforcing proxy" that validates tokens via introspection
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		bearerToken := strings.TrimPrefix(authHeader, "Bearer ")
+		if bearerToken == authHeader {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		// Introspect via the IdP
+		form := url.Values{"token": {bearerToken}}
+		resp, err := idp.Client().Post(
+			idp.IntrospectionEndpoint(),
+			"application/x-www-form-urlencoded",
+			strings.NewReader(form.Encode()),
+		)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		defer resp.Body.Close() //nolint:errcheck
+		body, _ := io.ReadAll(resp.Body)
+
+		var result struct {
+			Active bool `json:"active"`
+		}
+		if err := json.Unmarshal(body, &result); err != nil || !result.Active {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer proxy.Close()
+
+	cases := []struct {
+		name       string
+		authHeader string
+		wantStatus int
+	}{
+		{
+			name:       "valid token returns 200",
+			authHeader: "Bearer " + token,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "no auth header returns 401",
+			authHeader: "",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "invalid token returns 403",
+			authHeader: "Bearer invalid-token-value",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "malformed auth header returns 401",
+			authHeader: "Basic dXNlcjpwYXNz",
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/resource", nil)
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			defer resp.Body.Close() //nolint:errcheck
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("got status %d, want %d", resp.StatusCode, tc.wantStatus)
+			}
+		})
+	}
+}
+
+// TestAuthFlow_TokenRefreshExpiry validates behavior when tokens expire:
+// obtain a token, verify it works, wait for expiry, verify rejection,
+// then re-acquire and verify the new token works.
+func TestAuthFlow_TokenRefreshExpiry(t *testing.T) {
+	idp := testidp.Start(t, testidp.WithTokenTTL(500*time.Millisecond))
+	idp.RegisterClient("test-ns/ephemeral", "eph-secret")
+
+	// Obtain initial token
+	token1, err := idp.RequestWorkloadToken("test-ns/ephemeral", "eph-secret")
+	if err != nil {
+		t.Fatalf("first token request: %v", err)
+	}
+	if _, valid := idp.ValidateToken(token1); !valid {
+		t.Fatal("token1 should be valid immediately")
+	}
+
+	// Wait for expiry
+	time.Sleep(600 * time.Millisecond)
+
+	if _, valid := idp.ValidateToken(token1); valid {
+		t.Fatal("token1 should be expired after TTL")
+	}
+
+	// Acquire a fresh token (simulates Auth Bridge refresh)
+	token2, err := idp.RequestWorkloadToken("test-ns/ephemeral", "eph-secret")
+	if err != nil {
+		t.Fatalf("second token request: %v", err)
+	}
+	if token2 == token1 {
+		t.Fatal("refreshed token should be different from expired token")
+	}
+	if _, valid := idp.ValidateToken(token2); !valid {
+		t.Fatal("token2 should be valid")
+	}
+}
+
+// TestAuthFlow_EndToEnd_RegisterAndAuthenticate exercises the full operator flow:
+// admin token -> register client -> audience scope -> workload authenticates.
+func TestAuthFlow_EndToEnd_RegisterAndAuthenticate(t *testing.T) {
+	idp := testidp.Start(t)
+
+	a := Admin{BaseURL: idp.URL(), HTTPClient: idp.Client()}
+	ctx := context.Background()
+
+	// Step 1: Admin obtains token
+	adminToken, err := a.PasswordGrantToken(ctx, "admin", "admin")
+	if err != nil {
+		t.Fatalf("admin token: %v", err)
+	}
+	if adminToken == "" {
+		t.Fatal("expected non-empty admin token")
+	}
+
+	// Step 2: Register client with token
+	clientID := "production/my-agent"
+	internalID, secret, err := a.RegisterOrFetchClientWithToken(ctx, adminToken, ClientRegistrationParams{
+		Realm:               "kagenti",
+		ClientID:            clientID,
+		ClientName:          clientID,
+		TokenExchangeEnable: true,
+	})
+	if err != nil {
+		t.Fatalf("register client: %v", err)
+	}
+	if internalID == "" || secret == "" {
+		t.Fatalf("expected non-empty id=%q secret=%q", internalID, secret)
+	}
+
+	// Step 3: Ensure audience scope (best-effort, like the operator)
+	err = a.EnsureAudienceScope(ctx, adminToken, AudienceParams{
+		Realm:                "kagenti",
+		ClientName:           clientID,
+		AudienceClientID:     clientID,
+		PlatformClientIDs:    []string{"kagenti"},
+		AudienceScopeEnabled: true,
+	})
+	if err != nil {
+		t.Fatalf("ensure audience scope: %v", err)
+	}
+
+	// Step 4: Workload authenticates using registered credentials
+	workloadToken, err := idp.RequestWorkloadToken(clientID, secret)
+	if err != nil {
+		t.Fatalf("workload token: %v", err)
+	}
+	if workloadToken == "" {
+		t.Fatal("expected non-empty workload token")
+	}
+	if cid, valid := idp.ValidateToken(workloadToken); !valid || cid != clientID {
+		t.Fatalf("token validation: valid=%v clientID=%q", valid, cid)
+	}
+}

--- a/kagenti-operator/internal/keycloak/authflow_test.go
+++ b/kagenti-operator/internal/keycloak/authflow_test.go
@@ -165,7 +165,7 @@ func TestAuthFlow_PolicyEnforcement(t *testing.T) {
 // obtain a token, verify it works, wait for expiry, verify rejection,
 // then re-acquire and verify the new token works.
 func TestAuthFlow_TokenRefreshExpiry(t *testing.T) {
-	idp := testidp.Start(t, testidp.WithTokenTTL(500*time.Millisecond))
+	idp := testidp.Start(t, testidp.WithTokenTTL(50*time.Millisecond))
 	idp.RegisterClient("test-ns/ephemeral", "eph-secret")
 
 	// Obtain initial token
@@ -178,7 +178,7 @@ func TestAuthFlow_TokenRefreshExpiry(t *testing.T) {
 	}
 
 	// Wait for expiry
-	time.Sleep(600 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	if _, valid := idp.ValidateToken(token1); valid {
 		t.Fatal("token1 should be expired after TTL")

--- a/kagenti-operator/internal/keycloak/testidp/fake_idp.go
+++ b/kagenti-operator/internal/keycloak/testidp/fake_idp.go
@@ -1,0 +1,535 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+// Package testidp provides a configurable httptest server that simulates both
+// the Keycloak admin REST API and a workload-facing OIDC token endpoint.
+// It is intended for use in unit and integration tests across the operator.
+package testidp
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ClientEntry represents a registered Keycloak client.
+type ClientEntry struct {
+	InternalID string
+	ClientID   string
+	Name       string
+	Secret     string
+	Attributes map[string]any
+}
+
+// IssuedToken tracks a token issued by the fake IdP.
+type IssuedToken struct {
+	Token     string
+	ClientID  string
+	ExpiresAt time.Time
+}
+
+// Option configures a FakeIDP before starting.
+type Option func(*FakeIDP)
+
+// WithAdminCredentials sets the admin username/password accepted by the master realm token endpoint.
+func WithAdminCredentials(user, pass string) Option {
+	return func(f *FakeIDP) {
+		f.adminUser = user
+		f.adminPass = pass
+	}
+}
+
+// WithTokenTTL sets the default access token TTL for both admin and workload tokens.
+func WithTokenTTL(d time.Duration) Option {
+	return func(f *FakeIDP) { f.tokenTTL = d }
+}
+
+// WithRealm sets the realm name used in URL paths (default: "kagenti").
+func WithRealm(realm string) Option {
+	return func(f *FakeIDP) { f.realm = realm }
+}
+
+// WithErrorMode makes the server return the given HTTP status on all requests
+// until ClearErrorMode is called. Useful for simulating outages.
+func WithErrorMode(statusCode int) Option {
+	return func(f *FakeIDP) { f.errorMode = statusCode }
+}
+
+// FakeIDP is a test Keycloak server that handles admin REST, client_credentials grants,
+// and token introspection.
+type FakeIDP struct {
+	Server *httptest.Server
+
+	mu         sync.Mutex
+	realm      string
+	adminUser  string
+	adminPass  string
+	tokenTTL   time.Duration
+	errorMode  int
+	clients    map[string]*ClientEntry // keyed by clientId
+	tokens     map[string]*IssuedToken // keyed by token string
+	scopes     map[string]scopeEntry   // keyed by scope ID
+	nextUUID   int
+	tokenCalls int
+	t          testing.TB
+}
+
+type scopeEntry struct {
+	ID   string
+	Name string
+}
+
+// Start creates and starts a new FakeIDP. Call Close() when done.
+func Start(t testing.TB, opts ...Option) *FakeIDP {
+	t.Helper()
+	f := &FakeIDP{
+		realm:     "kagenti",
+		adminUser: "admin",
+		adminPass: "admin",
+		tokenTTL:  time.Hour,
+		clients:   make(map[string]*ClientEntry),
+		tokens:    make(map[string]*IssuedToken),
+		scopes:    make(map[string]scopeEntry),
+		t:         t,
+	}
+	for _, o := range opts {
+		o(f)
+	}
+	f.Server = httptest.NewServer(http.HandlerFunc(f.handler))
+	t.Cleanup(f.Server.Close)
+	return f
+}
+
+// URL returns the base URL of the fake server.
+func (f *FakeIDP) URL() string { return f.Server.URL }
+
+// Client returns the httptest server's HTTP client (handles TLS correctly).
+func (f *FakeIDP) Client() *http.Client { return f.Server.Client() }
+
+// SetErrorMode makes all subsequent requests return the given status code.
+func (f *FakeIDP) SetErrorMode(code int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.errorMode = code
+}
+
+// ClearErrorMode returns the server to normal operation.
+func (f *FakeIDP) ClearErrorMode() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.errorMode = 0
+}
+
+// SetTokenTTL changes the TTL for newly issued tokens.
+func (f *FakeIDP) SetTokenTTL(d time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.tokenTTL = d
+}
+
+// TokenHTTPCalls returns how many token endpoint HTTP requests were received.
+func (f *FakeIDP) TokenHTTPCalls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.tokenCalls
+}
+
+// RegisterClient pre-registers a client so admin operations find it.
+func (f *FakeIDP) RegisterClient(clientID, secret string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nextUUID++
+	f.clients[clientID] = &ClientEntry{
+		InternalID: fmt.Sprintf("uuid-%d", f.nextUUID),
+		ClientID:   clientID,
+		Name:       clientID,
+		Secret:     secret,
+		Attributes: map[string]any{"standard.token.exchange.enabled": []any{"false"}},
+	}
+}
+
+// GetClient returns a registered client, or nil.
+func (f *FakeIDP) GetClient(clientID string) *ClientEntry {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.clients[clientID]
+}
+
+// ValidateToken checks whether a token string is valid (exists and not expired).
+func (f *FakeIDP) ValidateToken(token string) (clientID string, valid bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	t, ok := f.tokens[token]
+	if !ok {
+		return "", false
+	}
+	if time.Now().After(t.ExpiresAt) {
+		delete(f.tokens, token)
+		return t.ClientID, false
+	}
+	return t.ClientID, true
+}
+
+func (f *FakeIDP) handler(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	errMode := f.errorMode
+	f.mu.Unlock()
+	if errMode != 0 {
+		http.Error(w, "simulated error", errMode)
+		return
+	}
+
+	path := r.URL.Path
+	switch {
+	// Master realm token endpoint (admin password grant)
+	case path == "/realms/master/protocol/openid-connect/token" && r.Method == http.MethodPost:
+		f.handleAdminToken(w, r)
+
+	// Workload token endpoint (client_credentials grant)
+	case path == fmt.Sprintf("/realms/%s/protocol/openid-connect/token", f.realm) && r.Method == http.MethodPost:
+		f.handleWorkloadToken(w, r)
+
+	// Token introspection
+	case path == fmt.Sprintf("/realms/%s/protocol/openid-connect/token/introspect", f.realm) && r.Method == http.MethodPost:
+		f.handleIntrospect(w, r)
+
+	// Client list by clientId query param
+	case strings.HasPrefix(path, fmt.Sprintf("/admin/realms/%s/clients", f.realm)) && r.Method == http.MethodGet && r.URL.Query().Get("clientId") != "":
+		f.handleListClients(w, r)
+
+	// Client secret
+	case r.Method == http.MethodGet && strings.HasSuffix(path, "/client-secret"):
+		f.handleClientSecret(w, r)
+
+	// GET single client
+	case r.Method == http.MethodGet && f.isClientUUIDPath(path):
+		f.handleGetClient(w, r)
+
+	// PUT single client (drift reconciliation)
+	case r.Method == http.MethodPut && f.isClientUUIDPath(path):
+		f.handleUpdateClient(w, r)
+
+	// POST create client
+	case path == fmt.Sprintf("/admin/realms/%s/clients", f.realm) && r.Method == http.MethodPost:
+		f.handleCreateClient(w, r)
+
+	// Client scopes list
+	case path == fmt.Sprintf("/admin/realms/%s/client-scopes", f.realm) && r.Method == http.MethodGet:
+		f.handleListClientScopes(w, r)
+
+	// Client scope create
+	case path == fmt.Sprintf("/admin/realms/%s/client-scopes", f.realm) && r.Method == http.MethodPost:
+		f.handleCreateClientScope(w, r)
+
+	// Protocol mapper create (audience mapper)
+	case r.Method == http.MethodPost && strings.Contains(path, "/protocol-mappers/models"):
+		w.WriteHeader(http.StatusCreated)
+
+	// Realm default scope / client default scope PUTs
+	case r.Method == http.MethodPut && (strings.Contains(path, "/default-default-client-scopes/") || strings.Contains(path, "/default-client-scopes/")):
+		w.WriteHeader(http.StatusNoContent)
+
+	default:
+		f.t.Errorf("FakeIDP: unexpected request %s %s", r.Method, r.URL)
+		http.NotFound(w, r)
+	}
+}
+
+func (f *FakeIDP) handleAdminToken(w http.ResponseWriter, r *http.Request) {
+	_ = r.ParseForm()
+	f.mu.Lock()
+	f.tokenCalls++
+	ttl := f.tokenTTL
+	user := f.adminUser
+	pass := f.adminPass
+	f.mu.Unlock()
+
+	if r.FormValue("username") != user || r.FormValue("password") != pass {
+		http.Error(w, `{"error":"invalid_grant"}`, http.StatusUnauthorized)
+		return
+	}
+
+	tok := f.issueToken("admin-cli", ttl)
+	writeJSON(w, map[string]any{
+		"access_token": tok,
+		"expires_in":   int(ttl.Seconds()),
+		"token_type":   "Bearer",
+	})
+}
+
+func (f *FakeIDP) handleWorkloadToken(w http.ResponseWriter, r *http.Request) {
+	_ = r.ParseForm()
+	if r.FormValue("grant_type") != "client_credentials" {
+		http.Error(w, `{"error":"unsupported_grant_type"}`, http.StatusBadRequest)
+		return
+	}
+
+	clientID := r.FormValue("client_id")
+	clientSecret := r.FormValue("client_secret")
+
+	f.mu.Lock()
+	entry, ok := f.clients[clientID]
+	ttl := f.tokenTTL
+	f.tokenCalls++
+	f.mu.Unlock()
+
+	if !ok || entry.Secret != clientSecret {
+		http.Error(w, `{"error":"invalid_client"}`, http.StatusUnauthorized)
+		return
+	}
+
+	tok := f.issueToken(clientID, ttl)
+	writeJSON(w, map[string]any{
+		"access_token": tok,
+		"expires_in":   int(ttl.Seconds()),
+		"token_type":   "Bearer",
+	})
+}
+
+func (f *FakeIDP) handleIntrospect(w http.ResponseWriter, r *http.Request) {
+	_ = r.ParseForm()
+	token := r.FormValue("token")
+
+	clientID, valid := f.ValidateToken(token)
+	if !valid {
+		writeJSON(w, map[string]any{"active": false})
+		return
+	}
+	writeJSON(w, map[string]any{
+		"active":     true,
+		"client_id":  clientID,
+		"token_type": "Bearer",
+	})
+}
+
+func (f *FakeIDP) handleListClients(w http.ResponseWriter, r *http.Request) {
+	cid := r.URL.Query().Get("clientId")
+	f.mu.Lock()
+	entry, ok := f.clients[cid]
+	f.mu.Unlock()
+
+	if !ok {
+		writeJSON(w, []any{})
+		return
+	}
+	writeJSON(w, []map[string]string{{"id": entry.InternalID, "clientId": entry.ClientID}})
+}
+
+func (f *FakeIDP) handleClientSecret(w http.ResponseWriter, r *http.Request) {
+	uuid := f.uuidFromPath(r.URL.Path)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, c := range f.clients {
+		if c.InternalID == uuid {
+			writeJSON(w, map[string]string{"value": c.Secret})
+			return
+		}
+	}
+	http.NotFound(w, r)
+}
+
+func (f *FakeIDP) handleGetClient(w http.ResponseWriter, r *http.Request) {
+	uuid := f.uuidFromPath(r.URL.Path)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, c := range f.clients {
+		if c.InternalID == uuid {
+			writeJSON(w, map[string]any{
+				"id":                        c.InternalID,
+				"clientId":                  c.ClientID,
+				"name":                      c.Name,
+				"standardFlowEnabled":       true,
+				"directAccessGrantsEnabled": true,
+				"serviceAccountsEnabled":    true,
+				"fullScopeAllowed":          false,
+				"publicClient":              false,
+				"clientAuthenticatorType":   "client-secret",
+				"attributes":                c.Attributes,
+			})
+			return
+		}
+	}
+	http.NotFound(w, r)
+}
+
+func (f *FakeIDP) handleUpdateClient(w http.ResponseWriter, r *http.Request) {
+	uuid := f.uuidFromPath(r.URL.Path)
+	var body map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, c := range f.clients {
+		if c.InternalID == uuid {
+			if attrs, ok := body["attributes"].(map[string]any); ok {
+				c.Attributes = attrs
+			}
+			if name, ok := body["name"].(string); ok {
+				c.Name = name
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+	}
+	http.NotFound(w, r)
+}
+
+func (f *FakeIDP) handleCreateClient(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ClientID string `json:"clientId"`
+		Name     string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	f.mu.Lock()
+	if _, exists := f.clients[body.ClientID]; exists {
+		f.mu.Unlock()
+		w.WriteHeader(http.StatusConflict)
+		return
+	}
+	f.nextUUID++
+	secret := randomHex(16)
+	entry := &ClientEntry{
+		InternalID: fmt.Sprintf("uuid-%d", f.nextUUID),
+		ClientID:   body.ClientID,
+		Name:       body.Name,
+		Secret:     secret,
+		Attributes: map[string]any{},
+	}
+	f.clients[body.ClientID] = entry
+	f.mu.Unlock()
+
+	w.Header().Set("Location", fmt.Sprintf("%s/admin/realms/%s/clients/%s",
+		f.Server.URL, f.realm, entry.InternalID))
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (f *FakeIDP) handleListClientScopes(w http.ResponseWriter, _ *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	list := make([]map[string]string, 0, len(f.scopes))
+	for _, s := range f.scopes {
+		list = append(list, map[string]string{"id": s.ID, "name": s.Name})
+	}
+	if list == nil {
+		list = []map[string]string{}
+	}
+	writeJSON(w, list)
+}
+
+func (f *FakeIDP) handleCreateClientScope(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	f.mu.Lock()
+	f.nextUUID++
+	id := fmt.Sprintf("scope-%d", f.nextUUID)
+	f.scopes[id] = scopeEntry{ID: id, Name: body.Name}
+	f.mu.Unlock()
+
+	w.Header().Set("Location", fmt.Sprintf("%s/admin/realms/%s/client-scopes/%s",
+		f.Server.URL, f.realm, id))
+	w.WriteHeader(http.StatusCreated)
+}
+
+// issueToken creates a token and stores it. Caller must NOT hold f.mu.
+func (f *FakeIDP) issueToken(clientID string, ttl time.Duration) string {
+	tok := randomHex(32)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.tokens[tok] = &IssuedToken{
+		Token:     tok,
+		ClientID:  clientID,
+		ExpiresAt: time.Now().Add(ttl),
+	}
+	return tok
+}
+
+// WorkloadTokenEndpoint returns the full URL for the realm's token endpoint.
+func (f *FakeIDP) WorkloadTokenEndpoint() string {
+	return fmt.Sprintf("%s/realms/%s/protocol/openid-connect/token", f.Server.URL, f.realm)
+}
+
+// IntrospectionEndpoint returns the full URL for the realm's token introspection endpoint.
+func (f *FakeIDP) IntrospectionEndpoint() string {
+	return fmt.Sprintf("%s/realms/%s/protocol/openid-connect/token/introspect", f.Server.URL, f.realm)
+}
+
+// isClientUUIDPath returns true if the path matches /admin/realms/{realm}/clients/{uuid}
+// (not /client-secret, not a query-param list).
+func (f *FakeIDP) isClientUUIDPath(path string) bool {
+	prefix := fmt.Sprintf("/admin/realms/%s/clients/", f.realm)
+	if !strings.HasPrefix(path, prefix) {
+		return false
+	}
+	rest := strings.TrimPrefix(path, prefix)
+	return rest != "" && !strings.Contains(rest, "/")
+}
+
+// uuidFromPath extracts the last path segment (e.g. uuid from .../clients/uuid or .../clients/uuid/client-secret).
+func (f *FakeIDP) uuidFromPath(path string) string {
+	// Strip trailing /client-secret if present
+	path = strings.TrimSuffix(path, "/client-secret")
+	path = strings.TrimRight(path, "/")
+	if idx := strings.LastIndex(path, "/"); idx >= 0 {
+		return path[idx+1:]
+	}
+	return ""
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func randomHex(n int) string {
+	b := make([]byte, n)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// RequestWorkloadToken performs a client_credentials grant against the fake IdP and returns the access token.
+// This is a test helper — it simulates what the Auth Bridge sidecar does.
+func (f *FakeIDP) RequestWorkloadToken(clientID, clientSecret string) (string, error) {
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_id", clientID)
+	form.Set("client_secret", clientSecret)
+
+	resp, err := f.Client().Post(f.WorkloadTokenEndpoint(), "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token request failed: status %d", resp.StatusCode)
+	}
+	var result struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	return result.AccessToken, nil
+}

--- a/kagenti-operator/test/integration/authbridge_auth_flow_integration_test.go
+++ b/kagenti-operator/test/integration/authbridge_auth_flow_integration_test.go
@@ -1,0 +1,241 @@
+//go:build integration
+// +build integration
+
+/*
+Copyright 2026.
+
+Integration tests for Auth Bridge authentication flow (RHAIENG-4356).
+
+These tests validate that Auth Bridge works end-to-end against a real Keycloak
+deployment: token acquisition via client_credentials, Envoy policy enforcement
+(valid token → 200, no token → 401/403), and token refresh on expiry.
+
+Prerequisites:
+  - kubectl configured with access to a Kubernetes cluster with kagenti CRDs installed
+  - A Keycloak instance accessible from the test runner
+  - Environment variables set:
+    KEYCLOAK_URL            — base URL (e.g. https://keycloak.apps.example.com)
+    KEYCLOAK_ADMIN_USER     — admin username
+    KEYCLOAK_ADMIN_PASSWORD — admin password
+    KEYCLOAK_REALM          — realm name (default: kagenti)
+    ENVOY_PROXY_URL         — (optional) URL of an Auth Bridge Envoy proxy to test policy enforcement
+
+Run with: go test -v -tags=integration ./test/integration/... -timeout 5m -run TestAuthBridge
+*/
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kagenti/operator/internal/keycloak"
+)
+
+func keycloakEnvOrSkip(t *testing.T) (baseURL, adminUser, adminPass, realm string) {
+	t.Helper()
+	baseURL = os.Getenv("KEYCLOAK_URL")
+	adminUser = os.Getenv("KEYCLOAK_ADMIN_USER")
+	adminPass = os.Getenv("KEYCLOAK_ADMIN_PASSWORD")
+	realm = os.Getenv("KEYCLOAK_REALM")
+	if realm == "" {
+		realm = "kagenti"
+	}
+	if baseURL == "" || adminUser == "" || adminPass == "" {
+		t.Skip("requires real Keycloak deployment — set KEYCLOAK_URL, KEYCLOAK_ADMIN_USER, KEYCLOAK_ADMIN_PASSWORD (see RHAIENG-4356)")
+	}
+	return
+}
+
+func envoyURLOrSkip(t *testing.T) string {
+	t.Helper()
+	u := os.Getenv("ENVOY_PROXY_URL")
+	if u == "" {
+		t.Skip("requires ENVOY_PROXY_URL — set to an Auth Bridge Envoy proxy endpoint (see RHAIENG-4356)")
+	}
+	return u
+}
+
+func TestAuthBridge_RealKeycloak_TokenAcquisition(t *testing.T) {
+	baseURL, adminUser, adminPass, realm := keycloakEnvOrSkip(t)
+
+	a := keycloak.Admin{
+		BaseURL:    baseURL,
+		HTTPClient: keycloak.DefaultHTTPClient(),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Register or fetch a test client
+	clientID := fmt.Sprintf("integration-test/%d", time.Now().UnixNano())
+	internalID, secret, err := a.RegisterOrFetchClient(ctx, adminUser, adminPass, keycloak.ClientRegistrationParams{
+		Realm:      realm,
+		ClientID:   clientID,
+		ClientName: clientID,
+	})
+	if err != nil {
+		t.Fatalf("RegisterOrFetchClient: %v", err)
+	}
+	if internalID == "" || secret == "" {
+		t.Fatalf("expected non-empty id=%q secret=%q", internalID, secret)
+	}
+
+	// Use the credentials to obtain a workload token via client_credentials
+	tokenURL := fmt.Sprintf("%s/realms/%s/protocol/openid-connect/token",
+		strings.TrimRight(baseURL, "/"), realm)
+	form := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {clientID},
+		"client_secret": {secret},
+	}
+	resp, err := http.DefaultClient.Post(tokenURL, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("token request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	t.Logf("successfully obtained workload token for client %q", clientID)
+}
+
+func TestAuthBridge_RealEnvoy_PolicyEnforcement(t *testing.T) {
+	proxyURL := envoyURLOrSkip(t)
+	baseURL, _, _, realm := keycloakEnvOrSkip(t)
+
+	// Use the workload's own registered credentials to get a token with proper audience.
+	// The operator registers the workload and stores credentials in a Secret named in
+	// WORKLOAD_CLIENT_ID / WORKLOAD_CLIENT_SECRET env vars, or falls back to default
+	// test namespace/name convention.
+	workloadClientID := os.Getenv("WORKLOAD_CLIENT_ID")
+	workloadClientSecret := os.Getenv("WORKLOAD_CLIENT_SECRET")
+	if workloadClientID == "" || workloadClientSecret == "" {
+		t.Skip("requires WORKLOAD_CLIENT_ID and WORKLOAD_CLIENT_SECRET — " +
+			"read from the kagenti-keycloak-client-credentials-* Secret in the test namespace (see RHAIENG-4356)")
+	}
+
+	// Obtain a valid token using the workload's own credentials
+	tokenURL := fmt.Sprintf("%s/realms/%s/protocol/openid-connect/token",
+		strings.TrimRight(baseURL, "/"), realm)
+	form := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {workloadClientID},
+		"client_secret": {workloadClientSecret},
+	}
+	resp, err := http.DefaultClient.Post(tokenURL, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("token request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("token request: expected 200, got %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading token response: %v", err)
+	}
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		t.Fatalf("parsing token response: %v", err)
+	}
+	if tokenResp.AccessToken == "" {
+		t.Fatal("empty access_token in token response")
+	}
+
+	// Test: no auth header → 401
+	req, _ := http.NewRequest(http.MethodGet, proxyURL, nil)
+	noAuthResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("no-auth request: %v", err)
+	}
+	noAuthResp.Body.Close()
+	if noAuthResp.StatusCode != http.StatusUnauthorized && noAuthResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 401 or 403 for unauthenticated request, got %d", noAuthResp.StatusCode)
+	}
+
+	// Test: invalid token → 401/403
+	req, _ = http.NewRequest(http.MethodGet, proxyURL, nil)
+	req.Header.Set("Authorization", "Bearer invalid-token-value")
+	badResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("bad-token request: %v", err)
+	}
+	badResp.Body.Close()
+	if badResp.StatusCode != http.StatusUnauthorized && badResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 401 or 403 for invalid token, got %d", badResp.StatusCode)
+	}
+
+	// Test: valid token → 200
+	req, _ = http.NewRequest(http.MethodGet, proxyURL, nil)
+	req.Header.Set("Authorization", "Bearer "+tokenResp.AccessToken)
+	goodResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("valid-token request: %v", err)
+	}
+	goodResp.Body.Close()
+	if goodResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for valid token, got %d", goodResp.StatusCode)
+	}
+
+	t.Log("policy enforcement test completed (unauthenticated rejected, invalid token rejected, valid token accepted)")
+}
+
+func TestAuthBridge_RealKeycloak_TokenRefresh(t *testing.T) {
+	baseURL, adminUser, adminPass, realm := keycloakEnvOrSkip(t)
+
+	a := keycloak.Admin{
+		BaseURL:    baseURL,
+		HTTPClient: keycloak.DefaultHTTPClient(),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	clientID := fmt.Sprintf("integration-test-refresh/%d", time.Now().UnixNano())
+	_, secret, err := a.RegisterOrFetchClient(ctx, adminUser, adminPass, keycloak.ClientRegistrationParams{
+		Realm:      realm,
+		ClientID:   clientID,
+		ClientName: clientID,
+	})
+	if err != nil {
+		t.Fatalf("RegisterOrFetchClient: %v", err)
+	}
+
+	tokenURL := fmt.Sprintf("%s/realms/%s/protocol/openid-connect/token",
+		strings.TrimRight(baseURL, "/"), realm)
+	form := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {clientID},
+		"client_secret": {secret},
+	}
+
+	// Obtain first token
+	resp1, err := http.DefaultClient.Post(tokenURL, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("first token: %v", err)
+	}
+	resp1.Body.Close()
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("first token: expected 200, got %d", resp1.StatusCode)
+	}
+
+	// Obtain second token (simulates refresh — in production, Auth Bridge handles this)
+	resp2, err := http.DefaultClient.Post(tokenURL, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("second token: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("second token: expected 200, got %d", resp2.StatusCode)
+	}
+
+	t.Log("token refresh test completed (two successive token acquisitions succeeded)")
+}

--- a/kagenti-operator/test/integration/authbridge_auth_flow_integration_test.go
+++ b/kagenti-operator/test/integration/authbridge_auth_flow_integration_test.go
@@ -4,7 +4,7 @@
 /*
 Copyright 2026.
 
-Integration tests for Auth Bridge authentication flow (RHAIENG-4356).
+Integration tests for Auth Bridge authentication flow.
 
 These tests validate that Auth Bridge works end-to-end against a real Keycloak
 deployment: token acquisition via client_credentials, Envoy policy enforcement
@@ -19,6 +19,7 @@ Prerequisites:
     KEYCLOAK_ADMIN_PASSWORD — admin password
     KEYCLOAK_REALM          — realm name (default: kagenti)
     ENVOY_PROXY_URL         — (optional) URL of an Auth Bridge Envoy proxy to test policy enforcement
+    KEYCLOAK_CA_CERT        — (optional) path to PEM CA bundle for custom Keycloak TLS
 
 Run with: go test -v -tags=integration ./test/integration/... -timeout 5m -run TestAuthBridge
 */
@@ -26,6 +27,8 @@ package integration
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -39,6 +42,32 @@ import (
 	"github.com/kagenti/operator/internal/keycloak"
 )
 
+// httpClient returns an *http.Client that trusts the CA bundle at KEYCLOAK_CA_CERT
+// (PEM file path). If the env var is unset it falls back to the system root CAs.
+func httpClient(t *testing.T) *http.Client {
+	t.Helper()
+	caPath := os.Getenv("KEYCLOAK_CA_CERT")
+	if caPath == "" {
+		return http.DefaultClient
+	}
+	pem, err := os.ReadFile(caPath)
+	if err != nil {
+		t.Fatalf("reading KEYCLOAK_CA_CERT (%s): %v", caPath, err)
+	}
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		pool = x509.NewCertPool()
+	}
+	if !pool.AppendCertsFromPEM(pem) {
+		t.Fatalf("KEYCLOAK_CA_CERT (%s): no valid certificates found", caPath)
+	}
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool},
+		},
+	}
+}
+
 func keycloakEnvOrSkip(t *testing.T) (baseURL, adminUser, adminPass, realm string) {
 	t.Helper()
 	baseURL = os.Getenv("KEYCLOAK_URL")
@@ -49,7 +78,8 @@ func keycloakEnvOrSkip(t *testing.T) (baseURL, adminUser, adminPass, realm strin
 		realm = "kagenti"
 	}
 	if baseURL == "" || adminUser == "" || adminPass == "" {
-		t.Skip("requires real Keycloak deployment — set KEYCLOAK_URL, KEYCLOAK_ADMIN_USER, KEYCLOAK_ADMIN_PASSWORD (see RHAIENG-4356)")
+		t.Skip("requires real Keycloak deployment — set KEYCLOAK_URL, " +
+			"KEYCLOAK_ADMIN_USER, KEYCLOAK_ADMIN_PASSWORD")
 	}
 	return
 }
@@ -58,7 +88,7 @@ func envoyURLOrSkip(t *testing.T) string {
 	t.Helper()
 	u := os.Getenv("ENVOY_PROXY_URL")
 	if u == "" {
-		t.Skip("requires ENVOY_PROXY_URL — set to an Auth Bridge Envoy proxy endpoint (see RHAIENG-4356)")
+		t.Skip("requires ENVOY_PROXY_URL — set to an Auth Bridge Envoy proxy endpoint")
 	}
 	return u
 }
@@ -95,11 +125,12 @@ func TestAuthBridge_RealKeycloak_TokenAcquisition(t *testing.T) {
 		"client_id":     {clientID},
 		"client_secret": {secret},
 	}
-	resp, err := http.DefaultClient.Post(tokenURL, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	client := httpClient(t)
+	resp, err := client.Post(tokenURL, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatalf("token request: %v", err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -118,7 +149,7 @@ func TestAuthBridge_RealEnvoy_PolicyEnforcement(t *testing.T) {
 	workloadClientSecret := os.Getenv("WORKLOAD_CLIENT_SECRET")
 	if workloadClientID == "" || workloadClientSecret == "" {
 		t.Skip("requires WORKLOAD_CLIENT_ID and WORKLOAD_CLIENT_SECRET — " +
-			"read from the kagenti-keycloak-client-credentials-* Secret in the test namespace (see RHAIENG-4356)")
+			"read from the kagenti-keycloak-client-credentials-* Secret in the test namespace")
 	}
 
 	// Obtain a valid token using the workload's own credentials
@@ -129,11 +160,12 @@ func TestAuthBridge_RealEnvoy_PolicyEnforcement(t *testing.T) {
 		"client_id":     {workloadClientID},
 		"client_secret": {workloadClientSecret},
 	}
-	resp, err := http.DefaultClient.Post(tokenURL, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	client := httpClient(t)
+	resp, err := client.Post(tokenURL, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatalf("token request: %v", err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("token request: expected 200, got %d", resp.StatusCode)
 	}
@@ -153,11 +185,11 @@ func TestAuthBridge_RealEnvoy_PolicyEnforcement(t *testing.T) {
 
 	// Test: no auth header → 401
 	req, _ := http.NewRequest(http.MethodGet, proxyURL, nil)
-	noAuthResp, err := http.DefaultClient.Do(req)
+	noAuthResp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("no-auth request: %v", err)
 	}
-	noAuthResp.Body.Close()
+	noAuthResp.Body.Close() //nolint:errcheck
 	if noAuthResp.StatusCode != http.StatusUnauthorized && noAuthResp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected 401 or 403 for unauthenticated request, got %d", noAuthResp.StatusCode)
 	}
@@ -165,11 +197,11 @@ func TestAuthBridge_RealEnvoy_PolicyEnforcement(t *testing.T) {
 	// Test: invalid token → 401/403
 	req, _ = http.NewRequest(http.MethodGet, proxyURL, nil)
 	req.Header.Set("Authorization", "Bearer invalid-token-value")
-	badResp, err := http.DefaultClient.Do(req)
+	badResp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("bad-token request: %v", err)
 	}
-	badResp.Body.Close()
+	badResp.Body.Close() //nolint:errcheck
 	if badResp.StatusCode != http.StatusUnauthorized && badResp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected 401 or 403 for invalid token, got %d", badResp.StatusCode)
 	}
@@ -177,11 +209,11 @@ func TestAuthBridge_RealEnvoy_PolicyEnforcement(t *testing.T) {
 	// Test: valid token → 200
 	req, _ = http.NewRequest(http.MethodGet, proxyURL, nil)
 	req.Header.Set("Authorization", "Bearer "+tokenResp.AccessToken)
-	goodResp, err := http.DefaultClient.Do(req)
+	goodResp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("valid-token request: %v", err)
 	}
-	goodResp.Body.Close()
+	goodResp.Body.Close() //nolint:errcheck
 	if goodResp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200 for valid token, got %d", goodResp.StatusCode)
 	}
@@ -218,21 +250,22 @@ func TestAuthBridge_RealKeycloak_TokenRefresh(t *testing.T) {
 	}
 
 	// Obtain first token
-	resp1, err := http.DefaultClient.Post(tokenURL, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	client := httpClient(t)
+	resp1, err := client.Post(tokenURL, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatalf("first token: %v", err)
 	}
-	resp1.Body.Close()
+	resp1.Body.Close() //nolint:errcheck
 	if resp1.StatusCode != http.StatusOK {
 		t.Fatalf("first token: expected 200, got %d", resp1.StatusCode)
 	}
 
 	// Obtain second token (simulates refresh — in production, Auth Bridge handles this)
-	resp2, err := http.DefaultClient.Post(tokenURL, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	resp2, err := client.Post(tokenURL, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatalf("second token: %v", err)
 	}
-	resp2.Body.Close()
+	resp2.Body.Close() //nolint:errcheck
 	if resp2.StatusCode != http.StatusOK {
 		t.Fatalf("second token: expected 200, got %d", resp2.StatusCode)
 	}


### PR DESCRIPTION
RHAIENG-4356

## Summary
Adds comprehensive test coverage for the Auth Bridge authentication flow, covering token acquisition, Envoy policy enforcement, token refresh/expiry, and the client registration reconciler's end-to-end credential validation.

## Changes
- `internal/keycloak/authflow_test.go` — httptest-based unit tests for token acquisition, policy enforcement (valid/invalid/missing/malformed tokens), token refresh and expiry handling
- `internal/keycloak/testidp/fake_idp.go` — reusable fake Keycloak IdP (admin REST API + OIDC token endpoint) for deterministic unit testing
- `internal/controller/clientregistration_controller_test.go` — end-to-end test verifying reconciler-created credentials can authenticate against the IdP
- `test/integration/authbridge_auth_flow_integration_test.go` — integration test exercising a real Envoy+Keycloak deployment (requires cluster env vars)

## Test Plan
- [x] Unit tests pass: `go test ./internal/keycloak/... ./internal/controller/...`
- [ ] Integration tests pass on a cluster with Auth Bridge deployed (requires `ENVOY_PROXY_URL`, `KEYCLOAK_URL`, `KEYCLOAK_REALM`, `WORKLOAD_CLIENT_ID`, `WORKLOAD_CLIENT_SECRET`)
