### PR TITLE
fix(rbac): add sandboxes/finalizers permission for owner references

### DIFF
--- a/charts/kagenti-operator/templates/rbac/role.yaml
+++ b/charts/kagenti-operator/templates/rbac/role.yaml
@@ -103,6 +103,12 @@ rules:
 - apiGroups:
   - agents.x-k8s.io
   resources:
+  - sandboxes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - agents.x-k8s.io
+  resources:
   - sandboxes/scale
   verbs:
   - get

--- a/kagenti-operator/config/rbac/role.yaml
+++ b/kagenti-operator/config/rbac/role.yaml
@@ -92,6 +92,12 @@ rules:
 - apiGroups:
   - agents.x-k8s.io
   resources:
+  - sandboxes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - agents.x-k8s.io
+  resources:
   - sandboxes/scale
   verbs:
   - get

--- a/kagenti-operator/internal/controller/agentcardsync_controller.go
+++ b/kagenti-operator/internal/controller/agentcardsync_controller.go
@@ -57,6 +57,7 @@ type AgentCardSyncReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets/finalizers,verbs=update
 // +kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes/finalizers,verbs=update
 
 func (r *AgentCardSyncReconciler) ReconcileDeployment(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	syncLogger.V(1).Info("Reconciling Deployment for auto-sync", "namespacedName", req.NamespacedName)

--- a/kagenti-operator/internal/controller/clientregistration_controller.go
+++ b/kagenti-operator/internal/controller/clientregistration_controller.go
@@ -82,6 +82,7 @@ func (r *ClientRegistrationReconciler) uncachedReader() client.Reader {
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
 

--- a/kagenti-operator/internal/controller/clientregistration_controller.go
+++ b/kagenti-operator/internal/controller/clientregistration_controller.go
@@ -80,7 +80,9 @@ func (r *ClientRegistrationReconciler) uncachedReader() client.Reader {
 }
 
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=apps,resources=statefulsets/finalizers,verbs=update
 // +kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch


### PR DESCRIPTION
## Summary

- Add `sandboxes/finalizers` update permission to the operator ClusterRole
- Fixes Sandbox deployments failing on OpenShift with `cannot set blockOwnerDeletion` errors
- Updates kubebuilder markers, generated `config/rbac/role.yaml`, and Helm chart

## Problem

The `clientregistration` and `agentcardsync` controllers create Secrets and AgentCards with `blockOwnerDeletion` owner references pointing to Sandbox CRs. OpenShift enforces that the controller service account must have `update` permission on the owner resource's `finalizers` subresource. Without it:

```
secrets "kagenti-keycloak-client-credentials-<hash>" is forbidden:
  cannot set blockOwnerDeletion if an ownerReference refers to a resource
  you can't set finalizers on
```

This was not caught on Kind (which does not enforce this RBAC check) but breaks all Sandbox-type agent deployments on OpenShift.

## Changes

| File | Change |
|------|--------|
| `clientregistration_controller.go` | Add `+kubebuilder:rbac` marker for `sandboxes/finalizers` |
| `agentcardsync_controller.go` | Add `+kubebuilder:rbac` marker for `sandboxes/finalizers` |
| `config/rbac/role.yaml` | Add generated rule |
| `charts/.../rbac/role.yaml` | Add Helm chart rule |

Follows the existing pattern for `deployments/finalizers` and `statefulsets/finalizers`.

## Test plan

- [x] Verified fix on ROSA 4.19 cluster by patching the ClusterRole live — operator successfully created the missing secret and stuck Sandbox pod recovered to Running
- [ ] CI: verify unit tests pass with updated RBAC markers

Assisted-By: Claude Code