### PR TITLE
feat(webhook): Wire envoy-sidecar mTLS through pod mutator + fix svid-output mount

### DIFF
--- a/kagenti-operator/internal/webhook/injector/container_builder.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder.go
@@ -114,7 +114,15 @@ func (b *ContainerBuilder) BuildEnvoyProxyContainerWithSpireOption(spireEnabled 
 			corev1.VolumeMount{
 				Name:      "svid-output",
 				MountPath: "/opt",
-				ReadOnly:  true,
+				// Must be RW: the in-process spiffe Provider mirror inside the
+				// authbridge-envoy combined image writes /opt/svid.pem,
+				// /opt/svid_key.pem, /opt/svid_bundle.pem on every SPIRE
+				// rotation. Envoy's file-based DownstreamTlsContext /
+				// UpstreamTlsContext (used when mtlsMode != disabled) reads
+				// these files. The proxy-sidecar mount in
+				// BuildProxySidecarContainerWithPorts correctly defaults to RW;
+				// this branch was historically RO from the days of an external
+				// spiffe-helper writer, which no longer applies.
 			},
 			// authbridge-envoy bundles spiffe-helper; the entrypoint reads
 			// helper.conf from this mount. Without it, the bundled

--- a/kagenti-operator/internal/webhook/injector/container_builder_test.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder_test.go
@@ -33,8 +33,14 @@ func TestBuildEnvoyProxyContainer_SpireEnabled_HasSvidOutputMount(t *testing.T) 
 			if vm.MountPath != "/opt" {
 				t.Errorf("svid-output mount path = %q, want /opt", vm.MountPath)
 			}
-			if !vm.ReadOnly {
-				t.Error("svid-output mount should be read-only")
+			// Must be RW: the in-process spiffe Provider mirror inside the
+			// authbridge-envoy combined image writes /opt/svid*.pem there.
+			// The previous assertion (ReadOnly required) was wrong — it was
+			// asserting the bug as the desired behavior. Envoy's file-based
+			// DownstreamTlsContext / UpstreamTlsContext (used when mtlsMode
+			// != disabled) refuses to boot if these files don't exist.
+			if vm.ReadOnly {
+				t.Error("svid-output mount must be read-write so the spiffe Provider mirror can write SVIDs")
 			}
 			break
 		}

--- a/kagenti-operator/internal/webhook/injector/envoy.yaml.tmpl
+++ b/kagenti-operator/internal/webhook/injector/envoy.yaml.tmpl
@@ -33,7 +33,7 @@ static_resources:
               - match:
                   prefix: "/"
                 route:
-                  cluster: original_destination
+                  cluster: {{ if .MTLSStrict }}original_destination_tls{{ else }}original_destination{{ end }}
           http_filters:
           - name: envoy.filters.http.ext_proc
             typed_config:
@@ -59,10 +59,123 @@ static_resources:
         address: 0.0.0.0
         port_value: {{ .InboundPort }}
     listener_filters:
+    {{- if .MTLSEnabled }}
+    # tls_inspector peeks the first bytes (TLS record type 0x16) so the
+    # filter_chain_match below can route TLS to the mTLS chain and
+    # plaintext to the raw_buffer chain. Same idea as proxy-sidecar's
+    # authlib/listener/internal/tlssniff/listener.go, expressed as
+    # Envoy YAML.
+    - name: envoy.filters.listener.tls_inspector
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    {{- end }}
     - name: envoy.filters.listener.original_dst
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.filters.listener.original_dst.v3.OriginalDst
     filter_chains:
+    {{- if .MTLSEnabled }}
+    # mTLS chain — terminates the TLS handshake using the local
+    # SPIRE-issued SVID and validates the peer certificate against the
+    # SPIRE trust bundle. Cert paths are written by the in-process
+    # spiffe Provider mirror inside the authbridge-envoy combined image
+    # (svid-output emptyDir mounted RW at /opt).
+    - filter_chain_match:
+        transport_protocol: tls
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          require_client_certificate: true
+          common_tls_context:
+            tls_certificates:
+            - certificate_chain: { filename: /opt/svid.pem }
+              private_key:       { filename: /opt/svid_key.pem }
+            validation_context:
+              trusted_ca:        { filename: /opt/svid_bundle.pem }
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: inbound_http_tls
+          codec_type: AUTO
+          route_config:
+            name: inbound_routes
+            virtual_hosts:
+            - name: local_app
+              domains: ["*"]
+              request_headers_to_add:
+              - header:
+                  key: "x-authbridge-direction"
+                  value: "inbound"
+                append: false
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: original_destination
+          http_filters:
+          - name: envoy.filters.http.ext_proc
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+              grpc_service:
+                envoy_grpc:
+                  cluster_name: ext_proc_cluster
+                timeout: 30s
+              allow_mode_override: true
+              processing_mode:
+                request_header_mode: SEND
+                response_header_mode: SKIP
+                request_body_mode: NONE
+                response_body_mode: NONE
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+    {{- if .MTLSPermissive }}
+    # Plaintext chain — only present in permissive mode. Strict mode
+    # omits this entirely so non-TLS callers drop at filter chain match.
+    - filter_chain_match:
+        transport_protocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: inbound_http_plain
+          codec_type: AUTO
+          route_config:
+            name: inbound_routes_plain
+            virtual_hosts:
+            - name: local_app_plain
+              domains: ["*"]
+              request_headers_to_add:
+              - header:
+                  key: "x-authbridge-direction"
+                  value: "inbound"
+                append: false
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: original_destination
+          http_filters:
+          - name: envoy.filters.http.ext_proc
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+              grpc_service:
+                envoy_grpc:
+                  cluster_name: ext_proc_cluster
+                timeout: 30s
+              allow_mode_override: true
+              processing_mode:
+                request_header_mode: SEND
+                response_header_mode: SKIP
+                request_body_mode: NONE
+                response_body_mode: NONE
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+    {{- end }}
+    {{- else }}
+    # mTLS disabled — single plaintext chain (today's behavior).
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
@@ -101,6 +214,7 @@ static_resources:
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+    {{- end }}
 
 {{- if .SpireEnabled }}
   - name: agent_tls_listener
@@ -152,6 +266,32 @@ static_resources:
     lb_policy: CLUSTER_PROVIDED
     original_dst_lb_config:
       use_http_header: false
+
+  {{- if .MTLSStrict }}
+  # TLS-originating ORIGINAL_DST cluster — strict outbound only.
+  # Wraps every upstream connection in mTLS using the local SVID;
+  # peers must present a cert validated against the SPIRE trust
+  # bundle. Calls that need plaintext (Keycloak / JWKS / external
+  # HTTPS) bypass this listener: plugin outbound uses Go net/http
+  # directly, and proxy-init's iptables doesn't redirect arbitrary
+  # HTTPS egress. Same property proxy-sidecar's strict mode relies on.
+  - name: original_destination_tls
+    connect_timeout: 30s
+    type: ORIGINAL_DST
+    lb_policy: CLUSTER_PROVIDED
+    original_dst_lb_config:
+      use_http_header: false
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_certificates:
+          - certificate_chain: { filename: /opt/svid.pem }
+            private_key:       { filename: /opt/svid_key.pem }
+          validation_context:
+            trusted_ca:        { filename: /opt/svid_bundle.pem }
+  {{- end }}
 
   - name: ext_proc_cluster
     connect_timeout: 5s

--- a/kagenti-operator/internal/webhook/injector/envoy_template.go
+++ b/kagenti-operator/internal/webhook/injector/envoy_template.go
@@ -38,6 +38,19 @@ type envoyTemplateData struct {
 	SpireEnabled bool
 	// TLSPort is the port for the HTTPS listener (used when SpireEnabled is true).
 	TLSPort int32
+	// MTLSEnabled is true when MTLSMode is "permissive" or "strict". When
+	// enabled, the inbound listener gets a tls_inspector listener filter
+	// and a TLS filter chain backed by /opt/svid*.pem. The plaintext chain
+	// is also kept under permissive (filter_chain_match: raw_buffer);
+	// strict drops it so non-TLS callers fail at the listener.
+	MTLSEnabled bool
+	// MTLSPermissive / MTLSStrict are precomputed bool flags driven from
+	// MTLSMode and the constants in constants.go. The template uses these
+	// directly ({{ if .MTLSStrict }} / {{ if .MTLSPermissive }}) instead
+	// of comparing MTLSMode against bare string literals, so the
+	// constants stay the single source of truth.
+	MTLSPermissive bool
+	MTLSStrict     bool
 }
 
 // Default ext-proc gRPC port (go-processor).
@@ -47,9 +60,10 @@ const defaultExtProcPort int32 = 9090
 // If the resolved config already contains an EnvoyYAML string (from the
 // namespace ConfigMap), it is returned as-is for backward compatibility.
 //
-// TODO: wire RenderEnvoyConfig into the admission pipeline when per-workload
-// ConfigMap creation is implemented. Currently this function is only used in
-// unit tests.
+// The TLS blocks are gated on cfg.MTLSMode: permissive renders both a
+// TLS chain and a raw_buffer chain on the inbound listener; strict
+// renders the TLS chain only and routes outbound to a TLS-originating
+// cluster. disabled / "" produces today's plaintext config unchanged.
 func RenderEnvoyConfig(cfg *ResolvedConfig) (string, error) {
 	if cfg == nil || cfg.Platform == nil {
 		return "", fmt.Errorf("resolved config or platform config is nil")
@@ -58,11 +72,19 @@ func RenderEnvoyConfig(cfg *ResolvedConfig) (string, error) {
 		return cfg.EnvoyYAML, nil
 	}
 
+	// MTLSEnabled checks both "" and MTLSModeDisabled because
+	// ResolvedConfig leaves MTLSMode as "" when no source set it
+	// (CR / namespace ConfigMap / default — see ResolveConfig). The
+	// resolution chain only fills MTLSMode when something explicitly
+	// asked for it, so "" means "no opinion → treat as disabled".
 	data := envoyTemplateData{
-		AdminPort:    cfg.Platform.Proxy.AdminPort,
-		OutboundPort: cfg.Platform.Proxy.Port,
-		InboundPort:  cfg.Platform.Proxy.InboundProxyPort,
-		ExtProcPort:  defaultExtProcPort,
+		AdminPort:      cfg.Platform.Proxy.AdminPort,
+		OutboundPort:   cfg.Platform.Proxy.Port,
+		InboundPort:    cfg.Platform.Proxy.InboundProxyPort,
+		ExtProcPort:    defaultExtProcPort,
+		MTLSEnabled:    cfg.MTLSMode != "" && cfg.MTLSMode != MTLSModeDisabled,
+		MTLSPermissive: cfg.MTLSMode == MTLSModePermissive,
+		MTLSStrict:     cfg.MTLSMode == MTLSModeStrict,
 	}
 
 	var buf bytes.Buffer

--- a/kagenti-operator/internal/webhook/injector/envoy_template_test.go
+++ b/kagenti-operator/internal/webhook/injector/envoy_template_test.go
@@ -69,6 +69,110 @@ func TestRenderEnvoyConfig_TemplateRendering(t *testing.T) {
 	}
 }
 
+func TestRenderEnvoyConfig_MTLSDisabled_NoTLSBlocks(t *testing.T) {
+	// Default / disabled mode — no TLS blocks should render. Locks in
+	// the existing plaintext shape so a future template edit can't
+	// silently leak TLS config into pods that didn't ask for it.
+	for _, mode := range []string{"", MTLSModeDisabled} {
+		t.Run("mode="+mode, func(t *testing.T) {
+			cfg := &ResolvedConfig{
+				Platform: config.CompiledDefaults(),
+				MTLSMode: mode,
+			}
+			result, err := RenderEnvoyConfig(cfg)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for _, banned := range []string{
+				"tls_inspector",
+				"DownstreamTlsContext",
+				"UpstreamTlsContext",
+				"original_destination_tls",
+			} {
+				if strings.Contains(result, banned) {
+					t.Errorf("disabled mode should not render %q", banned)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderEnvoyConfig_MTLSPermissive(t *testing.T) {
+	cfg := &ResolvedConfig{
+		Platform: config.CompiledDefaults(),
+		MTLSMode: MTLSModePermissive,
+	}
+	result, err := RenderEnvoyConfig(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Inbound: tls_inspector + both TLS and raw_buffer chains.
+	for _, want := range []string{
+		"tls_inspector",
+		"DownstreamTlsContext",
+		"transport_protocol: tls",
+		"transport_protocol: raw_buffer",
+		"/opt/svid.pem",
+		"/opt/svid_key.pem",
+		"/opt/svid_bundle.pem",
+		"require_client_certificate: true",
+	} {
+		if !strings.Contains(result, want) {
+			t.Errorf("permissive should render %q", want)
+		}
+	}
+
+	// Outbound: stays plaintext — no UpstreamTlsContext, no TLS cluster.
+	for _, banned := range []string{
+		"UpstreamTlsContext",
+		"original_destination_tls",
+	} {
+		if strings.Contains(result, banned) {
+			t.Errorf("permissive outbound should stay plaintext; got %q", banned)
+		}
+	}
+}
+
+func TestRenderEnvoyConfig_MTLSStrict(t *testing.T) {
+	cfg := &ResolvedConfig{
+		Platform: config.CompiledDefaults(),
+		MTLSMode: MTLSModeStrict,
+	}
+	result, err := RenderEnvoyConfig(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Inbound: tls_inspector + TLS chain only.
+	for _, want := range []string{
+		"tls_inspector",
+		"DownstreamTlsContext",
+		"transport_protocol: tls",
+		"require_client_certificate: true",
+	} {
+		if !strings.Contains(result, want) {
+			t.Errorf("strict should render %q", want)
+		}
+	}
+	// Strict: no raw_buffer chain (plaintext drops at filter chain match).
+	if strings.Contains(result, "transport_protocol: raw_buffer") {
+		t.Error("strict mode must not render the raw_buffer chain — plaintext should drop at filter chain match")
+	}
+
+	// Outbound: TLS-originating cluster present + outbound listener
+	// routes to it.
+	for _, want := range []string{
+		"UpstreamTlsContext",
+		"original_destination_tls",
+		"cluster: original_destination_tls",
+	} {
+		if !strings.Contains(result, want) {
+			t.Errorf("strict outbound should render %q", want)
+		}
+	}
+}
+
 func TestRenderEnvoyConfig_CustomPorts(t *testing.T) {
 	platform := config.CompiledDefaults()
 	platform.Proxy.Port = 20000

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -570,16 +570,36 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 	// authbridge + bundled spiffe-helper. proxy-init is a separate
 	// init container. spiffe-helper starts conditionally on SPIRE_ENABLED.
 
-	// envoy-sidecar always passes mtlsMode="" — the validating webhook
-	// rejects mtlsMode != disabled with envoy-sidecar at admission, so
-	// we'd never reach this branch with a non-empty mtlsMode in practice;
-	// passing "" here is the explicit-defense complement.
+	// envoy-sidecar threads the resolved mtlsMode through to the per-agent
+	// authbridge-config CM (so the Provider's spiffe block + any future
+	// authbridge-side mTLS knobs reflect the CR's posture) AND renders a
+	// per-agent envoy-config CM with the matching TLS blocks. The envoy
+	// data plane terminates the actual TLS — DownstreamTlsContext on the
+	// inbound listener (gated on MTLSEnabled) and UpstreamTlsContext on
+	// original_destination_tls (strict only).
 	perAgentCMName, err := m.ensurePerAgentConfigMap(ctx, namespace, crName,
-		ModeEnvoySidecar, nsConfig.AuthBridgeRuntimeYAML, nsConfig, nil, "", allowedAudiences)
+		ModeEnvoySidecar, nsConfig.AuthBridgeRuntimeYAML, nsConfig, nil, mtlsMode, allowedAudiences)
 	if err != nil {
 		return false, fmt.Errorf("envoy-sidecar per-agent ConfigMap: %w", err)
 	}
 	requiredVolumes = overrideAuthBridgeConfigMapInVolumes(requiredVolumes, perAgentCMName)
+
+	// When mtlsMode is non-disabled, render a per-agent envoy-config CM
+	// so the workload's Envoy data plane carries the right TLS blocks.
+	// disabled stays on the namespace-level envoy-config (today's
+	// behavior, no per-agent CM churn).
+	if mtlsMode != MTLSModeDisabled {
+		// ResolveConfig is cheap/idempotent; we clear EnvoyYAML so
+		// RenderEnvoyConfig uses the template path (with mtls TLS
+		// blocks) instead of short-circuiting on the namespace CM.
+		resolvedForEnvoy := ResolveConfig(currentConfig, nsConfig, arOverrides)
+		resolvedForEnvoy.EnvoyYAML = ""
+		envoyCMName, err := m.ensurePerAgentEnvoyConfigMap(ctx, namespace, crName, resolvedForEnvoy)
+		if err != nil {
+			return false, fmt.Errorf("envoy-sidecar per-agent envoy ConfigMap: %w", err)
+		}
+		requiredVolumes = overrideEnvoyConfigMapInVolumes(requiredVolumes, envoyCMName)
+	}
 
 	if decision.EnvoyProxy.Inject && !containerExists(podSpec.Containers, EnvoyProxyContainerName) {
 		podSpec.Containers = append(podSpec.Containers, builder.BuildEnvoyProxyContainerWithSpireOption(spireEnabled))
@@ -665,6 +685,15 @@ func (m *PodMutator) apiReader() client.Reader {
 // perAgentConfigMapName returns the ConfigMap name for a specific agent's authbridge config.
 func perAgentConfigMapName(crName string) string {
 	return "authbridge-config-" + crName
+}
+
+// perAgentEnvoyConfigMapName returns the ConfigMap name for a
+// specific agent's rendered Envoy YAML. Envoy-sidecar workloads with
+// a non-disabled mtlsMode get a per-agent envoy-config CM so the TLS
+// blocks vary per workload; without mTLS the namespace-level
+// `envoy-config` is reused.
+func perAgentEnvoyConfigMapName(crName string) string {
+	return "envoy-config-" + crName
 }
 
 // synthesizePipeline builds the per-plugin pipeline section that
@@ -791,11 +820,12 @@ func injectAllowedAudiences(cfg map[string]interface{}, audiences []string) {
 // If baseYAML is empty (namespace has no authbridge-runtime-config), a minimal config
 // is generated from the NamespaceConfig fields.
 //
-// mtlsMode is the resolved mTLS posture (disabled / permissive / strict). Only
-// proxy-sidecar and lite paths reach this function with a non-disabled mtlsMode;
-// the AgentRuntime validating webhook rejects mtlsMode != disabled when
-// authBridgeMode is envoy-sidecar (Envoy SDS isn't wired in the kagenti envoy-config
-// today — tracked as a follow-up).
+// mtlsMode is the resolved mTLS posture (disabled / permissive / strict).
+// All three modes (proxy-sidecar, lite, envoy-sidecar) can reach this
+// function with any mtlsMode value. proxy-sidecar / lite consume the
+// rendered `mtls:` block via the authbridge listener directly;
+// envoy-sidecar uses a parallel per-agent envoy-config CM rendered by
+// ensurePerAgentEnvoyConfigMap (Envoy terminates TLS in its data plane).
 func (m *PodMutator) ensurePerAgentConfigMap(
 	ctx context.Context,
 	namespace, crName, mode string,
@@ -898,6 +928,52 @@ func (m *PodMutator) ensurePerAgentConfigMap(
 	}
 	mutatorLog.Info("Applied per-agent ConfigMap",
 		"namespace", namespace, "name", cmName, "mode", mode, "mtlsMode", mtlsMode)
+
+	return cmName, nil
+}
+
+// ensurePerAgentEnvoyConfigMap renders an envoy.yaml from the
+// resolved config and writes it to a per-agent ConfigMap named
+// envoy-config-<crName>. Used by the envoy-sidecar mode when
+// mtlsMode != disabled so each workload's Envoy config carries the
+// TLS blocks (DownstreamTlsContext on inbound, UpstreamTlsContext on
+// the strict-only original_destination_tls cluster) derived from the
+// resolved config's MTLSMode.
+//
+// Returns the ConfigMap name on success. The caller wires the
+// returned name into the envoy-config volume reference so the
+// envoy-proxy container mounts the per-agent CM instead of the
+// namespace-level `envoy-config`.
+//
+// SSA + OwnerReference machinery mirrors ensurePerAgentConfigMap;
+// the only differences are the CM name, the data key (envoy.yaml vs
+// config.yaml), and the YAML rendering source (RenderEnvoyConfig vs
+// the per-plugin authbridge runtime config).
+func (m *PodMutator) ensurePerAgentEnvoyConfigMap(
+	ctx context.Context,
+	namespace, crName string,
+	resolved *ResolvedConfig,
+) (string, error) {
+	cmName := perAgentEnvoyConfigMapName(crName)
+
+	envoyYAML, err := RenderEnvoyConfig(resolved)
+	if err != nil {
+		return "", fmt.Errorf("rendering per-agent envoy.yaml for %s/%s: %w", namespace, crName, err)
+	}
+
+	cmApply := applyconfigscorev1.ConfigMap(cmName, namespace).
+		WithLabels(map[string]string{managedByLabel: managedByValue}).
+		WithData(map[string]string{"envoy.yaml": envoyYAML})
+
+	if ownerRef := m.buildOwnerReference(ctx, namespace, crName); ownerRef != nil {
+		cmApply = cmApply.WithOwnerReferences(ownerRef)
+	}
+
+	if err := m.Client.Apply(ctx, cmApply, client.FieldOwner("kagenti-webhook"), client.ForceOwnership); err != nil {
+		return "", fmt.Errorf("failed to apply per-agent envoy ConfigMap %s/%s: %w", namespace, cmName, err)
+	}
+	mutatorLog.Info("Applied per-agent envoy ConfigMap",
+		"namespace", namespace, "name", cmName, "mtlsMode", resolved.MTLSMode)
 
 	return cmName, nil
 }

--- a/kagenti-operator/internal/webhook/injector/resolved_config.go
+++ b/kagenti-operator/internal/webhook/injector/resolved_config.go
@@ -53,6 +53,15 @@ type ResolvedConfig struct {
 
 	// AuthBridge runtime config — from namespace "authbridge-runtime-config" ConfigMap
 	AuthBridgeRuntimeYAML string // raw config.yaml (base for per-agent ConfigMap)
+
+	// AuthBridgeMode and MTLSMode are the resolved values from the chain
+	// CR > namespace ConfigMap > default. They're populated alongside the
+	// raw AuthBridgeRuntimeYAML so callers (e.g. RenderEnvoyConfig) can
+	// branch on the resolved values without re-parsing the YAML.
+	// AuthBridgeMode is "" when no source set it (caller picks the default).
+	// MTLSMode is "" when no source set it (caller treats as "disabled").
+	AuthBridgeMode string
+	MTLSMode       string
 }
 
 // ResolveConfig merges all three configuration layers into a single ResolvedConfig.
@@ -100,6 +109,22 @@ func ResolveConfig(platform *config.PlatformConfig, ns *NamespaceConfig, ar *Age
 		if ar.ClientRegistrationRealm != nil {
 			resolved.KeycloakRealm = *ar.ClientRegistrationRealm
 		}
+	}
+
+	// Resolve AuthBridgeMode + MTLSMode along the same CR > namespace > ""
+	// chain that pod_mutator uses. Keep this resolution local to
+	// ResolveConfig so consumers (e.g. RenderEnvoyConfig) can read the
+	// already-merged values straight off ResolvedConfig instead of
+	// re-implementing the chain.
+	if ar != nil && ar.AuthBridgeMode != nil {
+		resolved.AuthBridgeMode = *ar.AuthBridgeMode
+	} else if m := ExtractMode(resolved.AuthBridgeRuntimeYAML); m != "" {
+		resolved.AuthBridgeMode = m
+	}
+	if ar != nil && ar.MTLSMode != nil {
+		resolved.MTLSMode = *ar.MTLSMode
+	} else if m := ExtractMTLSMode(resolved.AuthBridgeRuntimeYAML); m != "" {
+		resolved.MTLSMode = m
 	}
 
 	return resolved

--- a/kagenti-operator/internal/webhook/injector/volume_builder.go
+++ b/kagenti-operator/internal/webhook/injector/volume_builder.go
@@ -244,3 +244,23 @@ func overrideAuthBridgeConfigMapInVolumes(volumes []corev1.Volume, cmName string
 	}
 	return result
 }
+
+// overrideEnvoyConfigMapInVolumes returns a copy of the volume list with
+// the envoy-config volume pointing at the given ConfigMap name. Used by
+// the envoy-sidecar mTLS path: the rendered per-agent envoy.yaml lives
+// in envoy-config-<crName>, replacing the namespace-level "envoy-config"
+// for that workload's Envoy. The volume name itself stays "envoy-config"
+// (matches the container's volumeMount); only the underlying ConfigMap
+// reference changes.
+func overrideEnvoyConfigMapInVolumes(volumes []corev1.Volume, cmName string) []corev1.Volume {
+	result := make([]corev1.Volume, len(volumes))
+	copy(result, volumes)
+	for i := range result {
+		if result[i].Name == EnvoyConfigMapName && result[i].ConfigMap != nil {
+			cmCopy := *result[i].ConfigMap
+			cmCopy.Name = cmName
+			result[i].ConfigMap = &cmCopy
+		}
+	}
+	return result
+}

--- a/kagenti-operator/internal/webhook/injector/volume_builder_test.go
+++ b/kagenti-operator/internal/webhook/injector/volume_builder_test.go
@@ -18,6 +18,8 @@ package injector
 
 import (
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestBuildResolvedVolumes_SpireDisabled(t *testing.T) {
@@ -140,4 +142,79 @@ func TestOverrideAuthBridgeConfigMapInVolumes(t *testing.T) {
 		}
 	}
 	t.Fatal("authbridge-runtime-config volume not found in overridden volumes")
+}
+
+// TestOverrideEnvoyConfigMapInVolumes locks the contract used by the
+// envoy-sidecar mtls path: when a per-agent envoy-config CM has been
+// rendered, the volume reference at the EnvoyConfigMapName slot must
+// be redirected to it without mutating the input slice or touching
+// any other volume.
+func TestOverrideEnvoyConfigMapInVolumes(t *testing.T) {
+	tests := []struct {
+		name    string
+		volumes func() []corev1.Volume
+		newCM   string
+		// found: true means the function should locate the envoy-config
+		// volume and update it; false means the input has no such
+		// volume and the result must equal the input element-for-element.
+		found bool
+	}{
+		{
+			name: "volume found, name swapped",
+			volumes: func() []corev1.Volume {
+				return BuildRequiredVolumes()
+			},
+			newCM: "envoy-config-my-agent",
+			found: true,
+		},
+		{
+			name: "no envoy-config volume, list unchanged",
+			volumes: func() []corev1.Volume {
+				return []corev1.Volume{{
+					Name:         "shared-data",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+				}}
+			},
+			newCM: "envoy-config-my-agent",
+			found: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := tt.volumes()
+			overridden := overrideEnvoyConfigMapInVolumes(original, tt.newCM)
+
+			// Original must not be mutated regardless of branch.
+			for _, v := range original {
+				if v.Name == EnvoyConfigMapName && v.ConfigMap != nil {
+					if v.ConfigMap.Name != EnvoyConfigMapName {
+						t.Errorf("original was mutated: got %q", v.ConfigMap.Name)
+					}
+				}
+			}
+
+			// Output length matches input length (no add/drop).
+			if len(overridden) != len(original) {
+				t.Fatalf("overridden length = %d, want %d", len(overridden), len(original))
+			}
+
+			// Find-and-swap behavior.
+			swappedFound := false
+			for _, v := range overridden {
+				if v.Name == EnvoyConfigMapName && v.ConfigMap != nil {
+					swappedFound = true
+					if v.ConfigMap.Name != tt.newCM {
+						t.Errorf("envoy-config CM name = %q, want %q", v.ConfigMap.Name, tt.newCM)
+					}
+				}
+			}
+			if tt.found && !swappedFound {
+				t.Fatal("expected envoy-config volume in overridden but didn't find it")
+			}
+			if !tt.found && swappedFound {
+				t.Fatal("envoy-config volume should not have been added")
+			}
+		})
+	}
 }

--- a/kagenti-operator/internal/webhook/v1alpha1/agentruntime_webhook.go
+++ b/kagenti-operator/internal/webhook/v1alpha1/agentruntime_webhook.go
@@ -82,29 +82,27 @@ func (v *AgentRuntimeValidator) ValidateDelete(_ context.Context, rt *agentv1alp
 	return nil, nil
 }
 
-// checkMTLSCompatibleWithMode rejects mtlsMode != disabled when authBridgeMode
-// is envoy-sidecar. Envoy SDS isn't currently configured by the kagenti
-// envoy-config — extending it to do real mTLS is a separate piece of work.
-// Until that lands, the only modes that actually carry mTLS are
-// proxy-sidecar and lite (kagenti-extensions PR #424). Rejecting at admission
-// makes the misconfiguration loud instead of producing a workload that
-// silently runs plaintext while the user believes they have strict mTLS.
-//
-// Empty / "disabled" mtlsMode is permitted for any authBridgeMode — that's
-// today's plaintext default. The error message points to the supported
-// modes and flags this as a current limitation, not a permanent one.
+// checkMTLSCompatibleWithMode validates the mtlsMode + authBridgeMode
+// combination. Empty / "disabled" mtlsMode is permitted for any
+// authBridgeMode (today's plaintext default). All three deployment
+// shapes (proxy-sidecar, lite, envoy-sidecar) now support permissive
+// and strict — proxy-sidecar / lite via the authbridge listener,
+// envoy-sidecar via TLS blocks rendered into a per-agent
+// envoy-config ConfigMap (DownstreamTlsContext on the inbound
+// listener, UpstreamTlsContext on original_destination_tls in
+// strict). The webhook keeps this function as the central enum
+// gate so future incompatible combinations can land here without
+// scattering the check.
 func checkMTLSCompatibleWithMode(rt *agentv1alpha1.AgentRuntime) error {
-	mtls := rt.Spec.MTLSMode
-	if mtls == "" || mtls == "disabled" {
-		return nil
-	}
-	if rt.Spec.AuthBridgeMode == "envoy-sidecar" {
-		return fmt.Errorf(
-			"mtlsMode=%q is not supported with authBridgeMode=envoy-sidecar; "+
-				"set authBridgeMode to proxy-sidecar or lite (envoy-sidecar mTLS is tracked as a follow-up)",
-			mtls,
-		)
-	}
+	// TODO(future-incompatibility): re-enable cross-field rejections
+	// here when a new authBridgeMode (e.g. waypoint, sidecarless) lands
+	// that needs different mTLS semantics. Today the matrix is fully
+	// supported — CRD enum validation pins mtlsMode and authBridgeMode
+	// to their enums, and every combination is implemented. The
+	// function intentionally stays as a single grep-target for the
+	// next incompatible combination so the rejection can land here
+	// instead of getting scattered across the validator.
+	_ = rt
 	return nil
 }
 

--- a/kagenti-operator/internal/webhook/v1alpha1/agentruntime_webhook_test.go
+++ b/kagenti-operator/internal/webhook/v1alpha1/agentruntime_webhook_test.go
@@ -247,12 +247,13 @@ func TestAgentRuntimeValidator_ValidateDelete(t *testing.T) {
 
 }
 
-// TestAgentRuntimeValidator_MTLSCompatWithMode covers the rejection of
-// mtlsMode != disabled when authBridgeMode is envoy-sidecar. The kagenti
-// envoy-config doesn't currently configure SDS, so an envoy-sidecar
-// workload that sets mtlsMode would silently run plaintext while the
-// user believes they have strict mTLS — the validator catches that at
-// admission time.
+// TestAgentRuntimeValidator_MTLSCompatWithMode covers the
+// authBridgeMode + mtlsMode compatibility matrix. All combinations
+// of {proxy-sidecar, lite, envoy-sidecar} × {disabled, permissive,
+// strict} are now valid — envoy-sidecar mtls is supported via
+// per-agent envoy-config rendering with TLS blocks
+// (DownstreamTlsContext / UpstreamTlsContext). Empty authBridgeMode
+// also admits across the matrix (resolution chain picks a default).
 func TestAgentRuntimeValidator_MTLSCompatWithMode(t *testing.T) {
 	ctx := context.Background()
 
@@ -271,8 +272,12 @@ func TestAgentRuntimeValidator_MTLSCompatWithMode(t *testing.T) {
 		{"empty mode + strict allowed", "", "strict", false},
 		{"envoy-sidecar + disabled allowed", "envoy-sidecar", "disabled", false},
 		{"envoy-sidecar + empty allowed", "envoy-sidecar", "", false},
-		{"envoy-sidecar + permissive rejected", "envoy-sidecar", "permissive", true},
-		{"envoy-sidecar + strict rejected", "envoy-sidecar", "strict", true},
+		// envoy-sidecar + permissive/strict — newly supported. Locked
+		// in here so a future regression that re-introduces the gate
+		// gets caught by tests instead of breaking the user-facing
+		// Spec.MTLSMode contract.
+		{"envoy-sidecar + permissive allowed", "envoy-sidecar", "permissive", false},
+		{"envoy-sidecar + strict allowed", "envoy-sidecar", "strict", false},
 	}
 
 	for _, tt := range tests {
@@ -287,10 +292,6 @@ func TestAgentRuntimeValidator_MTLSCompatWithMode(t *testing.T) {
 			if gotErr != tt.wantErr {
 				t.Errorf("ValidateCreate(mode=%q, mtls=%q): wantErr=%v, gotErr=%v (err=%v)",
 					tt.mode, tt.mtls, tt.wantErr, gotErr, err)
-			}
-			if tt.wantErr && err != nil &&
-				!strings.Contains(err.Error(), "envoy-sidecar mTLS is tracked as a follow-up") {
-				t.Errorf("error message should point to follow-up; got: %v", err)
 			}
 		})
 


### PR DESCRIPTION
## Summary

- Wires `Spec.MTLSMode` on `AgentRuntime` CRs through to a per-agent rendered Envoy data-plane TLS configuration when `Spec.AuthBridgeMode: envoy-sidecar`. Closes the operator-side gap that the kagenti-extensions PR #440 demo had to work around with hand-crafted manifests.
- Fixes a bundled bug: the `/opt` mount on envoy-sidecar's authbridge container was set `readOnly: true` (asymmetric with proxy-sidecar's RW), blocking the in-process spiffe Provider mirror from writing `/opt/svid*.pem` and Envoy from booting.
- Relaxes the admission webhook's envoy-sidecar + non-disabled mtls rejection. CRD enum validation already pins mtlsMode; no remaining incompatible combinations today.

## Design

Mode semantics match what the kagenti-extensions PR #440 demo proved at the data-plane level:

| `mtlsMode` | Inbound (peer-facing :15124) | Outbound (app-egress :15123) |
| --- | --- | --- |
| `disabled` (default) | plaintext | plaintext |
| `permissive` | `tls_inspector` + two filter chains: TLS chain terminates mTLS, raw_buffer chain accepts plaintext | plaintext (no TLS-wrap attempt) |
| `strict` | `tls_inspector` + single TLS chain; plaintext rejected at chain match | `UpstreamTlsContext` on `original_destination_tls` cluster: TLS-or-fail |

Inbound is byte-identical to proxy-sidecar's `tlssniff.Listener` semantics, expressed as Envoy filter chains — matches Istio's PERMISSIVE/STRICT inbound exactly.

Outbound is Istio-shaped: no per-connection try-then-fallback (Envoy has no native primitive for it, and Istio itself doesn't do it). Blanket TLS-or-fail in strict mode is practical for the same reason proxy-sidecar's strict mode is: outbound calls that need plaintext (Keycloak / JWKS / external HTTPS) bypass the listener (plugin-side via Go `net/http`, external HTTPS via iptables exclusion).

## Wiring

- `envoy.yaml.tmpl` — adds conditional TLS blocks gated on `MTLSEnabled` (permissive: tls_inspector + TLS chain + raw_buffer chain; strict: tls_inspector + TLS chain only) plus a strict-only `original_destination_tls` cluster with `UpstreamTlsContext`. SVID files at `/opt/svid*.pem`.
- `envoy_template.go` — `envoyTemplateData` carries `MTLSEnabled bool` + `MTLSMode string`; `RenderEnvoyConfig` populates from `ResolvedConfig.MTLSMode`.
- `resolved_config.go` — adds `MTLSMode` + `AuthBridgeMode` fields, populated via the same CR > namespace ConfigMap > "" chain `pod_mutator` already implements (`ExtractMode` / `ExtractMTLSMode` helpers).
- `pod_mutator.go` — envoy-sidecar branch now passes the resolved `mtlsMode` to `ensurePerAgentConfigMap` (was hardcoded `""` under the old webhook gate). When mtls is non-disabled, calls a new `ensurePerAgentEnvoyConfigMap` that SSAs an `envoy-config-<crName>` ConfigMap with the rendered `envoy.yaml`. SSA + OwnerReference machinery mirrors the existing `ensurePerAgentConfigMap`.
- `volume_builder.go` — adds `overrideEnvoyConfigMapInVolumes` (mirroring the existing `overrideAuthBridgeConfigMapInVolumes`) so the envoy-config volume reference points at the per-agent CM.
- `agentruntime_webhook.go` — `checkMTLSCompatibleWithMode` no longer rejects envoy-sidecar + non-disabled mtls. The function stays as a hook for future incompatible combinations.

## Bug fix

- `container_builder.go:117` — removed `ReadOnly: true` on the `svid-output` volumeMount in `BuildEnvoyProxyContainerWithSpireOption`. Asymmetric with `BuildProxySidecarContainerWithPorts` (correctly RW). The in-process spiffe Provider mirror inside the authbridge-envoy combined image needs to write SVID files there; under the RO mount it logged `atomicWrite: ... read-only file system` and Envoy refused to boot with `Invalid path: /opt/svid_bundle.pem`. Historical context: the RO was a copy-paste from the days of an external spiffe-helper writer container that no longer exists.
- `container_builder_test.go` — flipped the wrong test assertion. The test currently checks `if !vm.ReadOnly { t.Error("svid-output mount should be read-only") }` — i.e., it was asserting the bug as the desired behavior. Replaced with the opposite check.

## Tests

- `envoy_template_test.go` — three new cases lock in the rendered shape per mode (disabled = no TLS bits; permissive = both chains, no UpstreamTls; strict = TLS-only chain + UpstreamTlsContext + TLS cluster).
- `agentruntime_webhook_test.go` — `envoy-sidecar + permissive` and `envoy-sidecar + strict` cases flipped from `wantErr: true` to `wantErr: false`. Drops the `strings.Contains("envoy-sidecar mTLS is tracked as a follow-up")` check that's no longer applicable.
- `container_builder_test.go` — assertion flipped (svid-output mount must be RW).

## Test plan

- [x] `go test -race -count=1 ./internal/webhook/...` passes (config + injector + v1alpha1).
- [x] `go test -race -count=1 ./...` passes everything except `test/e2e` which wants a kind cluster named "kind" and is infra-dependent.
- [x] `go build ./...` clean.
- [x] **End-to-end on a SPIRE-enabled local kind cluster**: built the operator image with this PR, loaded into kind, restarted the controller, applied an `AgentRuntime` CR with `Spec.AuthBridgeMode: envoy-sidecar` + `Spec.MTLSMode: strict` plus its target Deployment. Verified:
  - Operator created `envoy-config-<name>` with `tls_inspector` + `DownstreamTlsContext` + `UpstreamTlsContext` + `original_destination_tls` cluster (strict-mode shape).
  - Operator created `authbridge-config-<name>` with `mtls.mode: strict` propagated through the resolution chain.
  - Pod reached 2/2 Running. The in-process spiffe Provider mirror successfully wrote `/opt/svid.pem`, `/opt/svid_key.pem`, `/opt/svid_bundle.pem` — confirming the bug 1 fix is what unblocks Envoy.
  - Envoy logs: `starting workers` cleanly, no `Invalid path: /opt/svid_bundle.pem` failures.

**Follow-up (separate, small PRs, not blocking):**
- kagenti-extensions: update `authbridge/demos/mtls/scripts/patch-mtls-config.sh` to patch the namespace `authbridge-runtime-config` CM instead of the per-agent CM (operator-owned). Fixes the existing `make demo-mtls` (proxy-sidecar) verification step.
- kagenti: relax the `envoy-sidecar + non-disabled mtls` rejection in `backend/app/routers/agents.py` and remove the matching UI lock in `ImportAgentPage.tsx`.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
