### PR TITLE
Feat: add OpenShift overlay with AuthBridge configs, SCC, and Istio shared trust

### DIFF
--- a/kagenti-operator/Makefile
+++ b/kagenti-operator/Makefile
@@ -193,6 +193,10 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} .
 	- $(CONTAINER_TOOL) buildx rm kagenti-operator-builder
 
+.PHONY: manifests-openshift
+manifests-openshift: manifests kustomize ## Build OpenShift standalone kustomize overlay manifests.
+	$(KUSTOMIZE) build config/openshift
+
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
@@ -229,9 +233,18 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | $(KUBECTL) apply --server-side  -f -
 
+.PHONY: deploy-openshift
+deploy-openshift: manifests kustomize ## Deploy controller with OpenShift extras (istio-trust, authbridge, SCC).
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/openshift | $(KUBECTL) apply --server-side  -f -
+
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+
+.PHONY: undeploy-openshift
+undeploy-openshift: kustomize ## Undeploy controller with OpenShift extras. Call with ignore-not-found=true to ignore resource not found errors.
+	$(KUSTOMIZE) build config/openshift | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: chart
 chart: manifests kustomize

--- a/kagenti-operator/cmd/main.go
+++ b/kagenti-operator/cmd/main.go
@@ -365,6 +365,11 @@ func main() {
 		}
 	}
 
+	// ========================================
+	// Operator namespace resolution
+	// ========================================
+	controller.SetClusterDefaultsNamespace(getOperatorNamespace())
+
 	if !requireA2ASignature && !enableVerifiedFetch {
 		setupLog.Info("WARNING: Neither --require-a2a-signature nor --enable-verified-fetch is set. " +
 			"Identity binding requires at least one trust mechanism to function. " +

--- a/kagenti-operator/cmd/main.go
+++ b/kagenti-operator/cmd/main.go
@@ -76,8 +76,9 @@ func init() {
 }
 
 // getOperatorNamespace returns the namespace the operator is running in.
-// Reads from POD_NAMESPACE environment variable (set via downward API in deployment),
-// falling back to kagenti-system if not set.
+// In production, the manager_webhook_patch.yaml injects POD_NAMESPACE via
+// the downward API, so the fallback is effectively dead code. It exists for
+// local development and test runs where the webhook patch is not applied.
 func getOperatorNamespace() string {
 	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
 		return ns
@@ -309,6 +310,11 @@ func main() {
 		})
 	}
 
+	// ========================================
+	// Operator namespace resolution
+	// ========================================
+	controller.SetClusterDefaultsNamespace(getOperatorNamespace())
+
 	cmCacheNamespaces := buildConfigMapCacheNamespaces(
 		requireA2ASignature, spireTrustBundleConfigMapName, spireTrustBundleConfigMapNS,
 	)
@@ -364,11 +370,6 @@ func main() {
 			setupLog.Info("Auto-discovered SPIRE trust domain", "trustDomain", spireTrustDomain)
 		}
 	}
-
-	// ========================================
-	// Operator namespace resolution
-	// ========================================
-	controller.SetClusterDefaultsNamespace(getOperatorNamespace())
 
 	if !requireA2ASignature && !enableVerifiedFetch {
 		setupLog.Info("WARNING: Neither --require-a2a-signature nor --enable-verified-fetch is set. " +

--- a/kagenti-operator/config/authbridge/authbridge-runtime-config.yaml
+++ b/kagenti-operator/config/authbridge/authbridge-runtime-config.yaml
@@ -1,0 +1,31 @@
+# AuthBridge runtime configuration template.
+# The operator copies this to agent namespaces via ensureNamespaceConfigMaps.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authbridge-runtime-config
+  namespace: kagenti-operator-system
+  labels:
+    app.kubernetes.io/name: kagenti-operator
+    app.kubernetes.io/component: authbridge
+    app.kubernetes.io/managed-by: kustomize
+data:
+  config.yaml: |
+    spiffe: {}
+    pipeline:
+      inbound:
+        plugins:
+          - name: jwt-validation
+            config:
+              issuer: "http://keycloak.localtest.me:8080/realms/kagenti"
+              keycloak_url: "http://keycloak-service.keycloak.svc:8080"
+              keycloak_realm: "kagenti"
+      outbound:
+        plugins:
+          - name: token-exchange
+            config:
+              keycloak_url: "http://keycloak-service.keycloak.svc:8080"
+              keycloak_realm: "kagenti"
+              default_policy: "passthrough"
+              identity:
+                type: "client-secret"

--- a/kagenti-operator/config/authbridge/envoy-config.yaml
+++ b/kagenti-operator/config/authbridge/envoy-config.yaml
@@ -1,0 +1,156 @@
+# Envoy proxy configuration template for envoy-sidecar mode.
+# The operator copies this to agent namespaces via ensureNamespaceConfigMaps.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-config
+  namespace: kagenti-operator-system
+  labels:
+    app.kubernetes.io/name: kagenti-operator
+    app.kubernetes.io/component: authbridge
+    app.kubernetes.io/managed-by: kustomize
+data:
+  envoy.yaml: |
+    admin:
+      address:
+        socket_address:
+          protocol: TCP
+          address: 127.0.0.1
+          port_value: 9901
+
+    static_resources:
+      listeners:
+      - name: outbound_listener
+        address:
+          socket_address:
+            protocol: TCP
+            address: 0.0.0.0
+            port_value: 15123
+        listener_filters:
+        - name: envoy.filters.listener.original_dst
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.original_dst.v3.OriginalDst
+        - name: envoy.filters.listener.tls_inspector
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+        filter_chains:
+        - filter_chain_match:
+            transport_protocol: tls
+          filters:
+          - name: envoy.filters.network.tcp_proxy
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+              stat_prefix: outbound_tls_passthrough
+              cluster: original_destination
+        - filter_chain_match:
+            transport_protocol: raw_buffer
+          filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stat_prefix: outbound_http
+              codec_type: AUTO
+              route_config:
+                name: outbound_routes
+                virtual_hosts:
+                - name: catch_all
+                  domains: ["*"]
+                  routes:
+                  - match:
+                      prefix: "/"
+                    route:
+                      cluster: original_destination
+                      timeout: 300s
+              http_filters:
+              - name: envoy.filters.http.ext_proc
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                  grpc_service:
+                    envoy_grpc:
+                      cluster_name: ext_proc_cluster
+                    timeout: 300s
+                  allow_mode_override: true
+                  processing_mode:
+                    request_header_mode: SEND
+                    response_header_mode: SEND
+                    request_body_mode: NONE
+                    response_body_mode: NONE
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+      - name: inbound_listener
+        address:
+          socket_address:
+            protocol: TCP
+            address: 0.0.0.0
+            port_value: 15124
+        listener_filters:
+        - name: envoy.filters.listener.original_dst
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.original_dst.v3.OriginalDst
+        filter_chains:
+        - filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stat_prefix: inbound_http
+              codec_type: AUTO
+              route_config:
+                name: inbound_routes
+                virtual_hosts:
+                - name: local_app
+                  domains: ["*"]
+                  routes:
+                  - match:
+                      prefix: "/"
+                    route:
+                      cluster: original_destination
+                      timeout: 300s
+              http_filters:
+              - name: envoy.filters.http.lua
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                  inline_code: |
+                    function envoy_on_request(request_handle)
+                      request_handle:headers():add("x-authbridge-direction", "inbound")
+                    end
+              - name: envoy.filters.http.ext_proc
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                  grpc_service:
+                    envoy_grpc:
+                      cluster_name: ext_proc_cluster
+                    timeout: 300s
+                  allow_mode_override: true
+                  processing_mode:
+                    request_header_mode: SEND
+                    response_header_mode: SEND
+                    request_body_mode: NONE
+                    response_body_mode: NONE
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+      clusters:
+      - name: original_destination
+        connect_timeout: 30s
+        type: ORIGINAL_DST
+        lb_policy: CLUSTER_PROVIDED
+        original_dst_lb_config:
+          use_http_header: false
+
+      - name: ext_proc_cluster
+        connect_timeout: 5s
+        type: STATIC
+        lb_policy: ROUND_ROBIN
+        http2_protocol_options: {}
+        load_assignment:
+          cluster_name: ext_proc_cluster
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 127.0.0.1
+                    port_value: 9090

--- a/kagenti-operator/config/authbridge/kustomization.yaml
+++ b/kagenti-operator/config/authbridge/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- authbridge-runtime-config.yaml
+- envoy-config.yaml
+- spiffe-helper-config.yaml

--- a/kagenti-operator/config/authbridge/spiffe-helper-config.yaml
+++ b/kagenti-operator/config/authbridge/spiffe-helper-config.yaml
@@ -1,0 +1,24 @@
+# SPIFFE helper configuration template.
+# The operator copies this to agent namespaces via ensureNamespaceConfigMaps.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spiffe-helper-config
+  namespace: kagenti-operator-system
+  labels:
+    app.kubernetes.io/name: kagenti-operator
+    app.kubernetes.io/component: authbridge
+    app.kubernetes.io/managed-by: kustomize
+data:
+  helper.conf: |
+    agent_address = "/spiffe-workload-api/spire-agent.sock"
+    cmd = ""
+    cmd_args = ""
+    svid_file_name = "/opt/svid.pem"
+    svid_key_file_name = "/opt/svid_key.pem"
+    svid_bundle_file_name = "/opt/svid_bundle.pem"
+    cert_file_mode = 0644
+    key_file_mode = 0640
+    jwt_svids = [{jwt_audience="http://keycloak.localtest.me:8080/realms/kagenti", jwt_svid_file_name="/opt/jwt_svid.token"}]
+    jwt_svid_file_mode = 0644
+    include_federated_domains = true

--- a/kagenti-operator/config/default/manager_webhook_patch.yaml
+++ b/kagenti-operator/config/default/manager_webhook_patch.yaml
@@ -12,6 +12,11 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert

--- a/kagenti-operator/config/istio-trust/certificates.yaml
+++ b/kagenti-operator/config/istio-trust/certificates.yaml
@@ -1,0 +1,68 @@
+# cert-manager Certificates for multi-mesh Istio shared trust.
+# Root CA in cert-manager namespace, intermediate CAs per Istio control plane.
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: istio-mesh-root-ca
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: kagenti-operator
+    app.kubernetes.io/component: shared-trust
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  isCA: true
+  commonName: istio-mesh-root-ca
+  duration: 87600h
+  renewBefore: 720h
+  secretName: istio-mesh-root-ca-secret
+  privateKey:
+    algorithm: RSA
+    size: 4096
+  issuerRef:
+    name: istio-mesh-root-selfsigned
+    kind: ClusterIssuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: istio-cacerts-default
+  namespace: istio-system
+  labels:
+    app.kubernetes.io/name: kagenti-operator
+    app.kubernetes.io/component: shared-trust
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  isCA: true
+  commonName: istio-ca-default
+  duration: 8760h
+  renewBefore: 720h
+  secretName: istio-cacerts-default-cert
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: istio-mesh-ca
+    kind: ClusterIssuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: istio-cacerts-openshift-gateway
+  namespace: openshift-ingress
+  labels:
+    app.kubernetes.io/name: kagenti-operator
+    app.kubernetes.io/component: shared-trust
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  isCA: true
+  commonName: istio-ca-openshift-gateway
+  duration: 8760h
+  renewBefore: 720h
+  secretName: istio-cacerts-og-cert
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: istio-mesh-ca
+    kind: ClusterIssuer

--- a/kagenti-operator/config/istio-trust/certificates.yaml
+++ b/kagenti-operator/config/istio-trust/certificates.yaml
@@ -1,5 +1,12 @@
 # cert-manager Certificates for multi-mesh Istio shared trust.
 # Root CA in cert-manager namespace, intermediate CAs per Istio control plane.
+#
+# Dependency chain: Root CA (istio-mesh-root-ca, 10-year duration) issues all
+# intermediate CAs via the istio-mesh-ca ClusterIssuer. If the root CA secret
+# (istio-mesh-root-ca-secret) is accidentally deleted, all intermediates become
+# orphaned and workload mTLS will break.
+# Recovery: re-create this Certificate to generate a new root CA, then restart
+# cert-manager to re-issue the intermediate CA certificates.
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/kagenti-operator/config/istio-trust/cluster-issuers.yaml
+++ b/kagenti-operator/config/istio-trust/cluster-issuers.yaml
@@ -1,0 +1,24 @@
+# ClusterIssuers for multi-mesh Istio shared trust via cert-manager.
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: istio-mesh-root-selfsigned
+  labels:
+    app.kubernetes.io/name: kagenti-operator
+    app.kubernetes.io/component: shared-trust
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: istio-mesh-ca
+  labels:
+    app.kubernetes.io/name: kagenti-operator
+    app.kubernetes.io/component: shared-trust
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  ca:
+    secretName: istio-mesh-root-ca-secret

--- a/kagenti-operator/config/istio-trust/kustomization.yaml
+++ b/kagenti-operator/config/istio-trust/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - cluster-issuers.yaml
+  - certificates.yaml

--- a/kagenti-operator/config/openshift/kustomization.yaml
+++ b/kagenti-operator/config/openshift/kustomization.yaml
@@ -9,3 +9,7 @@ resources:
 - ../istio-trust
 - ../authbridge
 - ../security
+
+patches:
+- path: patches/authbridge-keycloak.yaml
+- path: patches/spiffe-helper-keycloak.yaml

--- a/kagenti-operator/config/openshift/kustomization.yaml
+++ b/kagenti-operator/config/openshift/kustomization.yaml
@@ -1,0 +1,11 @@
+# OpenShift standalone overlay for kagenti-operator.
+#
+# Composes the operator core (config/default) with OpenShift-specific
+# resources: shared Istio trust certs, AuthBridge template ConfigMaps,
+# and the AuthBridge SCC.
+
+resources:
+- ../default
+- ../istio-trust
+- ../authbridge
+- ../security

--- a/kagenti-operator/config/openshift/patches/authbridge-keycloak.yaml
+++ b/kagenti-operator/config/openshift/patches/authbridge-keycloak.yaml
@@ -1,0 +1,27 @@
+# Strategic merge patch: override authbridge-runtime-config with
+# in-cluster Keycloak URLs for OpenShift deployments.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authbridge-runtime-config
+  namespace: kagenti-operator-system
+data:
+  config.yaml: |
+    spiffe: {}
+    pipeline:
+      inbound:
+        plugins:
+          - name: jwt-validation
+            config:
+              issuer: "http://keycloak-service.keycloak.svc:8080/realms/kagenti"
+              keycloak_url: "http://keycloak-service.keycloak.svc:8080"
+              keycloak_realm: "kagenti"
+      outbound:
+        plugins:
+          - name: token-exchange
+            config:
+              keycloak_url: "http://keycloak-service.keycloak.svc:8080"
+              keycloak_realm: "kagenti"
+              default_policy: "passthrough"
+              identity:
+                type: "client-secret"

--- a/kagenti-operator/config/openshift/patches/spiffe-helper-keycloak.yaml
+++ b/kagenti-operator/config/openshift/patches/spiffe-helper-keycloak.yaml
@@ -1,0 +1,20 @@
+# Strategic merge patch: override spiffe-helper-config with
+# in-cluster Keycloak JWT audience for OpenShift deployments.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spiffe-helper-config
+  namespace: kagenti-operator-system
+data:
+  helper.conf: |
+    agent_address = "/spiffe-workload-api/spire-agent.sock"
+    cmd = ""
+    cmd_args = ""
+    svid_file_name = "/opt/svid.pem"
+    svid_key_file_name = "/opt/svid_key.pem"
+    svid_bundle_file_name = "/opt/svid_bundle.pem"
+    cert_file_mode = 0644
+    key_file_mode = 0640
+    jwt_svids = [{jwt_audience="http://keycloak-service.keycloak.svc:8080/realms/kagenti", jwt_svid_file_name="/opt/jwt_svid.token"}]
+    jwt_svid_file_mode = 0644
+    include_federated_domains = true

--- a/kagenti-operator/config/security/kagenti-authbridge-scc.yaml
+++ b/kagenti-operator/config/security/kagenti-authbridge-scc.yaml
@@ -1,0 +1,77 @@
+# SCC for AuthBridge proxy-sidecar containers in agent namespaces.
+# Custom SCC needed because restricted-v2 does not permit CSI volumes
+# (csi.spiffe.io for SPIRE workload API).
+# groups is empty -- the operator creates per-namespace RoleBindings at runtime.
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: kagenti-authbridge
+  labels:
+    app.kubernetes.io/name: kagenti-operator
+    app.kubernetes.io/component: authbridge
+    app.kubernetes.io/managed-by: kustomize
+groups: []
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+allowPrivilegeEscalation: false
+allowedCapabilities: []
+defaultAddCapabilities: []
+requiredDropCapabilities:
+  - ALL
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+seccompProfiles:
+  - runtime/default
+volumes:
+  - configMap
+  - csi
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - persistentVolumeClaim
+  - projected
+  - secret
+---
+# ClusterRole granting "use" on the kagenti-authbridge SCC.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:openshift:scc:kagenti-authbridge
+  labels:
+    app.kubernetes.io/name: kagenti-operator
+    app.kubernetes.io/component: authbridge
+    app.kubernetes.io/managed-by: kustomize
+rules:
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    resourceNames: ["kagenti-authbridge"]
+    verbs: ["use"]
+---
+# Grants the operator SA "use" on the SCC so it can delegate via RoleBindings.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kagenti-operator-scc-authbridge
+  labels:
+    app.kubernetes.io/name: kagenti-operator
+    app.kubernetes.io/component: authbridge
+    app.kubernetes.io/managed-by: kustomize
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:kagenti-authbridge
+subjects:
+  - kind: ServiceAccount
+    name: kagenti-operator-controller-manager
+    namespace: kagenti-operator-system

--- a/kagenti-operator/config/security/kustomization.yaml
+++ b/kagenti-operator/config/security/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- kagenti-authbridge-scc.yaml

--- a/kagenti-operator/internal/controller/agentruntime_config.go
+++ b/kagenti-operator/internal/controller/agentruntime_config.go
@@ -36,8 +36,8 @@ const (
 	// ClusterFeatureGatesConfigMapName is the ConfigMap containing feature gate settings.
 	ClusterFeatureGatesConfigMapName = "kagenti-feature-gates"
 
-	// ClusterDefaultsNamespace is the namespace where cluster-level ConfigMaps live.
-	ClusterDefaultsNamespace = "kagenti-system"
+	// clusterDefaultsNamespaceDefault is the fallback namespace when POD_NAMESPACE is not set.
+	clusterDefaultsNamespaceDefault = "kagenti-system"
 
 	// LabelNamespaceDefaults identifies namespace-level defaults ConfigMaps.
 	LabelNamespaceDefaults = "kagenti.io/defaults"
@@ -48,6 +48,17 @@ const (
 	// hash picks them up and rolls affected workloads.
 	AuthBridgeRuntimeConfigMapName = "authbridge-runtime-config"
 )
+
+// ClusterDefaultsNamespace is the namespace where cluster-level ConfigMaps
+// and template ConfigMaps live. Defaults to "kagenti-system"; set to the
+// operator's own namespace by main() via SetClusterDefaultsNamespace
+var ClusterDefaultsNamespace = clusterDefaultsNamespaceDefault
+
+func SetClusterDefaultsNamespace(ns string) {
+	if ns != "" {
+		ClusterDefaultsNamespace = ns
+	}
+}
 
 // resolvedConfig is the canonical representation used for hash computation.
 // It captures the 2-layer merge of cluster defaults → namespace defaults.

--- a/kagenti-operator/internal/controller/agentruntime_config.go
+++ b/kagenti-operator/internal/controller/agentruntime_config.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -50,14 +51,22 @@ const (
 )
 
 // ClusterDefaultsNamespace is the namespace where cluster-level ConfigMaps
-// and template ConfigMaps live. Defaults to "kagenti-system"; set to the
-// operator's own namespace by main() via SetClusterDefaultsNamespace
-var ClusterDefaultsNamespace = clusterDefaultsNamespaceDefault
+// and template ConfigMaps live. Defaults to "kagenti-system"; set once to the
+// operator's own namespace by main() via SetClusterDefaultsNamespace.
+//
+// Write-once semantics: SetClusterDefaultsNamespace must be called exactly once
+// from main() before the manager starts. Subsequent calls are no-ops.
+var (
+	ClusterDefaultsNamespace     = clusterDefaultsNamespaceDefault
+	clusterDefaultsNamespaceOnce sync.Once
+)
 
 func SetClusterDefaultsNamespace(ns string) {
-	if ns != "" {
-		ClusterDefaultsNamespace = ns
-	}
+	clusterDefaultsNamespaceOnce.Do(func() {
+		if ns != "" {
+			ClusterDefaultsNamespace = ns
+		}
+	})
 }
 
 // resolvedConfig is the canonical representation used for hash computation.

--- a/kagenti-operator/internal/controller/agentruntime_controller.go
+++ b/kagenti-operator/internal/controller/agentruntime_controller.go
@@ -210,11 +210,19 @@ func (r *AgentRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// 4.7. Ensure SCC RoleBinding exists in the namespace.
 	// Creates a RoleBinding granting all ServiceAccounts in the namespace
 	// access to the kagenti-authbridge SCC. No-op on non-OpenShift clusters.
+	// On OpenShift, a transient failure is retried via requeue to prevent
+	// agent pods from failing with SCC violations at runtime.
 	if err := r.ensureNamespaceSCCBinding(ctx, rt.Namespace); err != nil {
 		logger.Error(err, "Failed to ensure SCC RoleBinding")
 		if r.Recorder != nil {
 			r.Recorder.Event(rt, corev1.EventTypeWarning, "SCCBindingError", err.Error())
 		}
+		r.setPhase(rt, agentv1alpha1.RuntimePhaseError)
+		r.setCondition(rt, ConditionTypeReady, metav1.ConditionFalse, "SCCBindingError", err.Error())
+		if statusErr := r.Status().Update(ctx, rt); statusErr != nil {
+			logger.Error(statusErr, "Failed to update status")
+		}
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
 	// 5. Compute config hash from merged configuration (cluster → namespace)

--- a/kagenti-operator/internal/controller/agentruntime_controller.go
+++ b/kagenti-operator/internal/controller/agentruntime_controller.go
@@ -28,6 +28,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -204,6 +205,16 @@ func (r *AgentRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	default:
 		r.setCondition(rt, ConditionTypeIstioMeshEnrolled, metav1.ConditionFalse, "OptedOut",
 			fmt.Sprintf("Namespace %s opted out of Istio mesh enrollment", rt.Namespace))
+	}
+
+	// 4.7. Ensure SCC RoleBinding exists in the namespace.
+	// Creates a RoleBinding granting all ServiceAccounts in the namespace
+	// access to the kagenti-authbridge SCC. No-op on non-OpenShift clusters.
+	if err := r.ensureNamespaceSCCBinding(ctx, rt.Namespace); err != nil {
+		logger.Error(err, "Failed to ensure SCC RoleBinding")
+		if r.Recorder != nil {
+			r.Recorder.Event(rt, corev1.EventTypeWarning, "SCCBindingError", err.Error())
+		}
 	}
 
 	// 5. Compute config hash from merged configuration (cluster → namespace)
@@ -1024,6 +1035,72 @@ func (r *AgentRuntimeReconciler) ensureNamespaceConfigMaps(ctx context.Context, 
 		}
 		logger.Info("Created ConfigMap from template", "namespace", namespace, "name", name)
 	}
+	return nil
+}
+
+const (
+	sccClusterRoleName = "system:openshift:scc:kagenti-authbridge"
+	sccRoleBindingName = "agent-authbridge-scc"
+)
+
+// ensureNamespaceSCCBinding creates a RoleBinding in the target namespace that
+// grants all ServiceAccounts access to the kagenti-authbridge SCC via the
+// system:openshift:scc:kagenti-authbridge ClusterRole. On non-OpenShift clusters
+// (ClusterRole absent), this is a silent no-op.
+func (r *AgentRuntimeReconciler) ensureNamespaceSCCBinding(ctx context.Context, namespace string) error {
+	logger := log.FromContext(ctx)
+	reader := r.uncachedReader()
+
+	// Check if the SCC ClusterRole exists — if not, skip (non-OpenShift).
+	cr := &rbacv1.ClusterRole{}
+	if err := reader.Get(ctx, client.ObjectKey{Name: sccClusterRoleName}, cr); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.V(1).Info("SCC ClusterRole not found, skipping SCC RoleBinding",
+				"clusterRole", sccClusterRoleName)
+			return nil
+		}
+		return fmt.Errorf("failed to check SCC ClusterRole %s: %w", sccClusterRoleName, err)
+	}
+
+	// Check if the RoleBinding already exists.
+	existing := &rbacv1.RoleBinding{}
+	err := reader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: sccRoleBindingName}, existing)
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to check RoleBinding %s/%s: %w", namespace, sccRoleBindingName, err)
+	}
+
+	// Create the RoleBinding.
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sccRoleBindingName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				LabelManagedBy: LabelManagedByValue,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     sccClusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     rbacv1.GroupKind,
+				APIGroup: rbacv1.GroupName,
+				Name:     "system:serviceaccounts:" + namespace,
+			},
+		},
+	}
+	if err := r.Create(ctx, rb); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to create SCC RoleBinding %s/%s: %w", namespace, sccRoleBindingName, err)
+	}
+	logger.Info("Created SCC RoleBinding", "namespace", namespace, "name", sccRoleBindingName)
 	return nil
 }
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary
Add a kustomize overlay (config/openshift) that composes the base operator deployment with OpenShift-specific resources:

AuthBridge sidecar configuration:
- authbridge-runtime-config ConfigMap (JWT validation, token exchange)
- envoy-config ConfigMap (inbound/outbound listeners with ext_proc)
- spiffe-helper-config ConfigMap (SVID and JWT SVID file output)

Security:
- kagenti-authbridge SCC allowing CSI volumes (csi.spiffe.io)
- ClusterRole and ClusterRoleBinding for SCC delegation
- Runtime SCC RoleBinding creation per agent namespace

Istio shared trust (cert-manager):
- Self-signed root CA ClusterIssuer and Certificate
- Intermediate CA Certificates for istio-system and openshift-ingress

Operator wiring:
- Makefile targets: deploy-openshift, undeploy-openshift, manifests-openshift
- POD_NAMESPACE env injection via manager webhook patch
- Dynamic ClusterDefaultsNamespace resolved from operator pod namespace
## Related issue(s)

## (Optional) Testing Instructions

Fixes #
