### PR TITLE
feat: add Sandbox support to AgentCard controller

### DIFF
--- a/kagenti-operator/internal/controller/agentcard_controller.go
+++ b/kagenti-operator/internal/controller/agentcard_controller.go
@@ -140,6 +140,7 @@ type AgentCardReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch
 
 func (r *AgentCardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	agentCardLogger.V(1).Info("Reconciling AgentCard", "namespacedName", req.NamespacedName)
@@ -1281,6 +1282,16 @@ func (r *AgentCardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.mapWorkloadToAgentCard("apps/v1", "StatefulSet")),
 			builder.WithPredicates(workloadPredicates),
 		)
+
+	if SandboxCRDExists(mgr.GetConfig()) {
+		sandboxObj := &unstructured.Unstructured{}
+		sandboxObj.SetGroupVersionKind(sandboxGVK)
+		controllerBuilder = controllerBuilder.Watches(
+			sandboxObj,
+			handler.EnqueueRequestsFromMapFunc(r.mapWorkloadToAgentCard("agents.x-k8s.io/v1alpha1", "Sandbox")),
+			builder.WithPredicates(workloadPredicates),
+		)
+	}
 
 	return controllerBuilder.
 		Named("AgentCard").

--- a/kagenti-operator/internal/controller/indexers_test.go
+++ b/kagenti-operator/internal/controller/indexers_test.go
@@ -23,7 +23,10 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	agentv1alpha1 "github.com/kagenti/operator/api/v1alpha1"
 )
 
 var _ = Describe("mapWorkloadToAgentCards", func() {
@@ -79,6 +82,51 @@ var _ = Describe("mapWorkloadToAgentCards", func() {
 
 			mapFn := mapWorkloadToAgentCards(k8sClient, "apps/v1", "Deployment", logger)
 			requests := mapFn(ctx, deploy)
+			Expect(requests).To(BeEmpty())
+		})
+	})
+
+	Context("when a Sandbox workload has agent labels and matching AgentCard exists", func() {
+		It("should return a reconcile request for the AgentCard", func() {
+			card := &agentv1alpha1.AgentCard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sandbox-card",
+					Namespace: namespace,
+				},
+				Spec: agentv1alpha1.AgentCardSpec{
+					TargetRef: &agentv1alpha1.TargetRef{
+						APIVersion: "agents.x-k8s.io/v1alpha1",
+						Kind:       "Sandbox",
+						Name:       "my-sandbox",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, card)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, card) })
+
+			sbx := &unstructured.Unstructured{}
+			sbx.SetGroupVersionKind(sandboxGVK)
+			sbx.SetName("my-sandbox")
+			sbx.SetNamespace(namespace)
+			sbx.SetLabels(map[string]string{LabelAgentType: LabelValueAgent})
+
+			mapFn := mapWorkloadToAgentCards(k8sClient, "agents.x-k8s.io/v1alpha1", "Sandbox", logger)
+			requests := mapFn(ctx, sbx)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].Name).To(Equal("sandbox-card"))
+		})
+	})
+
+	Context("when a Sandbox workload lacks agent labels", func() {
+		It("should return no reconcile requests", func() {
+			sbx := &unstructured.Unstructured{}
+			sbx.SetGroupVersionKind(sandboxGVK)
+			sbx.SetName("unlabeled-sandbox")
+			sbx.SetNamespace(namespace)
+			sbx.SetLabels(map[string]string{"app": "something"})
+
+			mapFn := mapWorkloadToAgentCards(k8sClient, "agents.x-k8s.io/v1alpha1", "Sandbox", logger)
+			requests := mapFn(ctx, sbx)
 			Expect(requests).To(BeEmpty())
 		})
 	})


### PR DESCRIPTION
## Summary

- Add conditional Sandbox Watches in `SetupWithManager` with `SandboxCRDExists()` guard
- Use `mapWorkloadToAgentCard("agents.x-k8s.io/v1alpha1", "Sandbox")` to enqueue AgentCard reconciliation on Sandbox changes
- Add RBAC marker for `agents.x-k8s.io` sandboxes

This ensures that changes to Sandbox workloads (label updates, scaling, etc.) trigger reconciliation of the associated AgentCard's status fields.

Closes #340

## Test plan

- [ ] Deploy operator with Sandbox CRD installed → verify Sandbox watch is registered
- [ ] Update a Sandbox with `kagenti.io/type: agent` that has an AgentCard → verify AgentCard status is refreshed
- [ ] Deploy operator without Sandbox CRD → verify no error and watch is skipped

Assisted-By: Claude Code