### PR TITLE
fix(test): register field indexer in controller test suite (#351)

### DIFF
--- a/kagenti-operator/internal/controller/indexers_test.go
+++ b/kagenti-operator/internal/controller/indexers_test.go
@@ -110,7 +110,7 @@ var _ = Describe("mapWorkloadToAgentCards", func() {
 			sbx.SetNamespace(namespace)
 			sbx.SetLabels(map[string]string{LabelAgentType: LabelValueAgent})
 
-			mapFn := mapWorkloadToAgentCards(k8sClient, "agents.x-k8s.io/v1alpha1", "Sandbox", logger)
+			mapFn := mapWorkloadToAgentCards(indexedClient, "agents.x-k8s.io/v1alpha1", "Sandbox", logger)
 			requests := mapFn(ctx, sbx)
 			Expect(requests).To(HaveLen(1))
 			Expect(requests[0].Name).To(Equal("sandbox-card"))

--- a/kagenti-operator/internal/controller/suite_test.go
+++ b/kagenti-operator/internal/controller/suite_test.go
@@ -28,10 +28,12 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	agentv1alpha1 "github.com/kagenti/operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
@@ -41,11 +43,12 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx       context.Context
-	cancel    context.CancelFunc
-	testEnv   *envtest.Environment
-	cfg       *rest.Config
-	k8sClient client.Client
+	ctx           context.Context
+	cancel        context.CancelFunc
+	testEnv       *envtest.Environment
+	cfg           *rest.Config
+	k8sClient     client.Client
+	indexedClient client.Client
 )
 
 func TestControllers(t *testing.T) {
@@ -87,6 +90,22 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:  scheme.Scheme,
+		Metrics: metricsserver.Options{BindAddress: "0"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = RegisterAgentCardTargetRefIndex(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(ctx)).To(Succeed())
+	}()
+
+	indexedClient = mgr.GetClient()
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
## Summary

- Register `AgentCard` `.spec.targetRef.name` field indexer in the controller test suite's `BeforeSuite`
- Replace plain `client.New()` with a `ctrl.Manager`-backed client that has the indexer registered
- Fixes the `mapWorkloadToAgentCards` test that fails with `field label not supported: .spec.targetRef.name`

Fixes #351

## Root Cause

`suite_test.go` created a plain `client.New(cfg, ...)` without a `ctrl.Manager`. The `mapWorkloadToAgentCards` function queries with `client.MatchingFields{".spec.targetRef.name": ...}` which requires the field indexer registered by `RegisterAgentCardTargetRefIndex(mgr)`. In production, the three controllers all register this in `SetupWithManager`, but the test suite skipped it.

## Changes

| File | What |
|------|------|
| `internal/controller/suite_test.go` | Create `ctrl.Manager`, register `AgentCardTargetRefIndex`, start manager, use `mgr.GetClient()` |

## Test Results

All 5 `mapWorkloadToAgentCards` specs pass (previously 1 failed):

```
Ran 5 of 163 Specs in 7.441 seconds
SUCCESS! -- 5 Passed | 0 Failed | 0 Pending | 158 Skipped
```

Assisted-By: Claude Code