### PR TITLE
chore(injector): remove unused JWTAudience field

### DIFF
--- a/kagenti-operator/internal/webhook/injector/namespace_config.go
+++ b/kagenti-operator/internal/webhook/injector/namespace_config.go
@@ -52,7 +52,6 @@ type NamespaceConfig struct {
 	DefaultOutboundPolicy string
 	ClientAuthType        string // "client-secret" or "federated-jwt"
 	SpiffeIdpAlias        string // Keycloak SPIFFE Identity Provider alias (e.g., "spire-spiffe")
-	JWTAudience           string // JWT audience for SPIFFE authentication
 
 	// From "spiffe-helper-config" ConfigMap
 	SpiffeHelperConf string // raw helper.conf content
@@ -89,7 +88,6 @@ func ReadNamespaceConfig(ctx context.Context, c client.Reader, namespace string)
 		cfg.DefaultOutboundPolicy = cm.Data["DEFAULT_OUTBOUND_POLICY"]
 		cfg.ClientAuthType = cm.Data["CLIENT_AUTH_TYPE"]
 		cfg.SpiffeIdpAlias = cm.Data["SPIFFE_IDP_ALIAS"]
-		cfg.JWTAudience = cm.Data["JWT_AUDIENCE"]
 	}
 
 	// Note: keycloak-admin-secret is not read here. The resolved container builder

--- a/kagenti-operator/internal/webhook/injector/resolved_config.go
+++ b/kagenti-operator/internal/webhook/injector/resolved_config.go
@@ -45,7 +45,6 @@ type ResolvedConfig struct {
 	DefaultOutboundPolicy string
 	ClientAuthType        string // "client-secret" or "federated-jwt"
 	SpiffeIdpAlias        string // Keycloak SPIFFE Identity Provider alias
-	JWTAudience           string // JWT audience for SPIFFE authentication
 
 	// Sidecar configs — from namespace CMs (not overridable by AgentRuntime v1alpha1)
 	SpiffeHelperConf    string
@@ -89,7 +88,6 @@ func ResolveConfig(platform *config.PlatformConfig, ns *NamespaceConfig, ar *Age
 		DefaultOutboundPolicy:      ns.DefaultOutboundPolicy,
 		ClientAuthType:             ns.ClientAuthType,
 		SpiffeIdpAlias:             ns.SpiffeIdpAlias,
-		JWTAudience:                ns.JWTAudience,
 		SpiffeHelperConf:           ns.SpiffeHelperConf,
 		EnvoyYAML:                  ns.EnvoyYAML,
 		AuthproxyRoutesYAML:        ns.AuthproxyRoutesYAML,


### PR DESCRIPTION
Companion to [kagenti-extensions#432](https://github.com/kagenti/kagenti-extensions/pull/432) and [kagenti#1653](https://github.com/kagenti/kagenti/pull/1653).

## What

Remove the `JWTAudience` field from the webhook injector's `NamespaceConfig` and `ResolvedConfig` structs, and the line that read `JWT_AUDIENCE` from the `authbridge-config` ConfigMap. Pure dead-code removal:

- `cfg.JWTAudience = cm.Data["JWT_AUDIENCE"]` was the only writer
- A grep for `\.JWTAudience` returns zero readers — the value was parsed and never used

## Why

The `JWT_AUDIENCE` env var was a vestige from when the legacy in-pod `client-registration` sidecar may have consumed it; that sidecar has long since been replaced by the operator's `ClientRegistrationReconciler` (which doesn't read it). The companion kagenti PR drops the env var from the chart's `authbridge-config` ConfigMap. After both PRs land, the env var is gone end-to-end.

The JWT-SVID client-assertion audience used by authbridge's `tokenexchange` plugin is now sourced per-tokenexchange-instance from the in-process SPIFFE provider config (kagenti-extensions#432's redesign), not via a cluster-wide env var.

## Sequencing

This PR is **fully orthogonal** to the other two. It can land in any order:

- **Before kagenti#1653 (chart still sets `JWT_AUDIENCE`)**: operator stops reading a key that's still set. Harmless — empty struct field, nothing reads it.
- **After kagenti#1653 (chart no longer sets it)**: operator stops trying to read a key that's no longer set. `cfg.JWTAudience` becomes empty string regardless. Same outcome.
- **Independent of kagenti-extensions#432**: this PR doesn't touch any volume mount, env var injection, or pod-spec modification. The new authbridge image reads SVIDs via the SPIRE agent socket (already mounted by `volume_builder.go:38` at `/spiffe-workload-api/spire-agent.sock`) — no operator change needed for that.

## What this PR does NOT touch (intentional)

- `spiffe-helper-config` ConfigMap volume mount remains. Old authbridge images still consume it (helper.conf). New images ignore it. Cleanup eligible after all old-image deployments are gone.
- `SpiffeHelperConfigMapName` constant + `SpiffeHelperConf` field remain — same backward-compat reason.
- E2E fixtures (`jwt_audience="kagenti"` inside helper.conf TOML strings) remain.

## Test plan

- [ ] `go build ./...` clean (verified)
- [ ] `go test ./...` — all 12 unit-test packages pass (E2E fails environmentally, looking for a Kind cluster named `kind`; same on `main`)
- [ ] grep confirms zero remaining `JWTAudience` references in the codebase post-merge

Assisted-By: Claude Code
