### PR TITLE
feat(webhook): Pass keycloak_url + keycloak_realm to jwt-validation in synthesizePipeline

### DIFF
--- a/kagenti-operator/internal/controller/clientregistration_controller_test.go
+++ b/kagenti-operator/internal/controller/clientregistration_controller_test.go
@@ -425,10 +425,17 @@ func TestClientRegistration_EndToEnd_CredentialsAuthenticate(t *testing.T) {
 		clusterFeatureGatesConfigMap(true),
 		dep,
 		authbridgeConfigMapForTest(clientRegistrationTestNamespace, idp.URL()),
-		keycloakAdminSecretForTest(clientRegistrationTestNamespace),
+		// keycloak-admin-secret lives in the operator namespace (not the
+		// agent namespace) after PR #321's security hardening. The
+		// reconciler reads it from there via OperatorNamespace.
+		keycloakAdminSecretForTest(clientRegistrationTestOperatorNS),
 	).Build()
 
-	r := &ClientRegistrationReconciler{Client: c, Scheme: scheme}
+	r := &ClientRegistrationReconciler{
+		Client:            c,
+		Scheme:            scheme,
+		OperatorNamespace: clientRegistrationTestOperatorNS,
+	}
 	res, err := r.Reconcile(ctx, req)
 	if err != nil || res != (ctrl.Result{}) {
 		t.Fatalf("Reconcile: result=%v err=%v", res, err)

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -570,9 +570,16 @@ func perAgentConfigMapName(crName string) string {
 //
 // The synthesized shape matches what plugins expect:
 //   - jwt-validation.config.issuer from NamespaceConfig.Issuer
-//     (rest of the plugin's config comes from its defaults —
+//     (for matching the JWT `iss` claim — the PUBLIC Keycloak URL in
+//     split-horizon deployments). keycloak_url + keycloak_realm are
+//     also passed through so the plugin can derive jwks_url from the
+//     INTERNAL URL — the sidecar actually GETs this URL from inside
+//     the cluster, and the public hostname typically won't resolve
+//     from inside the mesh. See kagenti-extensions#383 for why the
+//     jwt-validation plugin needs its own copy of these fields.
+//     Other plugin settings fall back to their own defaults —
 //     audience_file=/shared/client-id.txt, bypass_paths=standard
-//     probes, jwks_url derived from issuer).
+//     probes.
 //   - token-exchange.config with Keycloak URL/realm, default_policy,
 //     and identity block keyed off ClientAuthType. File paths fall
 //     through to plugin defaults so operators don't have to
@@ -585,6 +592,15 @@ func synthesizePipeline(nsConfig *NamespaceConfig) map[string]interface{} {
 	jwtCfg := map[string]interface{}{}
 	if nsConfig.Issuer != "" {
 		jwtCfg["issuer"] = nsConfig.Issuer
+	}
+	// Pass keycloak_url + keycloak_realm through to jwt-validation so
+	// it can derive jwks_url from the internal URL rather than the
+	// public issuer. Mirrors the pair already handed to token-exchange.
+	if nsConfig.KeycloakURL != "" {
+		jwtCfg["keycloak_url"] = nsConfig.KeycloakURL
+	}
+	if nsConfig.KeycloakRealm != "" {
+		jwtCfg["keycloak_realm"] = nsConfig.KeycloakRealm
 	}
 
 	tokenCfg := map[string]interface{}{}

--- a/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
@@ -1098,6 +1098,16 @@ func TestEnsurePerAgentConfigMap_EmptyBaseYAML_FallbackFromNsConfig(t *testing.T
 	if got, want := jwtCfg["issuer"], "http://keycloak:8080/realms/kagenti"; got != want {
 		t.Errorf("jwt-validation.config.issuer = %v, want %v", got, want)
 	}
+	// keycloak_url + keycloak_realm are passed to jwt-validation so the
+	// plugin derives jwks_url from the internal URL. Required for
+	// split-horizon deployments where `issuer` (public) isn't reachable
+	// from inside the pod. See kagenti-extensions#383.
+	if got, want := jwtCfg["keycloak_url"], "http://keycloak:8080"; got != want {
+		t.Errorf("jwt-validation.config.keycloak_url = %v, want %v", got, want)
+	}
+	if got, want := jwtCfg["keycloak_realm"], "kagenti"; got != want {
+		t.Errorf("jwt-validation.config.keycloak_realm = %v, want %v", got, want)
+	}
 
 	tokCfg := pluginConfigAt(t, cfg, "outbound", "token-exchange")
 	if got, want := tokCfg["keycloak_url"], "http://keycloak:8080"; got != want {


### PR DESCRIPTION
## Summary

Follow-up to kagenti/kagenti-extensions#383 on the operator side. When a namespace's `authbridge-runtime-config` ConfigMap has no `pipeline:` of its own, `synthesizePipeline` builds one from `NamespaceConfig`. Today it passes `keycloak_url` + `keycloak_realm` only to the outbound token-exchange plugin; jwt-validation gets just `issuer`.

kagenti-extensions#383 extends jwt-validation to accept those same two fields and derive `jwks_url` from the INTERNAL Keycloak URL (required so the sidecar can actually reach the JWKS endpoint from inside the cluster — `issuer` is the public hostname, typically unreachable from inside the pod). This PR updates the operator to hand those fields to jwt-validation so synthesized configs work in split-horizon deployments.

## Why we hit this

Observed in kagenti/kagenti#1507 CI (weather-tool-advanced envoy-proxy stderr, with base chart-provided runtime-config — but synthesizePipeline is the fallback path for namespaces that bypass the chart entirely):

```
msg="JWT validation failed" error="fetching JWKS:
  Get \"http://keycloak.localtest.me:8080/realms/kagenti/protocol/openid-connect/certs\":
  dial tcp [::1]:8080: connect: connection refused"
```

The synthesized config emitted only `issuer`. jwt-validation fell back to issuer-derivation, got the public hostname, resolved it to 127.0.0.1 via `localtest.me` wildcard, and hit `connection refused`.

Pre-PR-#378 the binary ran `config.Resolve()` → `deriveJWKSURL()` which derived `inbound.jwks_url` from `outbound.token_url` via a cross-plugin pass. Per-plugin decode gone that pass away; this PR pays that forward by handing the same hints to both plugins.

## Scope

- `pod_mutator.go`: add two lines to `synthesizePipeline` — pass `KeycloakURL` / `KeycloakRealm` into `jwtCfg` alongside the existing pass into `tokenCfg`.
- `pod_mutator_test.go`: extend `TestEnsurePerAgentConfigMap_EmptyBaseYAML_FallbackFromNsConfig` to assert jwt-validation now receives both.

Doc comment on `synthesizePipeline` updated to explain the split-horizon expectation and link to extensions#383.

## Compatibility

Requires the authbridge sidecar binary to accept the new jwt-validation fields (decoded with `DisallowUnknownFields`). The chart in kagenti/kagenti#1507 bumps both pins together — the operator PR and the chart PR gate each other's merge.

## Test plan

- [x] `go test ./internal/webhook/injector/...` — all green (9 ensure-configmap tests, including the updated synthesize assertions)
- [ ] E2E green via the chart PR with matched pins

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
