### PR TITLE
feat: add Sandbox support to AgentCardSync controller

### DIFF
--- a/kagenti-operator/internal/controller/agentcardsync_controller.go
+++ b/kagenti-operator/internal/controller/agentcardsync_controller.go
@@ -24,6 +24,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -55,6 +56,7 @@ type AgentCardSyncReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets/finalizers,verbs=update
+// +kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch
 
 func (r *AgentCardSyncReconciler) ReconcileDeployment(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	syncLogger.V(1).Info("Reconciling Deployment for auto-sync", "namespacedName", req.NamespacedName)
@@ -93,6 +95,25 @@ func (r *AgentCardSyncReconciler) ReconcileStatefulSet(ctx context.Context, req 
 
 	gvk := appsv1.SchemeGroupVersion.WithKind("StatefulSet")
 	return r.ensureAgentCard(ctx, statefulset, gvk)
+}
+
+func (r *AgentCardSyncReconciler) ReconcileSandbox(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	syncLogger.V(1).Info("Reconciling Sandbox for auto-sync", "namespacedName", req.NamespacedName)
+
+	sbx := &unstructured.Unstructured{}
+	sbx.SetGroupVersionKind(sandboxGVK)
+	if err := r.Get(ctx, req.NamespacedName, sbx); err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if !r.shouldSyncWorkload(sbx.GetLabels()) {
+		return ctrl.Result{}, nil
+	}
+
+	return r.ensureAgentCard(ctx, sbx, sandboxGVK)
 }
 
 func (r *AgentCardSyncReconciler) shouldSyncWorkload(labels map[string]string) bool {
@@ -399,6 +420,18 @@ func (r *AgentCardSyncReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
+	if SandboxCRDExists(mgr.GetConfig()) {
+		sandboxObj := &unstructured.Unstructured{}
+		sandboxObj.SetGroupVersionKind(sandboxGVK)
+		if err := ctrl.NewControllerManagedBy(mgr).
+			Named("agentcardsync-sandbox").
+			For(sandboxObj).
+			WithEventFilter(agentLabelPredicate()).
+			Complete(&sandboxReconcilerAdapter{r}); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -416,4 +449,12 @@ type statefulSetReconcilerAdapter struct {
 
 func (a *statefulSetReconcilerAdapter) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return a.ReconcileStatefulSet(ctx, req)
+}
+
+type sandboxReconcilerAdapter struct {
+	*AgentCardSyncReconciler
+}
+
+func (a *sandboxReconcilerAdapter) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	return a.ReconcileSandbox(ctx, req)
 }


### PR DESCRIPTION
## Summary

- Add `ReconcileSandbox` method using unstructured client to reconcile Sandbox workloads
- Register a separate named controller (`agentcardsync-sandbox`) with `SandboxCRDExists()` guard
- Add RBAC marker for `agents.x-k8s.io` sandboxes

This ensures AgentCards are auto-created for Sandbox workloads labelled with `kagenti.io/type: agent`, making agents discoverable via the A2A protocol.

Closes #339

## Test plan

- [ ] Deploy operator with Sandbox CRD installed → verify `agentcardsync-sandbox` controller registers
- [ ] Create a Sandbox with `kagenti.io/type: agent` + `protocol.kagenti.io/a2a: "true"` → verify AgentCard `<name>-sandbox-card` is created
- [ ] Deploy operator without Sandbox CRD → verify no error and controller is skipped

Assisted-By: Claude Code