### PR TITLE
fix(keycloak): add omitempty to protocolMapperRep.ID to prevent ghost PK

### DIFF
--- a/kagenti-operator/internal/keycloak/audience.go
+++ b/kagenti-operator/internal/keycloak/audience.go
@@ -39,7 +39,7 @@ type clientScopeCreateRep struct {
 }
 
 type protocolMapperRep struct {
-	ID              string            `json:"id"`
+	ID              string            `json:"id,omitempty"`
 	Name            string            `json:"name"`
 	Protocol        string            `json:"protocol"`
 	ProtocolMapper  string            `json:"protocolMapper"`


### PR DESCRIPTION
## Summary

- Add `omitempty` to `protocolMapperRep.ID` JSON tag so the zero-value `""` is omitted from POST payloads, allowing Keycloak to auto-generate mapper UUIDs

## Root cause

The `protocolMapperRep` struct serializes the zero-value ID field as `"id":""` in POST requests. Keycloak accepts this as an explicit primary key, inserting a row with PK `""` into the `PROTOCOL_MAPPER` table. Every subsequent mapper creation — for any agent, any scope — fails with:

```
duplicate key value violates unique constraint "constraint_pcm"
Detail: Key (id)=() already exists.
```

The operator's 409 handler does a GET to verify the mapper exists, but the ghost row (`id=""`) is not returned by the Keycloak REST API. The handler returns `nil`, the next reconcile retries with the same result, and the mapper is never created. This causes `"aud" not satisfied` 401 errors on all agents with AuthBridge enabled.

## Affected versions

This affects all deployments where the operator creates audience scopes (PR #360 / `EnsureAudienceScope`). The first agent deployed poisons the DB for all subsequent agents.

## Recovery

Existing deployments with the ghost row need a one-time DB cleanup:

```sql
DELETE FROM protocol_mapper_config WHERE protocol_mapper_id = '';
DELETE FROM protocol_mapper WHERE id = '';
```

After the cleanup + operator upgrade, new agents get correct audience mappers automatically.

## Test plan

- [x] Verified ghost row in Keycloak Postgres (`SELECT * FROM protocol_mapper WHERE id = ''`)
- [x] Deleted ghost row, rebuilt operator with fix, deployed to Kind
- [x] New agent with AuthBridge: audience mapper created with proper UUID, no 401

Assisted-By: Claude Code