### PR TITLE
fix(injector): Mount spire-agent-socket into authbridge containers

### DIFF
--- a/kagenti-operator/internal/webhook/injector/container_builder.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder.go
@@ -124,16 +124,19 @@ func (b *ContainerBuilder) BuildEnvoyProxyContainerWithSpireOption(spireEnabled 
 				ReadOnly:  true,
 			},
 			// SPIRE workload-API socket. The bundled spiffe-helper inside
-			// the combined image dials unix:///spiffe-workload-api/spire-agent.sock
-			// (per defaults.go SocketPath). The CSI volume `spire-agent-socket`
-			// is already declared at the Pod level in volume_builder.go;
-			// without this mount the helper sits in a silent dial-loop and
-			// never writes /opt/svid*.pem or /opt/jwt_svid.token. Hidden
-			// until kagenti-extensions PR #424 (mTLS) became the first
-			// real consumer of SPIRE-issued material.
+			// the combined image dials the SocketPath from defaults.go's
+			// SpiffeConfig (default unix:///spiffe-workload-api/spire-agent.sock).
+			// The CSI volume `spire-agent-socket` is already declared at
+			// the Pod level in volume_builder.go; without this mount the
+			// helper sits in a silent dial-loop and never writes
+			// /opt/svid*.pem or /opt/jwt_svid.token. Hidden until
+			// kagenti-extensions PR #424 (mTLS) became the first real
+			// consumer of SPIRE-issued material. Mount path derived from
+			// SpiffeConfig.SocketPath so the three sites — defaults.go,
+			// here, and the proxy-sidecar variant below — can never drift.
 			corev1.VolumeMount{
 				Name:      "spire-agent-socket",
-				MountPath: "/spiffe-workload-api",
+				MountPath: spireSocketDir(b.cfg.Spiffe.SocketPath),
 				ReadOnly:  true,
 			},
 		)
@@ -200,6 +203,27 @@ func spireEnabledStr(b bool) string {
 	return "false"
 }
 
+// spireSocketDir returns the directory portion of the SPIRE workload-API
+// socket path, suitable for use as a container mountPath. Drops the
+// "unix://" scheme prefix and strips the trailing socket filename so
+// e.g. "unix:///spiffe-workload-api/spire-agent.sock" yields
+// "/spiffe-workload-api". Single source of truth: defaults.go's
+// SpiffeConfig.SocketPath. Returns "" when the input has no path
+// component (caller should fall back to a hardcoded default in that
+// edge case, but the configured default is a well-formed unix:// URI).
+func spireSocketDir(socketPath string) string {
+	stripped := strings.TrimPrefix(socketPath, "unix://")
+	if stripped == "" || stripped == "/" {
+		return ""
+	}
+	// path.Dir would import "path"; using strings to avoid the
+	// dependency for a one-liner.
+	if i := strings.LastIndex(stripped, "/"); i > 0 {
+		return stripped[:i]
+	}
+	return ""
+}
+
 // BuildProxySidecarContainer creates a combined authbridge container for proxy-sidecar mode.
 // Uses the authbridge image (authbridge-proxy + spiffe-helper bundled, no Envoy).
 // The app uses HTTP_PROXY env vars to route outbound traffic through the forward proxy.
@@ -248,17 +272,13 @@ func (b *ContainerBuilder) BuildProxySidecarContainerWithPorts(spireEnabled bool
 				MountPath: "/etc/spiffe-helper",
 				ReadOnly:  true,
 			},
-			// SPIRE workload-API socket. The bundled spiffe-helper inside
-			// the combined image dials unix:///spiffe-workload-api/spire-agent.sock
-			// (per defaults.go SocketPath). The CSI volume `spire-agent-socket`
-			// is already declared at the Pod level in volume_builder.go;
-			// without this mount the helper sits in a silent dial-loop and
-			// never writes /opt/svid*.pem or /opt/jwt_svid.token. Hidden
-			// until kagenti-extensions PR #424 (mTLS) became the first
-			// real consumer of SPIRE-issued material.
+			// SPIRE workload-API socket. See the matching mount in
+			// BuildEnvoyProxyContainerWithSpireOption for the full
+			// rationale. Mount path derived from SpiffeConfig.SocketPath
+			// (single source of truth in defaults.go).
 			corev1.VolumeMount{
 				Name:      "spire-agent-socket",
-				MountPath: "/spiffe-workload-api",
+				MountPath: spireSocketDir(b.cfg.Spiffe.SocketPath),
 				ReadOnly:  true,
 			},
 		)

--- a/kagenti-operator/internal/webhook/injector/container_builder.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder.go
@@ -123,6 +123,19 @@ func (b *ContainerBuilder) BuildEnvoyProxyContainerWithSpireOption(spireEnabled 
 				MountPath: "/etc/spiffe-helper",
 				ReadOnly:  true,
 			},
+			// SPIRE workload-API socket. The bundled spiffe-helper inside
+			// the combined image dials unix:///spiffe-workload-api/spire-agent.sock
+			// (per defaults.go SocketPath). The CSI volume `spire-agent-socket`
+			// is already declared at the Pod level in volume_builder.go;
+			// without this mount the helper sits in a silent dial-loop and
+			// never writes /opt/svid*.pem or /opt/jwt_svid.token. Hidden
+			// until kagenti-extensions PR #424 (mTLS) became the first
+			// real consumer of SPIRE-issued material.
+			corev1.VolumeMount{
+				Name:      "spire-agent-socket",
+				MountPath: "/spiffe-workload-api",
+				ReadOnly:  true,
+			},
 		)
 	}
 
@@ -233,6 +246,19 @@ func (b *ContainerBuilder) BuildProxySidecarContainerWithPorts(spireEnabled bool
 			corev1.VolumeMount{
 				Name:      "spiffe-helper-config",
 				MountPath: "/etc/spiffe-helper",
+				ReadOnly:  true,
+			},
+			// SPIRE workload-API socket. The bundled spiffe-helper inside
+			// the combined image dials unix:///spiffe-workload-api/spire-agent.sock
+			// (per defaults.go SocketPath). The CSI volume `spire-agent-socket`
+			// is already declared at the Pod level in volume_builder.go;
+			// without this mount the helper sits in a silent dial-loop and
+			// never writes /opt/svid*.pem or /opt/jwt_svid.token. Hidden
+			// until kagenti-extensions PR #424 (mTLS) became the first
+			// real consumer of SPIRE-issued material.
+			corev1.VolumeMount{
+				Name:      "spire-agent-socket",
+				MountPath: "/spiffe-workload-api",
 				ReadOnly:  true,
 			},
 		)

--- a/kagenti-operator/internal/webhook/injector/container_builder.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder.go
@@ -18,6 +18,7 @@ package injector
 
 import (
 	"fmt"
+	"path"
 	"strconv"
 	"strings"
 
@@ -123,17 +124,8 @@ func (b *ContainerBuilder) BuildEnvoyProxyContainerWithSpireOption(spireEnabled 
 				MountPath: "/etc/spiffe-helper",
 				ReadOnly:  true,
 			},
-			// SPIRE workload-API socket. The bundled spiffe-helper inside
-			// the combined image dials the SocketPath from defaults.go's
-			// SpiffeConfig (default unix:///spiffe-workload-api/spire-agent.sock).
-			// The CSI volume `spire-agent-socket` is already declared at
-			// the Pod level in volume_builder.go; without this mount the
-			// helper sits in a silent dial-loop and never writes
-			// /opt/svid*.pem or /opt/jwt_svid.token. Hidden until
-			// kagenti-extensions PR #424 (mTLS) became the first real
-			// consumer of SPIRE-issued material. Mount path derived from
-			// SpiffeConfig.SocketPath so the three sites — defaults.go,
-			// here, and the proxy-sidecar variant below — can never drift.
+			// SPIRE workload-API socket — bundled spiffe-helper dials it.
+			// Path derived from SpiffeConfig.SocketPath (defaults.go).
 			corev1.VolumeMount{
 				Name:      "spire-agent-socket",
 				MountPath: spireSocketDir(b.cfg.Spiffe.SocketPath),
@@ -204,24 +196,16 @@ func spireEnabledStr(b bool) string {
 }
 
 // spireSocketDir returns the directory portion of the SPIRE workload-API
-// socket path, suitable for use as a container mountPath. Drops the
-// "unix://" scheme prefix and strips the trailing socket filename so
-// e.g. "unix:///spiffe-workload-api/spire-agent.sock" yields
-// "/spiffe-workload-api". Single source of truth: defaults.go's
-// SpiffeConfig.SocketPath. Returns "" when the input has no path
-// component (caller should fall back to a hardcoded default in that
-// edge case, but the configured default is a well-formed unix:// URI).
+// socket path (e.g. "unix:///spiffe-workload-api/spire-agent.sock" →
+// "/spiffe-workload-api"), suitable for use as a container mountPath.
+// Single source of truth: defaults.go's SpiffeConfig.SocketPath.
 func spireSocketDir(socketPath string) string {
 	stripped := strings.TrimPrefix(socketPath, "unix://")
-	if stripped == "" || stripped == "/" {
+	dir := path.Dir(stripped)
+	if dir == "." || dir == "/" {
 		return ""
 	}
-	// path.Dir would import "path"; using strings to avoid the
-	// dependency for a one-liner.
-	if i := strings.LastIndex(stripped, "/"); i > 0 {
-		return stripped[:i]
-	}
-	return ""
+	return dir
 }
 
 // BuildProxySidecarContainer creates a combined authbridge container for proxy-sidecar mode.
@@ -272,10 +256,8 @@ func (b *ContainerBuilder) BuildProxySidecarContainerWithPorts(spireEnabled bool
 				MountPath: "/etc/spiffe-helper",
 				ReadOnly:  true,
 			},
-			// SPIRE workload-API socket. See the matching mount in
-			// BuildEnvoyProxyContainerWithSpireOption for the full
-			// rationale. Mount path derived from SpiffeConfig.SocketPath
-			// (single source of truth in defaults.go).
+			// SPIRE workload-API socket — bundled spiffe-helper dials it.
+			// Path derived from SpiffeConfig.SocketPath (defaults.go).
 			corev1.VolumeMount{
 				Name:      "spire-agent-socket",
 				MountPath: spireSocketDir(b.cfg.Spiffe.SocketPath),

--- a/kagenti-operator/internal/webhook/injector/container_builder_test.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder_test.go
@@ -392,15 +392,26 @@ func TestBuildProxySidecarContainer_SpireEnabled(t *testing.T) {
 // combined image dials this socket; without the mount it sits in a
 // silent dial-loop and never writes /opt/svid*.pem.
 func TestBuildEnvoyProxyContainer_SpireEnabled_HasSocketMount(t *testing.T) {
-	builder := NewContainerBuilder(config.CompiledDefaults())
+	cfg := config.CompiledDefaults()
+	builder := NewContainerBuilder(cfg)
 	container := builder.BuildEnvoyProxyContainerWithSpireOption(true)
+
+	// Derive the expected mount path from SpiffeConfig.SocketPath the
+	// same way the production code does, so a future change to the
+	// canonical SocketPath in defaults.go can't leave this test
+	// asserting against a stale literal.
+	wantPath := spireSocketDir(cfg.Spiffe.SocketPath)
+	if wantPath == "" {
+		t.Fatalf("spireSocketDir(%q) returned empty — defaults must declare a valid socket path", cfg.Spiffe.SocketPath)
+	}
 
 	found := false
 	for _, vm := range container.VolumeMounts {
 		if vm.Name == "spire-agent-socket" {
 			found = true
-			if vm.MountPath != "/spiffe-workload-api" {
-				t.Errorf("spire-agent-socket mount path = %q, want /spiffe-workload-api (matches defaults.go SocketPath)", vm.MountPath)
+			if vm.MountPath != wantPath {
+				t.Errorf("spire-agent-socket mount path = %q, want %q (derived from SpiffeConfig.SocketPath %q)",
+					vm.MountPath, wantPath, cfg.Spiffe.SocketPath)
 			}
 			if !vm.ReadOnly {
 				t.Error("spire-agent-socket mount should be read-only (CSI volume itself is read-only)")
@@ -432,15 +443,22 @@ func TestBuildEnvoyProxyContainer_SpireDisabled_NoSocketMount(t *testing.T) {
 // the envoy-proxy variant but for the proxy-sidecar combined image.
 // The bundled spiffe-helper has the same workload-API requirement.
 func TestBuildProxySidecarContainer_SpireEnabled_HasSocketMount(t *testing.T) {
-	builder := NewContainerBuilder(config.CompiledDefaults())
+	cfg := config.CompiledDefaults()
+	builder := NewContainerBuilder(cfg)
 	container := builder.BuildProxySidecarContainer(true)
+
+	wantPath := spireSocketDir(cfg.Spiffe.SocketPath)
+	if wantPath == "" {
+		t.Fatalf("spireSocketDir(%q) returned empty — defaults must declare a valid socket path", cfg.Spiffe.SocketPath)
+	}
 
 	found := false
 	for _, vm := range container.VolumeMounts {
 		if vm.Name == "spire-agent-socket" {
 			found = true
-			if vm.MountPath != "/spiffe-workload-api" {
-				t.Errorf("spire-agent-socket mount path = %q, want /spiffe-workload-api (matches defaults.go SocketPath)", vm.MountPath)
+			if vm.MountPath != wantPath {
+				t.Errorf("spire-agent-socket mount path = %q, want %q (derived from SpiffeConfig.SocketPath %q)",
+					vm.MountPath, wantPath, cfg.Spiffe.SocketPath)
 			}
 			if !vm.ReadOnly {
 				t.Error("spire-agent-socket mount should be read-only (CSI volume itself is read-only)")

--- a/kagenti-operator/internal/webhook/injector/container_builder_test.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder_test.go
@@ -385,3 +385,83 @@ func TestBuildProxySidecarContainer_SpireEnabled(t *testing.T) {
 		t.Error("svid-output volume mount should be present when SPIRE is enabled")
 	}
 }
+
+// TestBuildEnvoyProxyContainer_SpireEnabled_HasSocketMount asserts that
+// the SPIRE workload-API socket volume is mounted into the envoy-proxy
+// container when SPIRE is on. The bundled spiffe-helper inside the
+// combined image dials this socket; without the mount it sits in a
+// silent dial-loop and never writes /opt/svid*.pem.
+func TestBuildEnvoyProxyContainer_SpireEnabled_HasSocketMount(t *testing.T) {
+	builder := NewContainerBuilder(config.CompiledDefaults())
+	container := builder.BuildEnvoyProxyContainerWithSpireOption(true)
+
+	found := false
+	for _, vm := range container.VolumeMounts {
+		if vm.Name == "spire-agent-socket" {
+			found = true
+			if vm.MountPath != "/spiffe-workload-api" {
+				t.Errorf("spire-agent-socket mount path = %q, want /spiffe-workload-api (matches defaults.go SocketPath)", vm.MountPath)
+			}
+			if !vm.ReadOnly {
+				t.Error("spire-agent-socket mount should be read-only (CSI volume itself is read-only)")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("envoy-proxy container missing spire-agent-socket mount when SPIRE is enabled — bundled spiffe-helper can't reach the workload API")
+	}
+}
+
+// TestBuildEnvoyProxyContainer_SpireDisabled_NoSocketMount: with SPIRE
+// off the socket mount must be absent — there's no spiffe-helper to
+// dial the socket, and mounting it would still try to schedule the
+// CSI volume.
+func TestBuildEnvoyProxyContainer_SpireDisabled_NoSocketMount(t *testing.T) {
+	builder := NewContainerBuilder(config.CompiledDefaults())
+	container := builder.BuildEnvoyProxyContainerWithSpireOption(false)
+
+	for _, vm := range container.VolumeMounts {
+		if vm.Name == "spire-agent-socket" {
+			t.Error("envoy-proxy container should NOT have spire-agent-socket mount when SPIRE is disabled")
+		}
+	}
+}
+
+// TestBuildProxySidecarContainer_SpireEnabled_HasSocketMount: same as
+// the envoy-proxy variant but for the proxy-sidecar combined image.
+// The bundled spiffe-helper has the same workload-API requirement.
+func TestBuildProxySidecarContainer_SpireEnabled_HasSocketMount(t *testing.T) {
+	builder := NewContainerBuilder(config.CompiledDefaults())
+	container := builder.BuildProxySidecarContainer(true)
+
+	found := false
+	for _, vm := range container.VolumeMounts {
+		if vm.Name == "spire-agent-socket" {
+			found = true
+			if vm.MountPath != "/spiffe-workload-api" {
+				t.Errorf("spire-agent-socket mount path = %q, want /spiffe-workload-api (matches defaults.go SocketPath)", vm.MountPath)
+			}
+			if !vm.ReadOnly {
+				t.Error("spire-agent-socket mount should be read-only (CSI volume itself is read-only)")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("proxy-sidecar container missing spire-agent-socket mount when SPIRE is enabled — bundled spiffe-helper can't reach the workload API")
+	}
+}
+
+// TestBuildProxySidecarContainer_SpireDisabled_NoSocketMount mirrors
+// the envoy-proxy negative test for the proxy-sidecar variant.
+func TestBuildProxySidecarContainer_SpireDisabled_NoSocketMount(t *testing.T) {
+	builder := NewContainerBuilder(config.CompiledDefaults())
+	container := builder.BuildProxySidecarContainer(false)
+
+	for _, vm := range container.VolumeMounts {
+		if vm.Name == "spire-agent-socket" {
+			t.Error("proxy-sidecar container should NOT have spire-agent-socket mount when SPIRE is disabled")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The webhook creates the `spire-agent-socket` POD-level volume (CSI driver `csi.spiffe.io`) when `spire-enabled` is true, but **never mounts it into either authbridge container**. The bundled `spiffe-helper` inside the combined authbridge images dials `unix:///spiffe-workload-api/spire-agent.sock` (per `internal/webhook/config/defaults.go:73`'s `SocketPath`) and sits in a silent dial-loop forever because the directory doesn't exist in the container.

This PR completes the bundled-spiffe-helper migration alluded to in `injection_decision.go:22`'s TODO — when the standalone spiffe-helper sidecar was removed and the helper moved into the combined authbridge images, the volume mount got lost.

## Why this was hidden

No in-production workload actually consumes SPIRE-issued material today:

- **`token-exchange`** uses `/shared/client-secret.txt` (Keycloak `client_credentials` from a Secret the operator provisions), not JWT-SVIDs.
- **`jwt-validation`** uses JWKS over HTTP, not SPIRE.
- `/opt/svid*.pem` and `/opt/jwt_svid.token` sit empty in every spire-enabled pod. Verified: `weather-agent` has been running 3+ days with `kagenti.io/spire: enabled` and `/opt/` empty the whole time.

[`kagenti-extensions` PR #424](https://github.com/kagenti/kagenti-extensions/pull/424) (mTLS between authbridge sidecars via SPIRE X.509 SVIDs) is the first workload that actually consumes SPIRE material. Without this fix, the mTLS feature can't function — `tls.ServerConfig` errors at construction when `/opt/svid.pem` is missing.

## Change

Two locations in `internal/webhook/injector/container_builder.go`:

1. **`BuildEnvoyProxyContainerWithSpireOption`** (envoy-sidecar mode)
2. **`BuildProxySidecarContainerWithPorts`** (proxy-sidecar / lite modes)

Both append `spire-agent-socket → /spiffe-workload-api` (ReadOnly) inside the existing `if spireEnabled` block.

The mount path `/spiffe-workload-api` matches the `SocketPath` in `defaults.go`. ReadOnly is correct — the CSI volume itself is already declared read-only at the Pod level (`volume_builder.go:170`).

## Test plan

- [x] `go test -race -count=1 ./internal/webhook/injector/...` — all pass, including new tests:
  - `TestBuildEnvoyProxyContainer_SpireEnabled_HasSocketMount` — locks mount presence + path + ReadOnly when SPIRE is on
  - `TestBuildEnvoyProxyContainer_SpireDisabled_NoSocketMount` — asserts absent when SPIRE is off
  - `TestBuildProxySidecarContainer_SpireEnabled_HasSocketMount` — same shape for proxy-sidecar
  - `TestBuildProxySidecarContainer_SpireDisabled_NoSocketMount` — proxy-sidecar negative case
- [x] `go vet ./...`, `gofmt -l` clean
- [x] Built operator image, kind-loaded, restarted controller-manager. Mtls demo pods now render with the new mount in their spec; kubelet correctly attempts to mount (proves the operator change is live).
- [ ] CI passes
- [ ] Full e2e mTLS demo verification deferred to PR #424's reviewer once the SPIRE agent + CSI driver are restored on the test cluster — they were absent during local verification, blocking the mount-success path but not the operator's correctness.

## Files

- `internal/webhook/injector/container_builder.go` — 2 mount additions, ~24 LOC including comments
- `internal/webhook/injector/container_builder_test.go` — 4 new test functions, ~80 LOC

Net: +106 / 0.

## Out of scope

- **`MTLSMode` resolution chain** (AgentRuntime CR spec + namespace ConfigMap + per-agent ConfigMap merge). Deferred to a follow-up operator PR. Keeps the demo's namespace-ConfigMap patch as the interim until that lands.
- **Renaming the deprecated `kagenti.io/spiffe-helper-inject` label** to `kagenti.io/spire-enabled` (TODO at `injection_decision.go:22`). Separate breaking-label PR.

## Release coordination

This fix should be released alongside `kagenti-extensions` PR #424 (or before it). Without this operator fix landing first, the authbridge mTLS feature can't function in any deployment.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
