### PR TITLE
Docs: provide text for 'oc explain' on operator CRDs

### DIFF
--- a/kagenti-operator/api/v1alpha1/agentcard_types.go
+++ b/kagenti-operator/api/v1alpha1/agentcard_types.go
@@ -345,7 +345,9 @@ type SkillParameter struct {
 // +kubebuilder:printcolumn:name="LastSync",type="date",JSONPath=".status.lastSyncTime",description="Last Sync Time"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
-// AgentCard is the Schema for the agentcards API.
+// AgentCard binds an A2A agent card to a backing workload. The controller periodically
+// fetches the card from the referenced workload, verifies its JWS signature and SPIFFE
+// identity against the configured trust domain, and caches the result in status.
 type AgentCard struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/kagenti-operator/api/v1alpha1/agentruntime_types.go
+++ b/kagenti-operator/api/v1alpha1/agentruntime_types.go
@@ -124,7 +124,9 @@ type AgentRuntimeStatus struct {
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Runtime Phase"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
-// AgentRuntime is the Schema for the agentruntimes API.
+// AgentRuntime attaches runtime configuration to a backing workload classified as an
+// agent or tool, providing per-workload overrides for SPIFFE identity and OpenTelemetry
+// tracing. The controller reports pod configuration coverage and phase in status.
 type AgentRuntime struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/kagenti-operator/config/crd/bases/agent.kagenti.dev_agentcards.yaml
+++ b/kagenti-operator/config/crd/bases/agent.kagenti.dev_agentcards.yaml
@@ -56,7 +56,10 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: AgentCard is the Schema for the agentcards API.
+        description: |-
+          AgentCard binds an A2A agent card to a backing workload. The controller periodically
+          fetches the card from the referenced workload, verifies its JWS signature and SPIFFE
+          identity against the configured trust domain, and caches the result in status.
         properties:
           apiVersion:
             description: |-

--- a/kagenti-operator/config/crd/bases/agent.kagenti.dev_agentruntimes.yaml
+++ b/kagenti-operator/config/crd/bases/agent.kagenti.dev_agentruntimes.yaml
@@ -36,7 +36,10 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: AgentRuntime is the Schema for the agentruntimes API.
+        description: |-
+          AgentRuntime attaches runtime configuration to a backing workload classified as an
+          agent or tool, providing per-workload overrides for SPIFFE identity and OpenTelemetry
+          tracing. The controller reports pod configuration coverage and phase in status.
         properties:
           apiVersion:
             description: |-

--- a/kagenti-operator/config/webhook/manifests.yaml
+++ b/kagenti-operator/config/webhook/manifests.yaml
@@ -13,28 +13,6 @@ webhooks:
       path: /mutate-workloads-authbridge
   failurePolicy: Fail
   name: inject.kagenti.io
-  namespaceSelector:
-    matchExpressions:
-    - key: kubernetes.io/metadata.name
-      operator: NotIn
-      values:
-      - kube-system
-      - kube-public
-      - kube-node-lease
-      - kagenti-operator-system
-    matchLabels:
-      kagenti-enabled: "true"
-  objectSelector:
-    matchExpressions:
-    - key: kagenti.io/type
-      operator: In
-      values:
-      - agent
-      - tool
-    - key: kagenti.io/inject
-      operator: NotIn
-      values:
-      - disabled
   reinvocationPolicy: IfNeeded
   rules:
   - apiGroups:
@@ -46,7 +24,6 @@ webhooks:
     resources:
     - pods
   sideEffects: None
-  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/kagenti-operator/config/webhook/manifests.yaml
+++ b/kagenti-operator/config/webhook/manifests.yaml
@@ -13,6 +13,28 @@ webhooks:
       path: /mutate-workloads-authbridge
   failurePolicy: Fail
   name: inject.kagenti.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - kube-public
+      - kube-node-lease
+      - kagenti-operator-system
+    matchLabels:
+      kagenti-enabled: "true"
+  objectSelector:
+    matchExpressions:
+    - key: kagenti.io/type
+      operator: In
+      values:
+      - agent
+      - tool
+    - key: kagenti.io/inject
+      operator: NotIn
+      values:
+      - disabled
   reinvocationPolicy: IfNeeded
   rules:
   - apiGroups:
@@ -24,6 +46,7 @@ webhooks:
     resources:
     - pods
   sideEffects: None
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration


### PR DESCRIPTION
## Summary

Kubernetes and OpenShift admins use `oc explain` to understand CRDs.

The previous output for our CRDs was based on generated Go code and very confusing:

```
oc explain agentcard
...
DESCRIPTION:
     AgentCard is the Schema for the agentcards API.
...
```

This PR gives a real description for each of our CRDs.

## (Optional) Testing Instructions

```bash
make manifests
kubectl apply -f config/crd/bases/agent.kagenti.dev_agentcards.yaml 
kubectl apply -f config/crd/bases/agent.kagenti.dev_agentruntimes.yaml
oc explain agentcard
oc explain agentruntimes
```

With this change, the output should include

```
DESCRIPTION:
     AgentCard binds an A2A agent card to a backing workload. The controller
     periodically fetches the card from the referenced workload, verifies its
     JWS signature and SPIFFE identity against the configured trust domain, and
     caches the result in status.
```

and

```
DESCRIPTION:
     AgentRuntime attaches runtime configuration to a backing workload
     classified as an agent or tool, providing per-workload overrides for SPIFFE
     identity and OpenTelemetry tracing. The controller reports pod
     configuration coverage and phase in status.
```

Note: Running `make manifest`, overrides The namespaceSelector, objectSelector, and timeoutSeconds: 10 that were deliberately added manually to _config/webhook/manifests.yaml_ in commits 19918ea and b89651f .  If we plan to continue allowing `make manifest` to work, we should probably also make the changes to _authbridge_webhook.go_:214.