### PR TITLE
fix(chart): Render --spire-trust-domain independently of signatureVerification.enabled

### DIFF
--- a/charts/kagenti-operator/templates/manager/manager.yaml
+++ b/charts/kagenti-operator/templates/manager/manager.yaml
@@ -42,9 +42,6 @@ spec:
             {{- if .Values.signatureVerification.enforceNetworkPolicies }}
             - "--enforce-network-policies=true"
             {{- end }}
-            {{- if .Values.signatureVerification.spireTrustDomain }}
-            - "--spire-trust-domain={{ .Values.signatureVerification.spireTrustDomain }}"
-            {{- end }}
             {{- if .Values.signatureVerification.spireTrustBundle.configMapName }}
             - "--spire-trust-bundle-configmap={{ .Values.signatureVerification.spireTrustBundle.configMapName }}"
             {{- end }}
@@ -60,6 +57,19 @@ spec:
             {{- if .Values.signatureVerification.svidExpiryGracePeriod }}
             - "--svid-expiry-grace-period={{ .Values.signatureVerification.svidExpiryGracePeriod }}"
             {{- end }}
+            {{- end }}
+            {{/*
+              --spire-trust-domain is rendered independently of
+              signatureVerification.enabled. The flag is also consumed by the
+              ClientRegistrationReconciler, which resolves SPIFFE client IDs of
+              the form spiffe://<trust-domain>/ns/<ns>/sa/<sa> when
+              authbridge-config has SPIRE_ENABLED=true. Gating it on signature
+              verification would break operator-managed client registration in
+              clusters that use SPIRE for workload identity but do not enable
+              A2A signature enforcement.
+            */}}
+            {{- if .Values.signatureVerification.spireTrustDomain }}
+            - "--spire-trust-domain={{ .Values.signatureVerification.spireTrustDomain }}"
             {{- end }}
           command:
             - {{ .Values.controllerManager.container.cmd }}

--- a/charts/kagenti-operator/values.yaml
+++ b/charts/kagenti-operator/values.yaml
@@ -100,7 +100,12 @@ signatureVerification:
   auditMode: false
   # Enforce network policies based on signature verification
   enforceNetworkPolicies: false
-  # SPIRE trust domain (required when enabled)
+  # SPIRE trust domain. Required when SPIRE is enabled in the cluster even if
+  # signatureVerification.enabled is false: the ClientRegistrationReconciler
+  # uses this to build SPIFFE-shaped Keycloak client IDs
+  # (spiffe://<trust-domain>/ns/<ns>/sa/<sa>) whenever authbridge-config has
+  # SPIRE_ENABLED=true. The chart renders --spire-trust-domain independently of
+  # signatureVerification.enabled for this reason.
   spireTrustDomain: ""
   # Key within the SPIRE trust bundle ConfigMap. Matches the SPIRE hardened Helm chart default
   # and the binary flag default. Override to "bundle.crt" only for older ZTWIM deployments.


### PR DESCRIPTION
## Summary

The chart template gates `--spire-trust-domain` on `signatureVerification.enabled`, but the trust domain is consumed by **two** controllers in this operator binary:

- **AgentCardReconciler** (signature verification) — builds expected SPIFFE IDs when verifying x5c chains on agent card signatures.
- **ClientRegistrationReconciler** (operator-managed Keycloak client lifecycle) — builds SPIFFE-shaped client IDs `spiffe://<trust-domain>/ns/<ns>/sa/<sa>` when `authbridge-config` has `SPIRE_ENABLED=true`.

Clusters that use SPIRE for workload identity but do **not** enable A2A signature enforcement (which is the default configuration for kagenti on HyperShift) fail client registration. The reconciler loops every 30s with:

```
"cannot resolve Keycloak client id yet"
reason="SPIRE enabled: operator --spire-trust-domain is required for operator-managed client registration"
```

...and no agent ever gets registered in Keycloak.

## Change

- Move `--spire-trust-domain` out of the `signatureVerification.enabled` block in `charts/kagenti-operator/templates/manager/manager.yaml` so the flag is rendered whenever `.Values.signatureVerification.spireTrustDomain` is non-empty, regardless of whether signature verification is on.
- Keep the signature-specific flags inside the gate: `--require-a2a-signature`, `--signature-audit-mode`, `--enforce-network-policies`, `--svid-expiry-grace-period`, and the `--spire-trust-bundle-*` family (trust bundle is verification cert material, only used by the signature verifier).
- Update `values.yaml` comment to describe the new semantics. No default value change.
- No `Chart.yaml` version bump in this PR — leaving release cut to maintainers.

## Evidence from the wild

Full failure trace from `kagenti/kagenti#1491`: https://github.com/kagenti/kagenti/actions/runs/25469555513

Operator reconciler log (300s window, every 30s):
```
{"level":"info","msg":"cannot resolve Keycloak client id yet","controller":"clientregistration","Deployment":{"name":"weather-service","namespace":"team1"},"reason":"SPIRE enabled: operator --spire-trust-domain is required for operator-managed client registration"}
```

`signatureVerification.spireTrustDomain` was set via Helm values — the value just never made it to the rendered Deployment because the outer gate evaluates to false.

## Test plan

- [x] `helm template` the chart with `signatureVerification.enabled=false` and `signatureVerification.spireTrustDomain=localtest.me` — the rendered Deployment includes `--spire-trust-domain=localtest.me` in the manager container args.
- [x] `helm template` with both fields at defaults (`enabled=false`, `spireTrustDomain=""`) — no `--spire-trust-domain` arg rendered (unchanged from today).
- [x] `helm template` with `signatureVerification.enabled=true` and `spireTrustDomain=localtest.me` — both signature flags and the trust-domain flag render (unchanged from today).
- [ ] Re-run `kagenti/kagenti#1491` E2E after chart release + dependency bump; operator should emit `"operator client registration applied" workload=weather-service` and the `agent-team1-weather-service-aud` scope should appear in Keycloak realm within seconds.

## Follow-up for downstream

Once this lands and a new chart version is published:

- Drop the workaround in `kagenti/kagenti#1491` — values.yaml's hardcoded `--spire-trust-domain=localtest.me` in the args list, and the ansible full-args-list override.
- Bump `kagenti/charts/kagenti/Chart.yaml` dependency version to the new release.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
