### PR TITLE
refactor: consolidate redundant spireEnabled checks

### DIFF
--- a/kagenti-operator/internal/webhook/injector/container_builder.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder.go
@@ -109,22 +109,21 @@ func (b *ContainerBuilder) BuildEnvoyProxyContainerWithSpireOption(spireEnabled 
 		},
 	}
 	if spireEnabled {
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "svid-output",
-			MountPath: "/opt",
-			ReadOnly:  true,
-		})
-	}
-
-	if spireEnabled {
-		// authbridge-envoy bundles spiffe-helper; the entrypoint reads
-		// helper.conf from this mount. Without it, the bundled
-		// spiffe-helper would fail to start on SPIRE_ENABLED=true.
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "spiffe-helper-config",
-			MountPath: "/etc/spiffe-helper",
-			ReadOnly:  true,
-		})
+		volumeMounts = append(volumeMounts,
+			corev1.VolumeMount{
+				Name:      "svid-output",
+				MountPath: "/opt",
+				ReadOnly:  true,
+			},
+			// authbridge-envoy bundles spiffe-helper; the entrypoint reads
+			// helper.conf from this mount. Without it, the bundled
+			// spiffe-helper would fail to start on SPIRE_ENABLED=true.
+			corev1.VolumeMount{
+				Name:      "spiffe-helper-config",
+				MountPath: "/etc/spiffe-helper",
+				ReadOnly:  true,
+			},
+		)
 	}
 
 	var env []corev1.EnvVar


### PR DESCRIPTION
## Summary

Consolidates two consecutive `if spireEnabled` blocks in `BuildEnvoyProxyContainerWithSpireOption` into a single conditional block.

## Changes

- Merged lines 111-117 and 119-128 in `container_builder.go`
- Both volume mounts (`svid-output` and `spiffe-helper-config`) now added in a single `append` call
- Preserved the comment explaining why `spiffe-helper-config` is needed

## Testing

- ✅ All existing tests pass
- No functional changes, purely refactoring for readability

## Before

```go
if spireEnabled {
    volumeMounts = append(volumeMounts, corev1.VolumeMount{...})
}

if spireEnabled {
    volumeMounts = append(volumeMounts, corev1.VolumeMount{...})
}
```

## After

```go
if spireEnabled {
    volumeMounts = append(volumeMounts,
        corev1.VolumeMount{...},
        corev1.VolumeMount{...},
    )
}
```

Assisted-By: Claude Code