### PR TITLE
fix: watch Sandbox resources in ClientRegistration controller

### DIFF
--- a/kagenti-operator/internal/controller/clientregistration_controller.go
+++ b/kagenti-operator/internal/controller/clientregistration_controller.go
@@ -19,6 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -80,6 +81,7 @@ func (r *ClientRegistrationReconciler) uncachedReader() client.Reader {
 
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
 
@@ -117,23 +119,58 @@ func (r *ClientRegistrationReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	sts := &appsv1.StatefulSet{}
-	if err := r.Get(ctx, req.NamespacedName, sts); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, sts); err == nil {
+		return r.reconcileOne(ctx, sts, injectTools, sts.Name, &sts.Spec.Template,
+			func(ctx context.Context) error {
+				return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					s := &appsv1.StatefulSet{}
+					if err := r.Get(ctx, req.NamespacedName, s); err != nil {
+						return err
+					}
+					if !injectKeycloakClientCredentialsAnnotation(&s.Spec.Template, keycloakClientCredentialsSecretName(s.Namespace, s.Name)) {
+						return nil
+					}
+					return r.Update(ctx, s)
+				})
+			})
+	}
+	if !apierrors.IsNotFound(err) {
+		return ctrl.Result{}, err
+	}
+
+	sbx := &unstructured.Unstructured{}
+	sbx.SetGroupVersionKind(sandboxGVK)
+	if err := r.Get(ctx, req.NamespacedName, sbx); err != nil {
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
 	}
-	return r.reconcileOne(ctx, sts, injectTools, sts.Name, &sts.Spec.Template,
+	podLabels, _, _ := unstructured.NestedStringMap(sbx.Object, "spec", "podTemplate", "metadata", "labels")
+	saName, _, _ := unstructured.NestedString(sbx.Object, "spec", "podTemplate", "spec", "serviceAccountName")
+	syntheticTemplate := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Labels: podLabels},
+		Spec:       corev1.PodSpec{ServiceAccountName: saName},
+	}
+	return r.reconcileOne(ctx, sbx, injectTools, sbx.GetName(), syntheticTemplate,
 		func(ctx context.Context) error {
 			return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				s := &appsv1.StatefulSet{}
-				if err := r.Get(ctx, req.NamespacedName, s); err != nil {
+				fresh := &unstructured.Unstructured{}
+				fresh.SetGroupVersionKind(sandboxGVK)
+				if err := r.Get(ctx, req.NamespacedName, fresh); err != nil {
 					return err
 				}
-				if !injectKeycloakClientCredentialsAnnotation(&s.Spec.Template, keycloakClientCredentialsSecretName(s.Namespace, s.Name)) {
+				secretName := keycloakClientCredentialsSecretName(fresh.GetNamespace(), fresh.GetName())
+				annotations, _, _ := unstructured.NestedStringMap(fresh.Object, "spec", "podTemplate", "metadata", "annotations")
+				if annotations != nil && annotations[AnnotationKeycloakClientSecretName] == secretName {
 					return nil
 				}
-				return r.Update(ctx, s)
+				if annotations == nil {
+					annotations = map[string]string{}
+				}
+				annotations[AnnotationKeycloakClientSecretName] = secretName
+				_ = unstructured.SetNestedStringMap(fresh.Object, annotations, "spec", "podTemplate", "metadata", "annotations")
+				return r.Update(ctx, fresh)
 			})
 		})
 }
@@ -437,6 +474,12 @@ func clientRegistrationWorkloadPredicate(obj client.Object) bool {
 		return workloadWantsOperatorClientReg(o.Spec.Template.Labels, true)
 	case *appsv1.StatefulSet:
 		return workloadWantsOperatorClientReg(o.Spec.Template.Labels, true)
+	case *unstructured.Unstructured:
+		if o.GroupVersionKind() != sandboxGVK {
+			return false
+		}
+		labels, _, _ := unstructured.NestedStringMap(o.Object, "spec", "podTemplate", "metadata", "labels")
+		return workloadWantsOperatorClientReg(labels, true)
 	default:
 		return false
 	}
@@ -446,13 +489,24 @@ func clientRegistrationWorkloadPredicate(obj client.Object) bool {
 // feature gates; the predicate uses injectTools=true so tool workloads are not dropped before gates load.
 func (r *ClientRegistrationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	pred := predicate.NewPredicateFuncs(clientRegistrationWorkloadPredicate)
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		Named("clientregistration").
 		For(&appsv1.Deployment{}, builder.WithPredicates(pred)).
 		Watches(
 			&appsv1.StatefulSet{},
 			&handler.EnqueueRequestForObject{},
 			builder.WithPredicates(pred),
-		).
-		Complete(r)
+		)
+
+	if SandboxCRDExists(mgr.GetConfig()) {
+		sandboxObj := &unstructured.Unstructured{}
+		sandboxObj.SetGroupVersionKind(sandboxGVK)
+		b = b.Watches(
+			sandboxObj,
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(pred),
+		)
+	}
+
+	return b.Complete(r)
 }

--- a/kagenti-operator/internal/controller/clientregistration_controller.go
+++ b/kagenti-operator/internal/controller/clientregistration_controller.go
@@ -99,7 +99,8 @@ func (r *ClientRegistrationReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	dep := &appsv1.Deployment{}
-	if err := r.Get(ctx, req.NamespacedName, dep); err == nil {
+	err = r.Get(ctx, req.NamespacedName, dep)
+	if err == nil {
 		return r.reconcileOne(ctx, dep, injectTools, dep.Name, &dep.Spec.Template,
 			func(ctx context.Context) error {
 				return retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -113,13 +114,13 @@ func (r *ClientRegistrationReconciler) Reconcile(ctx context.Context, req ctrl.R
 					return r.Update(ctx, d)
 				})
 			})
-	}
-	if !apierrors.IsNotFound(err) {
+	} else if !apierrors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
 
 	sts := &appsv1.StatefulSet{}
-	if err := r.Get(ctx, req.NamespacedName, sts); err == nil {
+	err = r.Get(ctx, req.NamespacedName, sts)
+	if err == nil {
 		return r.reconcileOne(ctx, sts, injectTools, sts.Name, &sts.Spec.Template,
 			func(ctx context.Context) error {
 				return retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -133,23 +134,23 @@ func (r *ClientRegistrationReconciler) Reconcile(ctx context.Context, req ctrl.R
 					return r.Update(ctx, s)
 				})
 			})
-	}
-	if !apierrors.IsNotFound(err) {
+	} else if !apierrors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
 
 	sbx := &unstructured.Unstructured{}
 	sbx.SetGroupVersionKind(sandboxGVK)
-	if err := r.Get(ctx, req.NamespacedName, sbx); err != nil {
+	if err = r.Get(ctx, req.NamespacedName, sbx); err != nil {
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
 	}
 	podLabels, _, _ := unstructured.NestedStringMap(sbx.Object, "spec", "podTemplate", "metadata", "labels")
+	podAnnotations, _, _ := unstructured.NestedStringMap(sbx.Object, "spec", "podTemplate", "metadata", "annotations")
 	saName, _, _ := unstructured.NestedString(sbx.Object, "spec", "podTemplate", "spec", "serviceAccountName")
 	syntheticTemplate := &corev1.PodTemplateSpec{
-		ObjectMeta: metav1.ObjectMeta{Labels: podLabels},
+		ObjectMeta: metav1.ObjectMeta{Labels: podLabels, Annotations: podAnnotations},
 		Spec:       corev1.PodSpec{ServiceAccountName: saName},
 	}
 	return r.reconcileOne(ctx, sbx, injectTools, sbx.GetName(), syntheticTemplate,
@@ -169,7 +170,9 @@ func (r *ClientRegistrationReconciler) Reconcile(ctx context.Context, req ctrl.R
 					annotations = map[string]string{}
 				}
 				annotations[AnnotationKeycloakClientSecretName] = secretName
-				_ = unstructured.SetNestedStringMap(fresh.Object, annotations, "spec", "podTemplate", "metadata", "annotations")
+				if err := unstructured.SetNestedStringMap(fresh.Object, annotations, "spec", "podTemplate", "metadata", "annotations"); err != nil {
+					return fmt.Errorf("setting podTemplate annotations: %w", err)
+				}
 				return r.Update(ctx, fresh)
 			})
 		})


### PR DESCRIPTION
## Summary

- Add Sandbox (`agents.x-k8s.io/v1alpha1`) as a watched resource type in `ClientRegistrationReconciler`
- Conditionally registers the watch only when the Sandbox CRD exists (mirrors `AgentRuntimeReconciler` pattern)
- Extracts pod template labels and serviceAccountName from the unstructured Sandbox spec
- Registers Keycloak OAuth client and patches `kagenti.io/keycloak-client-credentials-secret-name` annotation on the Sandbox podTemplate

**Why:** The controller only watched Deployment and StatefulSet, so Sandbox workloads deployed via the Sandbox epic (#1155) never got OAuth credentials registered — breaking AuthBridge authentication.

## Test plan

- [x] `go build ./...` — compiles clean
- [x] `go vet ./...` — no issues
- [x] Existing `TestClientRegistrationReconciler_Reconcile` tests pass (6/6)
- [x] Deploy a Sandbox workload with `kagenti.io/type: agent` label → verify operator watches Sandbox
- [ ] Verify `kagenti.io/keycloak-client-credentials-secret-name` annotation appears on Sandbox podTemplate (requires workload without legacy sidecar label)

## Verification (Kind cluster, v0.6.0-rc.1)

Operator built from this branch (rebased on v0.2.0-alpha.34) and deployed to Kind cluster.

**Controller now watches Sandbox resources (3 event sources instead of 2):**

```
$ kubectl logs deployment/kagenti-controller-manager -n kagenti-system | grep "Starting EventSource.*clientregistration"

{"msg":"Starting EventSource","controller":"clientregistration","source":"kind source: *unstructured.Unstructured"}
{"msg":"Starting EventSource","controller":"clientregistration","source":"kind source: *v1.Deployment"}
{"msg":"Starting EventSource","controller":"clientregistration","source":"kind source: *v1.StatefulSet"}
```

**Sandbox workload `weather-service-new` running 4/4 in team1:**

```
$ kubectl get pod weather-service-new -n team1

Init containers:
  proxy-init  ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.11

Containers:
  agent                        registry.cr-system.svc.cluster.local:5000/weather-service-new:v0.0.1
  envoy-proxy                  ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-alpha.11
  spiffe-helper                ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.11
  kagenti-client-registration  ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-alpha.11
```

This workload uses the legacy sidecar path (`kagenti.io/client-registration-inject: "true"`), so the operator-managed path correctly skips it. The fix enables the operator-managed path for Sandbox workloads that opt out of the legacy sidecar — matching Deployment/StatefulSet behavior.

## Workaround for local testing

The Helm chart passes `--enable-operator-client-registration=true` which requires building from the v0.2.0-alpha.34 base (not latest `main`). To test locally on Kind:

```bash
# Build from this branch (already rebased on v0.2.0-alpha.34)
cd kagenti-operator/
docker build -t ghcr.io/kagenti/kagenti-operator/kagenti-operator:sandbox-fix .

# Push to ghcr.io (Kind can't use kind load due to containerd snapshotter issue)
docker push ghcr.io/kagenti/kagenti-operator/kagenti-operator:sandbox-fix

# Patch the operator deployment
kubectl set image deployment/kagenti-controller-manager \
  manager=ghcr.io/kagenti/kagenti-operator/kagenti-operator:sandbox-fix \
  -n kagenti-system
```

**Important:** Use a unique tag each time (e.g. `sandbox-fix-v2`) because Kind nodes cache images by tag and `imagePullPolicy: IfNotPresent` won't repull a changed digest under the same tag.

Assisted-By: Claude Code