### PR TITLE
feat(authbridge): Wire mtlsMode through to per-agent config

### DIFF
--- a/charts/kagenti-operator/crds/agent.kagenti.dev_agentcards.yaml
+++ b/charts/kagenti-operator/crds/agent.kagenti.dev_agentcards.yaml
@@ -34,10 +34,10 @@ spec:
       jsonPath: .status.card.name
       name: Agent
       type: string
-    - description: Signature Verified
-      jsonPath: .status.validSignature
+    - description: Identity Verified
+      jsonPath: .status.conditions[?(@.type=='Verified')].status
       name: Verified
-      type: boolean
+      type: string
     - description: Identity Bound
       jsonPath: .status.bindingStatus.bound
       name: Bound
@@ -53,10 +53,18 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - description: Attested Agent SPIFFE ID
+      jsonPath: .status.attestedAgentSpiffeId
+      name: AttestedAgent
+      priority: 1
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: AgentCard is the Schema for the agentcards API.
+        description: |-
+          AgentCard binds an A2A agent card to a backing workload. The controller periodically
+          fetches the card from the referenced workload, verifies its JWS signature and SPIFFE
+          identity against the configured trust domain, and caches the result in status.
         properties:
           apiVersion:
             description: |-
@@ -84,8 +92,11 @@ spec:
                   strict:
                     default: false
                     description: |-
-                      Strict enables enforcement mode: binding failures trigger network isolation.
-                      When false (default), results are recorded in status only (audit mode).
+                      Strict controls whether binding failures trigger enforcement actions
+                      (label removal, restrictive NetworkPolicy).
+                      When true, binding failure removes the verified label and applies restrictive NetworkPolicy.
+                      When false (default), binding results are recorded in status only;
+                      the workload retains its verified label and permissive policy.
                     type: boolean
                   trustDomain:
                     description: |-
@@ -126,6 +137,11 @@ spec:
           status:
             description: AgentCardStatus defines the observed state of AgentCard.
             properties:
+              attestedAgentSpiffeId:
+                description: |-
+                  AttestedAgentSpiffeID is the SPIFFE ID extracted from the agent's TLS peer certificate
+                  during authenticated (mTLS) fetch. Set only when verifiedFetch is enabled and successful.
+                type: string
               bindingStatus:
                 description: BindingStatus contains the result of identity binding
                   evaluation

--- a/charts/kagenti-operator/crds/agent.kagenti.dev_agentruntimes.yaml
+++ b/charts/kagenti-operator/crds/agent.kagenti.dev_agentruntimes.yaml
@@ -36,7 +36,10 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: AgentRuntime is the Schema for the agentruntimes API.
+        description: |-
+          AgentRuntime attaches runtime configuration to a backing workload classified as an
+          agent or tool, providing per-workload overrides for SPIFFE identity and OpenTelemetry
+          tracing. The controller reports pod configuration coverage and phase in status.
         properties:
           apiVersion:
             description: |-
@@ -58,6 +61,39 @@ spec:
           spec:
             description: AgentRuntimeSpec defines the desired state of AgentRuntime.
             properties:
+              authBridgeMode:
+                description: |-
+                  AuthBridgeMode selects the deployment shape for this workload's
+                  authbridge sidecar. When unset, the namespace-level
+                  authbridge-runtime-config ConfigMap's mode is used; if that is
+                  also unset, the operator falls back to "proxy-sidecar".
+
+                  Four valid values:
+
+                    proxy-sidecar  HTTP_PROXY env + authbridge-proxy (full plugin
+                                   set, including a2a/mcp/inference parsers) +
+                                   spiffe-helper bundled. No Envoy, no iptables.
+                                   Default mode.
+                    envoy-sidecar  Envoy + ext_proc authbridge + spiffe-helper
+                                   bundled. Requires the proxy-init iptables
+                                   container.
+                    lite           Same listener layout as proxy-sidecar but uses
+                                   the authbridge-lite image (jwt-validation +
+                                   token-exchange only, parsers dropped to shrink
+                                   the binary). For size-constrained deployments
+                                   that don't need protocol-aware abctl events.
+                    waypoint       Standalone deployment, not injected as a
+                                   sidecar. Used by Istio ambient mesh.
+
+                  Set this when a single workload needs a different shape than the
+                  namespace default. Most deployments leave it unset and let the
+                  namespace ConfigMap drive the choice.
+                enum:
+                - proxy-sidecar
+                - envoy-sidecar
+                - lite
+                - waypoint
+                type: string
               identity:
                 description: Identity specifies optional per-workload identity overrides
                 properties:
@@ -72,6 +108,37 @@ spec:
                         type: string
                     type: object
                 type: object
+              mtlsMode:
+                description: |-
+                  MTLSMode selects the mTLS posture between authbridge sidecars on
+                  the proxy-sidecar / lite paths. envoy-sidecar handles transport
+                  security through Envoy SDS, which is currently not configured by
+                  the kagenti envoy-config — admission rejects mtlsMode != disabled
+                  when authBridgeMode is envoy-sidecar (tracked as a follow-up).
+
+                  Three valid values:
+
+                    disabled    Plaintext between sidecars (default).
+                    permissive  Inbound: byte-peek listener accepts both TLS and
+                                plaintext on the same port. Outbound: tries TLS,
+                                falls back to plaintext on handshake failure (one-line
+                                WARN log per fallback). Use during rollout.
+                    strict      Inbound: TLS-only, plaintext callers closed at
+                                accept. Outbound: TLS-or-fail. Use after rollout
+                                completes.
+
+                  Resolution: AgentRuntime CR > namespace authbridge-runtime-config
+                  mtls.mode > "disabled". Setting mtlsMode != disabled implicitly
+                  requires SPIRE — the operator auto-enables spire for the workload.
+
+                  Note: changing mtlsMode triggers a pod rollout because authbridge
+                  cannot hot-reload mTLS config (the byte-peek listener is wired at
+                  process start).
+                enum:
+                - disabled
+                - permissive
+                - strict
+                type: string
               targetRef:
                 description: TargetRef identifies the workload backing this agent
                   runtime (duck typing).

--- a/kagenti-operator/Makefile
+++ b/kagenti-operator/Makefile
@@ -61,6 +61,25 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd:allowDangerousTypes=true webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(MAKE) sync-chart-crds
+
+# sync-chart-crds keeps charts/kagenti-operator/crds/ in lockstep with
+# config/crd/bases/. Helm's crds/ directory is the install path consumers
+# get when they `helm install`; without this sync the chart copy drifts
+# silently every time a CRD field is added (which has happened multiple
+# times before — commits 677f63d, 21a2258, 4eb62af). Runs as the final
+# step of `make manifests` so the chart copy reflects the freshly
+# regenerated controller-gen output. Skips the stub `_.yaml` file
+# controller-gen sometimes emits.
+.PHONY: sync-chart-crds
+sync-chart-crds: ## Mirror config/crd/bases/ into charts/kagenti-operator/crds/.
+	@for f in $$(ls config/crd/bases/*.yaml 2>/dev/null); do \
+		base=$$(basename $$f); \
+		case $$base in \
+			_.yaml) ;; \
+			*) cp $$f ../charts/kagenti-operator/crds/$$base ;; \
+		esac; \
+	done
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/kagenti-operator/api/v1alpha1/agentruntime_types.go
+++ b/kagenti-operator/api/v1alpha1/agentruntime_types.go
@@ -90,6 +90,35 @@ type AgentRuntimeSpec struct {
 	// +optional
 	// +kubebuilder:validation:Enum=proxy-sidecar;envoy-sidecar;lite;waypoint
 	AuthBridgeMode string `json:"authBridgeMode,omitempty"`
+
+	// MTLSMode selects the mTLS posture between authbridge sidecars on
+	// the proxy-sidecar / lite paths. envoy-sidecar handles transport
+	// security through Envoy SDS, which is currently not configured by
+	// the kagenti envoy-config — admission rejects mtlsMode != disabled
+	// when authBridgeMode is envoy-sidecar (tracked as a follow-up).
+	//
+	// Three valid values:
+	//
+	//   disabled    Plaintext between sidecars (default).
+	//   permissive  Inbound: byte-peek listener accepts both TLS and
+	//               plaintext on the same port. Outbound: tries TLS,
+	//               falls back to plaintext on handshake failure (one-line
+	//               WARN log per fallback). Use during rollout.
+	//   strict      Inbound: TLS-only, plaintext callers closed at
+	//               accept. Outbound: TLS-or-fail. Use after rollout
+	//               completes.
+	//
+	// Resolution: AgentRuntime CR > namespace authbridge-runtime-config
+	// mtls.mode > "disabled". Setting mtlsMode != disabled implicitly
+	// requires SPIRE — the operator auto-enables spire for the workload.
+	//
+	// Note: changing mtlsMode triggers a pod rollout because authbridge
+	// cannot hot-reload mTLS config (the byte-peek listener is wired at
+	// process start).
+	//
+	// +optional
+	// +kubebuilder:validation:Enum=disabled;permissive;strict
+	MTLSMode string `json:"mtlsMode,omitempty"`
 }
 
 // IdentitySpec configures workload identity for an AgentRuntime.

--- a/kagenti-operator/api/v1alpha1/agentruntime_types.go
+++ b/kagenti-operator/api/v1alpha1/agentruntime_types.go
@@ -112,6 +112,13 @@ type AgentRuntimeSpec struct {
 	// mtls.mode > "disabled". Setting mtlsMode != disabled implicitly
 	// requires SPIRE — the operator auto-enables spire for the workload.
 	//
+	// CR-empty vs CR="disabled" are observably different in
+	// `kubectl get agentruntime -o yaml` (the former omits the field,
+	// the latter shows mtlsMode: disabled) but produce the same
+	// effective mode: empty falls through to the namespace ConfigMap,
+	// "disabled" is an explicit override that pins mode off even when
+	// the namespace default is non-disabled.
+	//
 	// Note: changing mtlsMode triggers a pod rollout because authbridge
 	// cannot hot-reload mTLS config (the byte-peek listener is wired at
 	// process start).

--- a/kagenti-operator/config/crd/bases/agent.kagenti.dev_agentruntimes.yaml
+++ b/kagenti-operator/config/crd/bases/agent.kagenti.dev_agentruntimes.yaml
@@ -108,6 +108,37 @@ spec:
                         type: string
                     type: object
                 type: object
+              mtlsMode:
+                description: |-
+                  MTLSMode selects the mTLS posture between authbridge sidecars on
+                  the proxy-sidecar / lite paths. envoy-sidecar handles transport
+                  security through Envoy SDS, which is currently not configured by
+                  the kagenti envoy-config — admission rejects mtlsMode != disabled
+                  when authBridgeMode is envoy-sidecar (tracked as a follow-up).
+
+                  Three valid values:
+
+                    disabled    Plaintext between sidecars (default).
+                    permissive  Inbound: byte-peek listener accepts both TLS and
+                                plaintext on the same port. Outbound: tries TLS,
+                                falls back to plaintext on handshake failure (one-line
+                                WARN log per fallback). Use during rollout.
+                    strict      Inbound: TLS-only, plaintext callers closed at
+                                accept. Outbound: TLS-or-fail. Use after rollout
+                                completes.
+
+                  Resolution: AgentRuntime CR > namespace authbridge-runtime-config
+                  mtls.mode > "disabled". Setting mtlsMode != disabled implicitly
+                  requires SPIRE — the operator auto-enables spire for the workload.
+
+                  Note: changing mtlsMode triggers a pod rollout because authbridge
+                  cannot hot-reload mTLS config (the byte-peek listener is wired at
+                  process start).
+                enum:
+                - disabled
+                - permissive
+                - strict
+                type: string
               targetRef:
                 description: TargetRef identifies the workload backing this agent
                   runtime (duck typing).

--- a/kagenti-operator/internal/controller/agentruntime_config.go
+++ b/kagenti-operator/internal/controller/agentruntime_config.go
@@ -43,6 +43,12 @@ const (
 
 	// LabelNamespaceDefaults identifies namespace-level defaults ConfigMaps.
 	LabelNamespaceDefaults = "kagenti.io/defaults"
+
+	// AuthBridgeRuntimeConfigMapName is the namespace-scoped ConfigMap that
+	// holds the authbridge runtime config (config.yaml). Edits to this
+	// ConfigMap are watched by AgentRuntimeReconciler so the resolved-config
+	// hash picks them up and rolls affected workloads.
+	AuthBridgeRuntimeConfigMapName = "authbridge-runtime-config"
 )
 
 // resolvedConfig is the canonical representation used for hash computation.
@@ -64,14 +70,16 @@ type resolvedConfig struct {
 	// effect. Including them here folds CR-edit changes into the
 	// config-hash so applyWorkloadConfig stamps a new hash on the pod
 	// template and the Deployment rolls.
-	//
-	// Namespace-level changes to the authbridge-runtime-config ConfigMap
-	// are NOT captured here today — that ConfigMap is consumed by the
-	// admission webhook, not the hash path. Operators editing the
-	// namespace ConfigMap should kubectl rollout restart the affected
-	// workload manually.
 	AuthBridgeMode string `json:"authBridgeMode,omitempty"`
 	MTLSMode       string `json:"mtlsMode,omitempty"`
+
+	// AuthBridgeRuntime captures the namespace authbridge-runtime-config
+	// ConfigMap's config.yaml content so namespace-level edits flow into
+	// the hash. Stored as the raw string (not parsed) because authbridge
+	// pipelines/listener/mtls config drift through here in any shape and
+	// we want any byte change to roll the workload. Empty string when
+	// the ConfigMap doesn't exist in the namespace.
+	AuthBridgeRuntime string `json:"authBridgeRuntime,omitempty"`
 }
 
 type traceConfig struct {
@@ -125,9 +133,19 @@ func resolveConfig(ctx context.Context, c client.Reader, namespace string, spec 
 	}
 	merged := mergeMaps(clusterDefaults, nsDefaults)
 
+	// Layer 2b: namespace authbridge-runtime-config (config.yaml).
+	// Captured raw so any byte change rolls the workload. The CM may
+	// not exist in every agent namespace; absence is normal and the
+	// admission webhook falls back to its own defaults.
+	abRuntime := ""
+	if data := readConfigMapData(ctx, c, namespace, AuthBridgeRuntimeConfigMapName); len(data) > 0 {
+		abRuntime = data["config.yaml"]
+	}
+
 	resolved := resolvedConfig{
-		FeatureGates: featureGates,
-		Defaults:     merged,
+		FeatureGates:      featureGates,
+		Defaults:          merged,
+		AuthBridgeRuntime: abRuntime,
 	}
 
 	if spec == nil {

--- a/kagenti-operator/internal/controller/agentruntime_config.go
+++ b/kagenti-operator/internal/controller/agentruntime_config.go
@@ -58,6 +58,20 @@ type resolvedConfig struct {
 	Trace        *traceConfig      `json:"trace,omitempty"`
 	FeatureGates map[string]string `json:"featureGates,omitempty"`
 	Defaults     map[string]string `json:"defaults,omitempty"`
+
+	// AuthBridgeMode and MTLSMode change the injected sidecar shape /
+	// transport posture, both of which require a pod restart to take
+	// effect. Including them here folds CR-edit changes into the
+	// config-hash so applyWorkloadConfig stamps a new hash on the pod
+	// template and the Deployment rolls.
+	//
+	// Namespace-level changes to the authbridge-runtime-config ConfigMap
+	// are NOT captured here today — that ConfigMap is consumed by the
+	// admission webhook, not the hash path. Operators editing the
+	// namespace ConfigMap should kubectl rollout restart the affected
+	// workload manually.
+	AuthBridgeMode string `json:"authBridgeMode,omitempty"`
+	MTLSMode       string `json:"mtlsMode,omitempty"`
 }
 
 type traceConfig struct {
@@ -142,6 +156,9 @@ func resolveConfig(ctx context.Context, c client.Reader, namespace string, spec 
 			resolved.Trace.Rate = spec.Trace.Sampling.Rate
 		}
 	}
+
+	resolved.AuthBridgeMode = spec.AuthBridgeMode
+	resolved.MTLSMode = spec.MTLSMode
 
 	return resolved, warnings
 }

--- a/kagenti-operator/internal/controller/agentruntime_config.go
+++ b/kagenti-operator/internal/controller/agentruntime_config.go
@@ -79,6 +79,15 @@ type resolvedConfig struct {
 	// pipelines/listener/mtls config drift through here in any shape and
 	// we want any byte change to roll the workload. Empty string when
 	// the ConfigMap doesn't exist in the namespace.
+	//
+	// Operational note: a single edit to authbridge-runtime-config
+	// re-hashes every AgentRuntime in the namespace and reconciles them
+	// in a burst. Kubernetes sequences the actual pod rolls per
+	// Deployment, but the controller's reconcile load scales linearly
+	// with the number of AgentRuntimes. For typical small namespaces
+	// (single-digit agents) this is fine; in larger deployments,
+	// formatting / whitespace edits to this CM during peak hours will
+	// trigger a noticeable rollout fan-out.
 	AuthBridgeRuntime string `json:"authBridgeRuntime,omitempty"`
 }
 

--- a/kagenti-operator/internal/controller/agentruntime_config_test.go
+++ b/kagenti-operator/internal/controller/agentruntime_config_test.go
@@ -257,6 +257,37 @@ var _ = Describe("AgentRuntime Config", func() {
 			r2, _ := ComputeConfigHash(ctx, k8sClient, namespace, spec)
 			Expect(r1.Hash).NotTo(Equal(r2.Hash))
 		})
+
+		It("should change when authbridge-runtime-config edits", func() {
+			// Edits to the namespace authbridge-runtime-config (which the
+			// admission webhook reads at pod creation) must roll
+			// affected workloads. The hash captures its config.yaml
+			// content as a raw string so any byte change registers.
+			abCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      AuthBridgeRuntimeConfigMapName,
+					Namespace: namespace,
+				},
+				Data: map[string]string{
+					"config.yaml": "mode: proxy-sidecar\n",
+				},
+			}
+			Expect(k8sClient.Create(ctx, abCM)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, abCM) }()
+
+			spec := &agentv1alpha1.AgentRuntimeSpec{
+				Type:      agentv1alpha1.RuntimeTypeAgent,
+				TargetRef: agentv1alpha1.TargetRef{APIVersion: "apps/v1", Kind: "Deployment", Name: "hash-abruntime"},
+			}
+
+			r1, _ := ComputeConfigHash(ctx, k8sClient, namespace, spec)
+
+			abCM.Data["config.yaml"] = "mode: proxy-sidecar\nmtls:\n  mode: strict\n"
+			Expect(k8sClient.Update(ctx, abCM)).To(Succeed())
+
+			r2, _ := ComputeConfigHash(ctx, k8sClient, namespace, spec)
+			Expect(r1.Hash).NotTo(Equal(r2.Hash))
+		})
 	})
 
 	Context("ComputeDefaultsOnlyHash", func() {
@@ -548,7 +579,19 @@ var _ = Describe("AgentRuntime Config", func() {
 			requests := r.mapNamespaceConfigMapToAgentRuntimes(ctx, cm)
 			Expect(requests).NotTo(BeEmpty())
 
-			// Should not match ConfigMap without label
+			// Should also match authbridge-runtime-config (matched by name,
+			// no label required). Editing this CM is the operator-facing
+			// way to change mtls / mode / pipeline plugins for the whole
+			// namespace; without this watch the rollout never fires.
+			abCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: AuthBridgeRuntimeConfigMapName, Namespace: namespace,
+				},
+			}
+			Expect(r.mapNamespaceConfigMapToAgentRuntimes(ctx, abCM)).NotTo(BeEmpty())
+
+			// Should not match ConfigMap without label and not named
+			// authbridge-runtime-config (random unrelated CM).
 			noLabel := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "no-label", Namespace: namespace},
 			}

--- a/kagenti-operator/internal/controller/agentruntime_config_test.go
+++ b/kagenti-operator/internal/controller/agentruntime_config_test.go
@@ -258,6 +258,46 @@ var _ = Describe("AgentRuntime Config", func() {
 			Expect(r1.Hash).NotTo(Equal(r2.Hash))
 		})
 
+		It("should change when MTLSMode flips on the CR", func() {
+			// CR-side parallel to the CM-edit test below: spec.mtlsMode
+			// must feed the hash so flipping disabled→strict on a CR
+			// rolls the workload. Without an explicit assertion a
+			// future refactor that drops MTLSMode from resolvedConfig
+			// would silently regress rollout-on-CR-edit.
+			specOff := &agentv1alpha1.AgentRuntimeSpec{
+				Type:      agentv1alpha1.RuntimeTypeAgent,
+				TargetRef: agentv1alpha1.TargetRef{APIVersion: "apps/v1", Kind: "Deployment", Name: "hash-mtls-cr"},
+				MTLSMode:  "disabled",
+			}
+			specOn := &agentv1alpha1.AgentRuntimeSpec{
+				Type:      agentv1alpha1.RuntimeTypeAgent,
+				TargetRef: agentv1alpha1.TargetRef{APIVersion: "apps/v1", Kind: "Deployment", Name: "hash-mtls-cr"},
+				MTLSMode:  "strict",
+			}
+
+			r1, _ := ComputeConfigHash(ctx, k8sClient, namespace, specOff)
+			r2, _ := ComputeConfigHash(ctx, k8sClient, namespace, specOn)
+			Expect(r1.Hash).NotTo(Equal(r2.Hash))
+		})
+
+		It("should change when AuthBridgeMode flips on the CR", func() {
+			// Bonus: AuthBridgeMode rollouts had a pre-existing gap
+			// (not in resolvedConfig) that this PR closed. Lock it.
+			specA := &agentv1alpha1.AgentRuntimeSpec{
+				Type:           agentv1alpha1.RuntimeTypeAgent,
+				TargetRef:      agentv1alpha1.TargetRef{APIVersion: "apps/v1", Kind: "Deployment", Name: "hash-abm-cr"},
+				AuthBridgeMode: "proxy-sidecar",
+			}
+			specB := &agentv1alpha1.AgentRuntimeSpec{
+				Type:           agentv1alpha1.RuntimeTypeAgent,
+				TargetRef:      agentv1alpha1.TargetRef{APIVersion: "apps/v1", Kind: "Deployment", Name: "hash-abm-cr"},
+				AuthBridgeMode: "lite",
+			}
+			r1, _ := ComputeConfigHash(ctx, k8sClient, namespace, specA)
+			r2, _ := ComputeConfigHash(ctx, k8sClient, namespace, specB)
+			Expect(r1.Hash).NotTo(Equal(r2.Hash))
+		})
+
 		It("should change when authbridge-runtime-config edits", func() {
 			// Edits to the namespace authbridge-runtime-config (which the
 			// admission webhook reads at pod creation) must roll

--- a/kagenti-operator/internal/controller/agentruntime_controller.go
+++ b/kagenti-operator/internal/controller/agentruntime_controller.go
@@ -643,11 +643,27 @@ func (r *AgentRuntimeReconciler) mapClusterConfigMapToAgentRuntimes(ctx context.
 	return agentRuntimesToRequests(rtList.Items)
 }
 
-// mapNamespaceConfigMapToAgentRuntimes maps changes to namespace-level defaults
-// ConfigMaps (kagenti.io/defaults=true) to AgentRuntimes in the same namespace.
+// mapNamespaceConfigMapToAgentRuntimes maps changes to relevant
+// namespace-scoped ConfigMaps to AgentRuntimes in the same namespace.
+// Two ConfigMap shapes are watched:
+//
+//  1. Namespace defaults — labeled kagenti.io/defaults=true. Folded into
+//     resolvedConfig.Defaults during resolveConfig.
+//  2. authbridge-runtime-config (matched by name, no label required) —
+//     this is the ConfigMap the admission webhook reads at pod creation.
+//     Editing it should trigger a rollout of every AgentRuntime in the
+//     namespace because the per-agent ConfigMap is rebuilt from this
+//     content on every pod admission.
+//
+// Both signals enqueue every AgentRuntime in the namespace; the
+// reconciler's hash check filters out no-op cases (only AgentRuntimes
+// whose computed hash actually changed re-stamp the pod template).
 func (r *AgentRuntimeReconciler) mapNamespaceConfigMapToAgentRuntimes(ctx context.Context, obj client.Object) []reconcile.Request {
 	labels := obj.GetLabels()
-	if labels[LabelNamespaceDefaults] != "true" {
+	isNsDefaults := labels[LabelNamespaceDefaults] == "true"
+	isAuthBridgeRuntime := obj.GetName() == AuthBridgeRuntimeConfigMapName
+
+	if !isNsDefaults && !isAuthBridgeRuntime {
 		return nil
 	}
 

--- a/kagenti-operator/internal/controller/agentruntime_controller.go
+++ b/kagenti-operator/internal/controller/agentruntime_controller.go
@@ -660,7 +660,14 @@ func (r *AgentRuntimeReconciler) mapClusterConfigMapToAgentRuntimes(ctx context.
 // whose computed hash actually changed re-stamp the pod template).
 func (r *AgentRuntimeReconciler) mapNamespaceConfigMapToAgentRuntimes(ctx context.Context, obj client.Object) []reconcile.Request {
 	labels := obj.GetLabels()
-	isNsDefaults := labels[LabelNamespaceDefaults] == "true"
+	// goconst flags this literal as the 11th "true" in the codebase and
+	// suggests reusing AnnotationRestartPendingValue, but that constant
+	// is semantically a restart-pending marker, not a generic label-true
+	// value — reusing it would obscure intent. Existing code (e.g.
+	// defaults_config_reconciler.go) uses the same literal-true idiom
+	// for label checks; rather than introduce a fresh `labelValueTrue`
+	// constant only here, suppress the rule on this one line.
+	isNsDefaults := labels[LabelNamespaceDefaults] == "true" //nolint:goconst
 	isAuthBridgeRuntime := obj.GetName() == AuthBridgeRuntimeConfigMapName
 
 	if !isNsDefaults && !isAuthBridgeRuntime {

--- a/kagenti-operator/internal/webhook/injector/agentruntime_config.go
+++ b/kagenti-operator/internal/webhook/injector/agentruntime_config.go
@@ -54,6 +54,12 @@ type AgentRuntimeOverrides struct {
 	// authbridge-runtime-config mode (if set) or the cluster fallback
 	// applies.
 	AuthBridgeMode *string
+
+	// mTLS posture — from .spec.mtlsMode
+	// Nil = no per-workload override; the namespace's
+	// authbridge-runtime-config mtls.mode (if set) or "disabled"
+	// applies.
+	MTLSMode *string
 }
 
 // ReadAgentRuntimeOverrides reads the AgentRuntime CR for a given workload
@@ -127,11 +133,18 @@ func extractOverrides(rt *agentv1alpha1.AgentRuntime) *AgentRuntimeOverrides {
 		overrides.AuthBridgeMode = &mode
 	}
 
+	// .spec.mtlsMode
+	if rt.Spec.MTLSMode != "" {
+		mode := rt.Spec.MTLSMode
+		overrides.MTLSMode = &mode
+	}
+
 	arConfigLog.Info("AgentRuntime overrides extracted",
 		"hasSpiffeTrustDomain", overrides.SpiffeTrustDomain != nil,
 		"hasClientRegistration", overrides.ClientRegistrationProvider != nil,
 		"hasTrace", overrides.TraceEndpoint != nil,
-		"hasAuthBridgeMode", overrides.AuthBridgeMode != nil)
+		"hasAuthBridgeMode", overrides.AuthBridgeMode != nil,
+		"hasMTLSMode", overrides.MTLSMode != nil)
 
 	return overrides
 }

--- a/kagenti-operator/internal/webhook/injector/constants.go
+++ b/kagenti-operator/internal/webhook/injector/constants.go
@@ -37,3 +37,15 @@ const (
 	IdentityTypeSpiffe         = "spiffe"
 	ClientAuthTypeFederatedJWT = "federated-jwt"
 )
+
+// mTLS modes for the proxy-sidecar / lite paths. Selected per workload
+// via AgentRuntime CR `Spec.MTLSMode`, falling back to the namespace
+// `authbridge-runtime-config` ConfigMap's `mtls.mode` field, then
+// MTLSModeDisabled. envoy-sidecar mode is incompatible with mTLS today
+// (Envoy SDS not configured by the kagenti envoy-config) — admission
+// rejects mtlsMode != disabled in that combination.
+const (
+	MTLSModeDisabled   = "disabled"
+	MTLSModePermissive = "permissive"
+	MTLSModeStrict     = "strict"
+)

--- a/kagenti-operator/internal/webhook/injector/namespace_config.go
+++ b/kagenti-operator/internal/webhook/injector/namespace_config.go
@@ -161,3 +161,28 @@ func ExtractMode(authbridgeYAML string) string {
 	}
 	return top.Mode
 }
+
+// ExtractMTLSMode parses an authbridge-runtime-config config.yaml string
+// and returns the value of its `mtls.mode` field. Returns "" if the YAML
+// is empty, malformed, has no `mtls` block, or its `mode` field is unset
+// — in any of those cases the caller should fall back to the next
+// resolution layer (or the "disabled" default).
+//
+// Same surgical-parse pattern as ExtractMode: tolerates extra top-level
+// keys so older or hand-edited ConfigMaps round-trip cleanly.
+func ExtractMTLSMode(authbridgeYAML string) string {
+	if authbridgeYAML == "" {
+		return ""
+	}
+	var top struct {
+		MTLS struct {
+			Mode string `json:"mode"`
+		} `json:"mtls"`
+	}
+	if err := yaml.Unmarshal([]byte(authbridgeYAML), &top); err != nil {
+		nsConfigLog.Info("WARN: failed to parse authbridge-runtime-config config.yaml for mtls.mode; falling back to next resolution layer",
+			"error", err.Error())
+		return ""
+	}
+	return top.MTLS.Mode
+}

--- a/kagenti-operator/internal/webhook/injector/namespace_config_test.go
+++ b/kagenti-operator/internal/webhook/injector/namespace_config_test.go
@@ -133,3 +133,33 @@ func TestReadNamespaceConfig_PartialConfig(t *testing.T) {
 			cfg.TokenURL, cfg.Issuer)
 	}
 }
+
+func TestExtractMTLSMode(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{"empty input", "", ""},
+		{"no mtls block", "mode: proxy-sidecar\n", ""},
+		{"mtls block, mode strict", "mtls:\n  mode: strict\n", "strict"},
+		{"mtls block, mode permissive", "mtls:\n  mode: permissive\n", "permissive"},
+		{"mtls block, mode disabled", "mtls:\n  mode: disabled\n", "disabled"},
+		{"mtls block with cert paths overridden", "mtls:\n  mode: strict\n  cert_file: /custom/cert.pem\n", "strict"},
+		{"mtls block, no mode key", "mtls:\n  cert_file: /opt/svid.pem\n", ""},
+		{"mtls and other blocks", "mode: proxy-sidecar\nmtls:\n  mode: permissive\nlistener:\n  reverse_proxy_addr: \":8080\"\n", "permissive"},
+		// Malformed YAML produces "" — caller falls through to the next
+		// resolution layer. Internal WARN log is logged but not asserted
+		// here (slog handler is a global; capturing it adds harness noise).
+		{"malformed yaml falls through", "mtls:\n  mode: strict\n  - this is invalid", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractMTLSMode(tt.yaml)
+			if got != tt.want {
+				t.Errorf("ExtractMTLSMode(%q) = %q, want %q", tt.yaml, got, tt.want)
+			}
+		})
+	}
+}

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -228,6 +228,63 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 		nsConfig = &NamespaceConfig{}
 	}
 
+	// ========================================
+	// Resolve mTLS posture (CR > namespace > "disabled")
+	// ========================================
+	//
+	// Done BEFORE the volume-building / per-workload resolution so that
+	// "mtlsMode != disabled implies SPIRE" can flip spireEnabled and
+	// fall through to the existing SPIRE-aware code paths (volumes,
+	// ServiceAccount, container env). Mode-compat validation
+	// (mtlsMode incompatible with envoy-sidecar) runs in the
+	// AgentRuntime validating webhook upstream of pod admission.
+	mtlsMode := MTLSModeDisabled
+	mtlsSource := "default"
+	if arOverrides != nil && arOverrides.MTLSMode != nil {
+		mtlsMode = *arOverrides.MTLSMode
+		mtlsSource = "agentruntime-cr"
+	}
+	if mtlsMode == MTLSModeDisabled {
+		if m := ExtractMTLSMode(nsConfig.AuthBridgeRuntimeYAML); m != "" {
+			mtlsMode = m
+			mtlsSource = "namespace-configmap"
+		}
+	}
+	switch mtlsMode {
+	case MTLSModeDisabled, MTLSModePermissive, MTLSModeStrict:
+		// recognized, keep as-is
+	default:
+		mutatorLog.Info("WARN: unrecognized mtlsMode; defaulting to disabled",
+			"namespace", namespace, "crName", crName,
+			"unrecognized", mtlsMode, "source", mtlsSource)
+		mtlsMode = MTLSModeDisabled
+		mtlsSource = "default-invalid-fallback"
+	}
+	mutatorLog.Info("resolved mTLS mode",
+		"namespace", namespace, "crName", crName,
+		"mode", mtlsMode, "source", mtlsSource)
+
+	// Auto-enable SPIRE when mtls is on. The bundled spiffe-helper
+	// writes /opt/svid*.pem from SPIRE-issued X.509 SVIDs; without
+	// SPIRE the cert files never appear and authbridge stays in its
+	// startup wait loop. Setting mtlsMode is sufficient declaration of
+	// intent — the operator does not require a separate SPIRE label.
+	if mtlsMode != MTLSModeDisabled && !spireEnabled {
+		mutatorLog.Info("mtlsMode set; auto-enabling SPIRE for this workload",
+			"namespace", namespace, "crName", crName, "mtlsMode", mtlsMode)
+		spireEnabled = true
+		if podSpec.ServiceAccountName == "" || podSpec.ServiceAccountName == "default" {
+			if err := m.ensureServiceAccount(ctx, namespace, crName); err != nil {
+				mutatorLog.Error(err, "Failed to ensure ServiceAccount for auto-enabled SPIRE",
+					"namespace", namespace, "name", crName)
+				return false, fmt.Errorf("failed to ensure service account for mtls auto-spire: %w", err)
+			}
+			podSpec.ServiceAccountName = crName
+			mutatorLog.Info("Set ServiceAccountName for auto-enabled SPIRE identity",
+				"namespace", namespace, "serviceAccount", crName)
+		}
+	}
+
 	if currentGates.PerWorkloadConfigResolution {
 		// Resolved path: build literal env vars from namespace config
 		// arOverrides was already read above as a gate check.
@@ -417,7 +474,8 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 				"reverse_proxy_addr":    fmt.Sprintf(":%d", originalAgentPort),
 				"reverse_proxy_backend": fmt.Sprintf("http://127.0.0.1:%d", newAgentPort),
 				"forward_proxy_addr":    fmt.Sprintf(":%d", forwardProxyPort),
-			})
+			},
+			mtlsMode)
 		if err != nil {
 			return false, fmt.Errorf("proxy-sidecar per-agent ConfigMap: %w", err)
 		}
@@ -488,8 +546,12 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 	// authbridge + bundled spiffe-helper. proxy-init is a separate
 	// init container. spiffe-helper starts conditionally on SPIRE_ENABLED.
 
+	// envoy-sidecar always passes mtlsMode="" — the validating webhook
+	// rejects mtlsMode != disabled with envoy-sidecar at admission, so
+	// we'd never reach this branch with a non-empty mtlsMode in practice;
+	// passing "" here is the explicit-defense complement.
 	perAgentCMName, err := m.ensurePerAgentConfigMap(ctx, namespace, crName,
-		ModeEnvoySidecar, nsConfig.AuthBridgeRuntimeYAML, nsConfig, nil)
+		ModeEnvoySidecar, nsConfig.AuthBridgeRuntimeYAML, nsConfig, nil, "")
 	if err != nil {
 		return false, fmt.Errorf("envoy-sidecar per-agent ConfigMap: %w", err)
 	}
@@ -668,16 +730,23 @@ func synthesizePipeline(nsConfig *NamespaceConfig) map[string]interface{} {
 
 // ensurePerAgentConfigMap creates or updates a per-agent ConfigMap that merges the
 // namespace-level authbridge-runtime-config with per-agent overrides (mode, listener
-// addresses). The authbridge sidecar mounts this instead of the shared ConfigMap.
+// addresses, mtls). The authbridge sidecar mounts this instead of the shared ConfigMap.
 //
 // If baseYAML is empty (namespace has no authbridge-runtime-config), a minimal config
 // is generated from the NamespaceConfig fields.
+//
+// mtlsMode is the resolved mTLS posture (disabled / permissive / strict). Only
+// proxy-sidecar and lite paths reach this function with a non-disabled mtlsMode;
+// the AgentRuntime validating webhook rejects mtlsMode != disabled when
+// authBridgeMode is envoy-sidecar (Envoy SDS isn't wired in the kagenti envoy-config
+// today — tracked as a follow-up).
 func (m *PodMutator) ensurePerAgentConfigMap(
 	ctx context.Context,
 	namespace, crName, mode string,
 	baseYAML string,
 	nsConfig *NamespaceConfig,
 	listenerOverrides map[string]string,
+	mtlsMode string,
 ) (string, error) {
 	cmName := perAgentConfigMapName(crName)
 
@@ -727,6 +796,21 @@ func (m *PodMutator) ensurePerAgentConfigMap(
 		cfg["listener"] = listener
 	}
 
+	// mTLS block. Cert paths are omitted on purpose — they match the
+	// authbridge defaults (/opt/svid.pem, /opt/svid_key.pem,
+	// /opt/svid_bundle.pem) written by the bundled spiffe-helper.
+	// Surfacing them here would couple the operator to authbridge's
+	// internal layout for no benefit.
+	if mtlsMode != "" && mtlsMode != MTLSModeDisabled {
+		cfg["mtls"] = map[string]interface{}{"mode": mtlsMode}
+	} else {
+		// Defensive: scrub any stale mtls block from the base YAML when
+		// mTLS is off. Otherwise toggling mtlsMode back to disabled
+		// without restarting the namespace ConfigMap would leak the
+		// previous setting through to the per-agent CM.
+		delete(cfg, "mtls")
+	}
+
 	// Marshal back to YAML
 	data, err := yaml.Marshal(cfg)
 	if err != nil {
@@ -748,7 +832,8 @@ func (m *PodMutator) ensurePerAgentConfigMap(
 	if err := m.Client.Apply(ctx, cmApply, client.FieldOwner("kagenti-webhook"), client.ForceOwnership); err != nil {
 		return "", fmt.Errorf("failed to apply per-agent ConfigMap %s/%s: %w", namespace, cmName, err)
 	}
-	mutatorLog.Info("Applied per-agent ConfigMap", "namespace", namespace, "name", cmName, "mode", mode)
+	mutatorLog.Info("Applied per-agent ConfigMap",
+		"namespace", namespace, "name", cmName, "mode", mode, "mtlsMode", mtlsMode)
 
 	return cmName, nil
 }

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -238,18 +238,33 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 	// ServiceAccount, container env). Mode-compat validation
 	// (mtlsMode incompatible with envoy-sidecar) runs in the
 	// AgentRuntime validating webhook upstream of pod admission.
-	mtlsMode := MTLSModeDisabled
-	mtlsSource := "default"
+	// Resolution chain: CR > namespace > "disabled". An explicit
+	// CR value (including "disabled") pins; the namespace fallback
+	// only fires when the CR doesn't set the field at all.
+	// arOverrides.MTLSMode is the sentinel — extractOverrides only
+	// populates it when Spec.MTLSMode is non-empty.
+	mtlsMode := ""
+	mtlsSource := ""
 	if arOverrides != nil && arOverrides.MTLSMode != nil {
 		mtlsMode = *arOverrides.MTLSMode
 		mtlsSource = "agentruntime-cr"
 	}
-	if mtlsMode == MTLSModeDisabled {
+	if mtlsMode == "" {
 		if m := ExtractMTLSMode(nsConfig.AuthBridgeRuntimeYAML); m != "" {
 			mtlsMode = m
 			mtlsSource = "namespace-configmap"
 		}
 	}
+	if mtlsMode == "" {
+		mtlsMode = MTLSModeDisabled
+		mtlsSource = "default"
+	}
+	// Defense in depth: the CRD enum check rejects unknown values at
+	// the API server, but the namespace ConfigMap and any future
+	// non-CRD source feed in raw strings. A typo (e.g. "strikt") would
+	// otherwise flow through unchecked. Same defensive pattern as the
+	// authBridgeMode resolution above; do not drop this switch as
+	// "redundant with CRD validation" — it covers paths the CRD doesn't.
 	switch mtlsMode {
 	case MTLSModeDisabled, MTLSModePermissive, MTLSModeStrict:
 		// recognized, keep as-is

--- a/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
@@ -1242,7 +1242,7 @@ func TestEnsurePerAgentConfigMap_EmptyBaseYAML_FallbackFromNsConfig(t *testing.T
 	}
 
 	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "weather-service",
-		ModeProxySidecar, "", nsConfig, nil)
+		ModeProxySidecar, "", nsConfig, nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1359,7 +1359,7 @@ pipeline:
 `
 
 	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "my-agent",
-		ModeEnvoySidecar, baseYAML, &NamespaceConfig{}, nil)
+		ModeEnvoySidecar, baseYAML, &NamespaceConfig{}, nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1418,7 +1418,7 @@ pipeline:
 	}
 
 	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "my-agent",
-		ModeProxySidecar, baseYAML, &NamespaceConfig{}, overrides)
+		ModeProxySidecar, baseYAML, &NamespaceConfig{}, overrides, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1454,7 +1454,7 @@ func TestEnsurePerAgentConfigMap_ExistingCM_OwnedByWebhook_Updated(t *testing.T)
 	ctx := context.Background()
 
 	_, err := m.ensurePerAgentConfigMap(ctx, "team1", "my-agent",
-		ModeEnvoySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil)
+		ModeEnvoySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1482,7 +1482,7 @@ func TestEnsurePerAgentConfigMap_ExistingCM_OverwrittenBySSA(t *testing.T) {
 	ctx := context.Background()
 
 	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "my-agent",
-		ModeEnvoySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil)
+		ModeEnvoySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1510,7 +1510,7 @@ func TestEnsurePerAgentConfigMap_OwnerReference_SetFromDeployment(t *testing.T) 
 	ctx := context.Background()
 
 	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "weather-service",
-		ModeEnvoySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil)
+		ModeEnvoySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1537,7 +1537,7 @@ func TestEnsurePerAgentConfigMap_OwnerReference_SetFromStatefulSet(t *testing.T)
 	ctx := context.Background()
 
 	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "my-stateful-agent",
-		ModeEnvoySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil)
+		ModeEnvoySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1558,7 +1558,7 @@ func TestEnsurePerAgentConfigMap_OwnerReference_NoWorkload_Skipped(t *testing.T)
 	ctx := context.Background()
 
 	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "bare-pod-agent",
-		ModeEnvoySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil)
+		ModeEnvoySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1581,7 +1581,7 @@ func TestEnsurePerAgentConfigMap_FederatedJWT_MapsToSpiffe(t *testing.T) {
 	}
 
 	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "spiffe-agent",
-		ModeEnvoySidecar, "", nsConfig, nil)
+		ModeEnvoySidecar, "", nsConfig, nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1603,4 +1603,129 @@ func TestEnsurePerAgentConfigMap_FederatedJWT_MapsToSpiffe(t *testing.T) {
 	// own convention layer — keeping the webhook schema-agnostic
 	// about file paths. See
 	// authbridge/authlib/plugins/CONVENTIONS.md.
+}
+
+// --- mTLS rendering tests ---
+//
+// These cover the per-agent ConfigMap rendering with the new mtlsMode
+// argument. The validating webhook upstream rejects mtlsMode != disabled
+// with envoy-sidecar mode, so the renderer doesn't need to gate by mode
+// — but we still test the negative ("disabled" / "" should not emit a
+// block) and the scrub case (toggling back to disabled wipes a stale
+// block from the base YAML).
+
+// TestEnsurePerAgentConfigMap_MTLSStrict_RendersBlock verifies that
+// mtlsMode=strict produces a top-level mtls: {mode: strict} block.
+// Cert paths are intentionally NOT emitted — they default to the
+// authbridge-side defaults (/opt/svid*.pem) written by spiffe-helper.
+func TestEnsurePerAgentConfigMap_MTLSStrict_RendersBlock(t *testing.T) {
+	m := newTestMutator()
+	ctx := context.Background()
+
+	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "mtls-agent",
+		ModeProxySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil, MTLSModeStrict)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cm := fetchConfigMap(t, m, "team1", cmName)
+	cfg := parseConfigYAML(t, cm)
+
+	mtls, ok := cfg["mtls"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected mtls block to be a map; got %T (cfg=%+v)", cfg["mtls"], cfg)
+	}
+	if mtls["mode"] != MTLSModeStrict {
+		t.Errorf("mtls.mode = %v, want %s", mtls["mode"], MTLSModeStrict)
+	}
+	// Cert paths are NOT rendered — operator stays decoupled from
+	// authbridge's internal layout.
+	for _, key := range []string{"cert_file", "key_file", "bundle_file"} {
+		if _, present := mtls[key]; present {
+			t.Errorf("mtls.%s should not be emitted (authbridge supplies defaults)", key)
+		}
+	}
+}
+
+// TestEnsurePerAgentConfigMap_MTLSPermissive_RendersBlock mirrors the
+// strict test for permissive mode — same shape, different mode value.
+func TestEnsurePerAgentConfigMap_MTLSPermissive_RendersBlock(t *testing.T) {
+	m := newTestMutator()
+	ctx := context.Background()
+
+	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "mtls-agent",
+		ModeProxySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil, MTLSModePermissive)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cm := fetchConfigMap(t, m, "team1", cmName)
+	cfg := parseConfigYAML(t, cm)
+
+	mtls, ok := cfg["mtls"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected mtls block to be a map; got %T", cfg["mtls"])
+	}
+	if mtls["mode"] != MTLSModePermissive {
+		t.Errorf("mtls.mode = %v, want %s", mtls["mode"], MTLSModePermissive)
+	}
+}
+
+// TestEnsurePerAgentConfigMap_MTLSDisabled_OmitsBlock verifies that the
+// renderer does NOT emit mtls when mtlsMode is disabled or empty.
+// Empty-string is the envoy-sidecar carve-out path — the call site
+// passes "" explicitly so we test that too.
+func TestEnsurePerAgentConfigMap_MTLSDisabled_OmitsBlock(t *testing.T) {
+	tests := []struct {
+		name     string
+		mtlsMode string
+	}{
+		{"empty string", ""},
+		{"disabled", MTLSModeDisabled},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestMutator()
+			ctx := context.Background()
+
+			cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "no-mtls-"+tt.name,
+				ModeProxySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil, tt.mtlsMode)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			cm := fetchConfigMap(t, m, "team1", cmName)
+			cfg := parseConfigYAML(t, cm)
+
+			if _, present := cfg["mtls"]; present {
+				t.Errorf("mtls block should not be emitted when mtlsMode=%q (cfg=%+v)", tt.mtlsMode, cfg)
+			}
+		})
+	}
+}
+
+// TestEnsurePerAgentConfigMap_MTLSScrubsStaleBlock guards against a
+// regression where toggling mtlsMode from strict back to disabled would
+// leak the previous mtls block through to the per-agent CM. The
+// renderer must explicitly delete cfg["mtls"] when mode is off.
+func TestEnsurePerAgentConfigMap_MTLSScrubsStaleBlock(t *testing.T) {
+	m := newTestMutator()
+	ctx := context.Background()
+
+	// Base YAML with a stale mtls: strict — simulates a namespace
+	// ConfigMap that was rendered earlier with mtls on.
+	baseYAML := "mode: proxy-sidecar\nmtls:\n  mode: strict\n"
+
+	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "scrub-agent",
+		ModeProxySidecar, baseYAML, &NamespaceConfig{ClientAuthType: "client-secret"}, nil, MTLSModeDisabled)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cm := fetchConfigMap(t, m, "team1", cmName)
+	cfg := parseConfigYAML(t, cm)
+
+	if _, present := cfg["mtls"]; present {
+		t.Errorf("stale mtls block should be scrubbed when mtlsMode=disabled; got cfg=%+v", cfg)
+	}
 }

--- a/kagenti-operator/internal/webhook/v1alpha1/agentruntime_webhook.go
+++ b/kagenti-operator/internal/webhook/v1alpha1/agentruntime_webhook.go
@@ -49,6 +49,9 @@ func (v *AgentRuntimeValidator) ValidateCreate(ctx context.Context, rt *agentv1a
 	if err := v.checkDuplicateTargetRef(ctx, rt); err != nil {
 		return nil, err
 	}
+	if err := checkMTLSCompatibleWithMode(rt); err != nil {
+		return nil, err
+	}
 
 	return nil, nil
 }
@@ -59,6 +62,9 @@ func (v *AgentRuntimeValidator) ValidateUpdate(ctx context.Context, _ *agentv1al
 	if err := v.checkDuplicateTargetRef(ctx, rt); err != nil {
 		return nil, err
 	}
+	if err := checkMTLSCompatibleWithMode(rt); err != nil {
+		return nil, err
+	}
 
 	return nil, nil
 }
@@ -67,6 +73,32 @@ func (v *AgentRuntimeValidator) ValidateDelete(_ context.Context, rt *agentv1alp
 	agentruntimelog.Info("validate delete", "name", rt.Name)
 
 	return nil, nil
+}
+
+// checkMTLSCompatibleWithMode rejects mtlsMode != disabled when authBridgeMode
+// is envoy-sidecar. Envoy SDS isn't currently configured by the kagenti
+// envoy-config — extending it to do real mTLS is a separate piece of work.
+// Until that lands, the only modes that actually carry mTLS are
+// proxy-sidecar and lite (kagenti-extensions PR #424). Rejecting at admission
+// makes the misconfiguration loud instead of producing a workload that
+// silently runs plaintext while the user believes they have strict mTLS.
+//
+// Empty / "disabled" mtlsMode is permitted for any authBridgeMode — that's
+// today's plaintext default. The error message points to the supported
+// modes and flags this as a current limitation, not a permanent one.
+func checkMTLSCompatibleWithMode(rt *agentv1alpha1.AgentRuntime) error {
+	mtls := rt.Spec.MTLSMode
+	if mtls == "" || mtls == "disabled" {
+		return nil
+	}
+	if rt.Spec.AuthBridgeMode == "envoy-sidecar" {
+		return fmt.Errorf(
+			"mtlsMode=%q is not supported with authBridgeMode=envoy-sidecar; "+
+				"set authBridgeMode to proxy-sidecar or lite (envoy-sidecar mTLS is tracked as a follow-up)",
+			mtls,
+		)
+	}
+	return nil
 }
 
 // checkDuplicateTargetRef rejects creation/update if another AgentRuntime already

--- a/kagenti-operator/internal/webhook/v1alpha1/agentruntime_webhook_test.go
+++ b/kagenti-operator/internal/webhook/v1alpha1/agentruntime_webhook_test.go
@@ -246,3 +246,67 @@ func TestAgentRuntimeValidator_ValidateDelete(t *testing.T) {
 	})
 
 }
+
+// TestAgentRuntimeValidator_MTLSCompatWithMode covers the rejection of
+// mtlsMode != disabled when authBridgeMode is envoy-sidecar. The kagenti
+// envoy-config doesn't currently configure SDS, so an envoy-sidecar
+// workload that sets mtlsMode would silently run plaintext while the
+// user believes they have strict mTLS — the validator catches that at
+// admission time.
+func TestAgentRuntimeValidator_MTLSCompatWithMode(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		mode    string
+		mtls    string
+		wantErr bool
+	}{
+		{"proxy-sidecar + strict allowed", "proxy-sidecar", "strict", false},
+		{"proxy-sidecar + permissive allowed", "proxy-sidecar", "permissive", false},
+		{"proxy-sidecar + disabled allowed", "proxy-sidecar", "disabled", false},
+		{"proxy-sidecar + empty allowed", "proxy-sidecar", "", false},
+		{"lite + strict allowed", "lite", "strict", false},
+		{"lite + permissive allowed", "lite", "permissive", false},
+		{"empty mode + strict allowed", "", "strict", false},
+		{"envoy-sidecar + disabled allowed", "envoy-sidecar", "disabled", false},
+		{"envoy-sidecar + empty allowed", "envoy-sidecar", "", false},
+		{"envoy-sidecar + permissive rejected", "envoy-sidecar", "permissive", true},
+		{"envoy-sidecar + strict rejected", "envoy-sidecar", "strict", true},
+	}
+
+	for _, tt := range tests {
+		t.Run("create/"+tt.name, func(t *testing.T) {
+			rt := validAgentRuntime()
+			rt.Spec.AuthBridgeMode = tt.mode
+			rt.Spec.MTLSMode = tt.mtls
+
+			v := &AgentRuntimeValidator{}
+			_, err := v.ValidateCreate(ctx, rt)
+			gotErr := err != nil
+			if gotErr != tt.wantErr {
+				t.Errorf("ValidateCreate(mode=%q, mtls=%q): wantErr=%v, gotErr=%v (err=%v)",
+					tt.mode, tt.mtls, tt.wantErr, gotErr, err)
+			}
+			if tt.wantErr && err != nil &&
+				!strings.Contains(err.Error(), "envoy-sidecar mTLS is tracked as a follow-up") {
+				t.Errorf("error message should point to follow-up; got: %v", err)
+			}
+		})
+
+		t.Run("update/"+tt.name, func(t *testing.T) {
+			old := validAgentRuntime()
+			updated := validAgentRuntime()
+			updated.Spec.AuthBridgeMode = tt.mode
+			updated.Spec.MTLSMode = tt.mtls
+
+			v := &AgentRuntimeValidator{}
+			_, err := v.ValidateUpdate(ctx, old, updated)
+			gotErr := err != nil
+			if gotErr != tt.wantErr {
+				t.Errorf("ValidateUpdate(mode=%q, mtls=%q): wantErr=%v, gotErr=%v (err=%v)",
+					tt.mode, tt.mtls, tt.wantErr, gotErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Wires the now-merged [kagenti-extensions PR #424](https://github.com/kagenti/kagenti-extensions/pull/424) (mTLS between authbridge sidecars on the proxy-sidecar / lite paths) through the operator so it can be enabled declaratively per workload — and folds in two pre-existing tech-debt items along the way.

The mTLS feature is already fully implemented on the authbridge side: the byte-peek listener, X.509 SVID consumption, permissive-with-fallback / strict modes — all live in the merged PR. This PR makes the operator render the right config, reject impossible combos, and closes two related rollout / chart-sync gaps.

## What ships

### mtlsMode wiring (commit 1)

* **`AgentRuntimeSpec.MTLSMode`** — new enum field (`disabled` | `permissive` | `strict`), default `disabled`. Resolution chain mirrors `AuthBridgeMode`: CR > namespace `authbridge-runtime-config` `mtls.mode` > default.

* **Per-agent ConfigMap renders `mtls: {mode: <value>}`** when resolved mode is non-disabled. Cert paths intentionally omitted — they match authbridge's bundled-spiffe-helper defaults (`/opt/svid.pem` etc.). Stale `mtls` blocks scrubbed when toggling back to disabled.

* **`mtlsMode != disabled` auto-enables SPIRE** for the workload (sets `spireEnabled` for that injection + ensures the dedicated ServiceAccount). Operators don't need to add the `kagenti.io/spiffe-helper-inject` label separately. We don't mutate the namespace `authbridge-config` ConfigMap — that would race with the kagenti meta-chart for ownership.

* **Validating webhook rejects `mtlsMode != disabled` + `authBridgeMode = envoy-sidecar`.** Envoy SDS isn't currently configured by the kagenti envoy-config. Accepting that combo would silently run plaintext while the user believed they had strict mTLS — exactly the wrong failure mode for a security-relevant posture claim. Error message names the supported modes (`proxy-sidecar` / `lite`) and explicitly flags this as a current limitation, not a permanent one.

* **Spec changes to `AuthBridgeMode` and `MTLSMode` feed the resolved-config hash.** Editing either CR field re-stamps `kagenti.io/config-hash` on the pod template, so the Deployment rolls automatically. (Bonus: this fixes a pre-existing gap where `AuthBridgeMode` changes weren't triggering rollouts.)

### Namespace-CM-edit rollout gap (commit 2)

The controller's resolved-config hash captured CR fields and cluster/namespace-defaults ConfigMaps, but **not** the `authbridge-runtime-config` ConfigMap that the admission webhook reads at pod creation. Editing it silently failed to roll workloads — operators had to know to `kubectl rollout restart` manually.

* New `AuthBridgeRuntime` field on `resolvedConfig` captures the raw `config.yaml` content (not parsed — any byte change rolls the workload, agnostic to whether it's mtls / pipeline / listener edits).
* `mapNamespaceConfigMapToAgentRuntimes` extended to also match ConfigMaps named `authbridge-runtime-config` (not just `kagenti.io/defaults=true` labeled ones).
* New tests: hash-changes-on-edit + mapper-matches-by-name.

### Chart-CRD drift (commit 2)

`charts/kagenti-operator/crds/` was last touched in commit 677f63d (initial webhook migration) and has been silently drifting from `config/crd/bases/` for at least three subsequent CRD-touching commits (21a2258, 4eb62af, this PR). Anyone helm-installing got an outdated CRD missing recent fields like `authBridgeMode`, `lite` mode, `mtlsMode`.

* Synced both `agent.kagenti.dev_agentruntimes.yaml` and `agent.kagenti.dev_agentcards.yaml` from `config/crd/bases/`.
* New `sync-chart-crds` Makefile target invoked at the tail of `make manifests`. Future `make manifests` runs propagate to the chart copy automatically.

## Out of scope (genuine, smaller follow-ups)

* **envoy-sidecar mTLS via Envoy SDS.** Requires extending the kagenti meta-chart's envoy-config template (SDS cluster, `tls_inspector`, transport_socket on listeners). Comparable in size to PR #424 itself.

## Test plan

- [x] `go test -race -count=1 ./internal/... ./api/...` — all pass
- [x] `go vet ./...`, `gofmt -l` clean
- [x] `make manifests` regenerates CRD schema with new `mtlsMode` enum AND propagates to chart copy
- [x] `make sync-chart-crds` is idempotent (running it twice produces no diff)
- [ ] CI passes
- [ ] End-to-end demo verification: deploy an AgentRuntime with `mtlsMode: strict` against a kagenti-extensions build that includes PR #424, confirm wire-level handshake, then patch to `permissive` and confirm the rolling update fires
- [ ] End-to-end demo verification of namespace-CM-edit rollout: `kubectl edit configmap authbridge-runtime-config -n team1` adding `mtls.mode: permissive`, confirm Deployments in that namespace roll automatically

## Files

Commit 1 (mtlsMode wiring):
- `api/v1alpha1/agentruntime_types.go` — new `MTLSMode` field with godoc
- `config/crd/bases/agent.kagenti.dev_agentruntimes.yaml` — regenerated schema
- `internal/webhook/injector/agentruntime_config.go` — extract from CR
- `internal/webhook/injector/namespace_config.go` — `ExtractMTLSMode` parser
- `internal/webhook/injector/constants.go` — `MTLSModeDisabled` / `Permissive` / `Strict`
- `internal/webhook/injector/pod_mutator.go` — resolution chain + render + auto-SPIRE
- `internal/webhook/v1alpha1/agentruntime_webhook.go` — `checkMTLSCompatibleWithMode`
- `internal/controller/agentruntime_config.go` — fold AuthBridgeMode + MTLSMode into hash
- Tests across all of the above

Commit 2 (rollout gap + chart drift):
- `internal/controller/agentruntime_config.go` — `AuthBridgeRuntime` field on resolvedConfig
- `internal/controller/agentruntime_controller.go` — extend mapper for `authbridge-runtime-config`
- `kagenti-operator/Makefile` — `sync-chart-crds` target
- `charts/kagenti-operator/crds/agent.kagenti.dev_agentruntimes.yaml` — synced
- `charts/kagenti-operator/crds/agent.kagenti.dev_agentcards.yaml` — synced
- Tests: hash-changes-on-edit + mapper-matches-by-name

Net: ~675 LOC added across 13 files (most of it tests + comments + generated CRD content).

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
