### PR TITLE
CI: grant pull-requests:read to pr-verifier caller

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
-permissions: {}
+permissions:
+  pull-requests: read
 
 jobs:
   verify-pr-title:


### PR DESCRIPTION
## Summary

The `permissions: {}` block added in e5a5605 locked all token permissions
to `none` at the workflow level. GitHub enforces the caller's permissions
as a hard ceiling for any reusable workflow it invokes, so the nested
`pr-title-check` job in `kagenti/.github/workflows/pr-verifier-required.yml`
was blocked from requesting `pull-requests: read` — causing the workflow to fail.
The workflow after that commit has failed to run on every PR made since:
https://github.com/kagenti/kagenti-operator/actions/workflows/pr-verifier.yml

## Changes

- Replace `permissions: {}` with `permissions: pull-requests: read` in
  `.github/workflows/pr-verifier.yml` — the minimum scope required by the
  reusable workflow

## Test Plan

- [x] The workflow runs successfully on a valid PR rh-dnagornuks/kagenti-operator/pull/1

Made with [Cursor](https://cursor.com/)