### PR TITLE
ci(release): parallelize image builds + add buildx cache + fix e2e

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,21 @@ env:
   CHARTS_PATH: ./charts
 
 jobs:
+  # Build the two images in parallel, one matrix instance per image.
+  # Each instance carries its own buildx cache scope so warm builds
+  # only re-pull what changed for that image.
   build-and-push:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image_config:
+          - name: kagenti-operator
+            context: ./kagenti-operator
+            dockerfile: ./kagenti-operator/Dockerfile
+          - name: agentcard-signer
+            context: ./kagenti-operator
+            dockerfile: ./kagenti-operator/cmd/agentcard-signer/Dockerfile
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -41,61 +54,56 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    # --- kagenti-operator image ---
-    - name: Extract Docker metadata (kagenti-operator)
-      id: operator-meta
+    - name: Extract Docker metadata
+      id: meta
       uses: docker/metadata-action@v6
       with:
-        images: ${{ env.REGISTRY }}/${{ github.repository }}/kagenti-operator
+        images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.image_config.name }}
         tags: |
           type=sha,prefix={{branch}}-,enable={{is_default_branch}}
           type=raw,value=latest,enable={{is_default_branch}}
           type=semver,pattern={{version}}
 
-    - name: Build and push kagenti-operator
+    - name: Build and push ${{ matrix.image_config.name }}
       uses: docker/build-push-action@v7
       with:
-        context: ./kagenti-operator
-        file: ./kagenti-operator/Dockerfile
+        context: ${{ matrix.image_config.context }}
+        file: ${{ matrix.image_config.dockerfile }}
         push: true
         platforms: linux/amd64,linux/arm64
-        tags: ${{ steps.operator-meta.outputs.tags }}
-        labels: ${{ steps.operator-meta.outputs.labels }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        # GitHub Actions cache, scoped per image so the two parallel
+        # matrix jobs don't trample each other.
+        cache-from: type=gha,scope=${{ matrix.image_config.name }}
+        cache-to: type=gha,mode=max,scope=${{ matrix.image_config.name }}
 
-    # --- agentcard-signer image ---
-    - name: Extract Docker metadata (agentcard-signer)
-      id: signer-meta
-      uses: docker/metadata-action@v6
-      with:
-        images: ${{ env.REGISTRY }}/${{ github.repository }}/agentcard-signer
-        tags: |
-          type=sha,prefix={{branch}}-,enable={{is_default_branch}}
-          type=raw,value=latest,enable={{is_default_branch}}
-          type=semver,pattern={{version}}
+  # Release-only steps (helm chart packaging + GitHub Release). Runs
+  # once after both image builds complete, only on tag pushes.
+  release:
+    needs: build-and-push
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
 
-    - name: Build and push agentcard-signer
-      uses: docker/build-push-action@v7
-      with:
-        context: ./kagenti-operator
-        file: ./kagenti-operator/cmd/agentcard-signer/Dockerfile
-        push: true
-        platforms: linux/amd64,linux/arm64
-        tags: ${{ steps.signer-meta.outputs.tags }}
-        labels: ${{ steps.signer-meta.outputs.labels }}
-
-    # --- Release-only steps (tag pushes) ---
     - name: Set up Helm
-      if: github.ref_type == 'tag'
       uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install yq
-      if: github.ref_type == 'tag'
       uses: mikefarah/yq@v4
 
+    - name: Log in to ghcr.io
+      uses: docker/login-action@v4
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Package and push Helm chart
-      if: github.ref_type == 'tag'
       run: |
         chartVersion=$(echo "${{ github.ref_name }}" | cut -c 2-)
         chartPackageName="kagenti-operator-chart-${chartVersion}.tgz"
@@ -106,8 +114,19 @@ jobs:
         helm push "./${chartPackageName}" oci://${{ env.REGISTRY }}/${{ env.REPO }}
 
     - name: Create GitHub Release
-      if: github.ref_type == 'tag'
-      run: gh release create "${{ github.ref_name }}" --generate-notes
+      run: |
+        # Idempotent: the release may have been pre-created out of band
+        # (e.g., a maintainer ran `gh release create` before pushing the
+        # tag). Treat 422 "already_exists" as success so the workflow
+        # doesn't fail on a benign race.
+        if ! gh release create "${{ github.ref_name }}" --generate-notes 2> /tmp/release.err; then
+          if grep -q "already_exists\|Release.tag_name already exists" /tmp/release.err; then
+            echo "Release ${{ github.ref_name }} already exists; skipping create."
+          else
+            cat /tmp/release.err >&2
+            exit 1
+          fi
+        fi
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -130,8 +149,13 @@ jobs:
         kubectl -n cert-manager rollout status deployment/cert-manager-cainjector --timeout=90s
 
     - name: Install Helm chart
+      # The chart's values.yaml ships with `tag: __PLACEHOLDER__`, which
+      # the release job substitutes only on tag pushes. On main pushes
+      # we override to `:latest` (which the build-and-push job just
+      # tagged) so the rendered Deployment can actually pull an image.
       run: |
-        helm install kagenti-operator ./charts/kagenti-operator
+        helm install kagenti-operator ./charts/kagenti-operator \
+          --set controllerManager.container.image.tag=latest
 
     - name: Wait for deployment rollout
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,15 +117,14 @@ jobs:
       run: |
         # Idempotent: the release may have been pre-created out of band
         # (e.g., a maintainer ran `gh release create` before pushing the
-        # tag). Treat 422 "already_exists" as success so the workflow
-        # doesn't fail on a benign race.
-        if ! gh release create "${{ github.ref_name }}" --generate-notes 2> /tmp/release.err; then
-          if grep -q "already_exists\|Release.tag_name already exists" /tmp/release.err; then
-            echo "Release ${{ github.ref_name }} already exists; skipping create."
-          else
-            cat /tmp/release.err >&2
-            exit 1
-          fi
+        # tag for custom notes). Use `gh release view` to short-circuit
+        # rather than grepping stderr from `gh release create` — that
+        # text is locale-dependent and a moving target across gh
+        # versions.
+        if gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
+          echo "Release ${{ github.ref_name }} already exists; skipping create."
+        else
+          gh release create "${{ github.ref_name }}" --generate-notes
         fi
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Three changes to `.github/workflows/release.yml`, all addressing pre-existing CI issues.

### 1. Parallelize the two image builds (matrix)

`build-and-push` was a single job building `kagenti-operator` and `agentcard-signer` sequentially. With QEMU-emulated `linux/arm64` builds, each took ~20 minutes. Total wall time: ~42 minutes per run.

Refactored into a matrix of two jobs running in parallel on separate runners. Wall time drops to ~22 minutes (the longest of the two parallel builds).

### 2. Add buildx GitHub Actions cache

Each matrix instance now has `cache-from: type=gha` / `cache-to: type=gha,mode=max` with a per-image `scope`. Warm builds (where Go module cache + earlier layers can be reused) typically drop to ~5–10 minutes per image. Per-image scoping prevents cache collisions between the two matrix variants.

### 3. Fix `e2e-helm-install` image-tag override (the actual bug)

The chart's `values.yaml` ships with:

```yaml
controllerManager:
  container:
    image:
      tag: __PLACEHOLDER__
```

The placeholder is substituted only in the **tag-push** code path:

```yaml
- name: Package and push Helm chart
  if: github.ref_type == 'tag'
  run: |
    yq -i '.controllerManager.container.image.tag = strenv(chartVersion)' values.yaml
    helm package . ...
```

The mutation lives only in that job's working directory. On **main pushes**, the `e2e-helm-install` job re-checks-out the repo (pristine `__PLACEHOLDER__`), runs `helm install kagenti-operator ./charts/kagenti-operator` with no `--set`, and the rendered Deployment tries to pull `ghcr.io/.../kagenti-operator:__PLACEHOLDER__` — `ErrImagePull` → 120s rollout timeout.

Every recent main-push run of this workflow has been failing for this reason (PRs #366, #369, #370, #373). This means the e2e step has been providing **zero coverage** — it can't catch real regressions when it always fails for the same trivial reason.

Fix: pass `--set controllerManager.container.image.tag=latest`. The build-and-push job tags `:latest` on default-branch pushes, so the e2e installs whatever was just built.

## Bonus changes

- **Split release-only steps into a `release` job** (gated `if: github.ref_type == 'tag'`). The original sequence-of-steps shape doesn't survive matrix-ization since the helm-chart packaging and `gh release create` shouldn't fan out per image. The `release` job runs once, after both matrix jobs complete.

- **Idempotent `Create GitHub Release`**: treat `Release.tag_name already exists` (HTTP 422) as a benign no-op. This handles the case where a maintainer ran `gh release create` out of band before pushing the tag (e.g., for custom release notes).

## Test plan

This PR's branch is on a feature branch in the fork; pushing the PR will trigger the modified workflow on a `main` push (the merge commit). Expected outcomes:

- [ ] `build-and-push` matrix produces 2 parallel jobs (kagenti-operator, agentcard-signer)
- [ ] Each finishes in 5–22 minutes (cold cache the first time, warmer thereafter)
- [ ] `e2e-helm-install` runs and the Deployment becomes Ready (because `:latest` resolves)
- [ ] No `release` job (since this is a main push, not a tag push)

Once merged, the next maintainer-cut tag will exercise the `release` job (helm chart push + `gh release create`).

## Sequencing

This PR is independent of any other in-flight work. Can land at any time.

Assisted-By: Claude Code
