### PR TITLE
fix(client-registration): attach audience scope to agent's own client

### DIFF
--- a/kagenti-operator/internal/controller/clientregistration_controller.go
+++ b/kagenti-operator/internal/controller/clientregistration_controller.go
@@ -255,7 +255,7 @@ func (r *ClientRegistrationReconciler) reconcileOne(
 		logger.Error(err, "Keycloak admin token failed")
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
-	_, clientSecret, err := kc.RegisterOrFetchClientWithToken(ctx, token, keycloak.ClientRegistrationParams{
+	agentClientUUID, clientSecret, err := kc.RegisterOrFetchClientWithToken(ctx, token, keycloak.ClientRegistrationParams{
 		Realm:               ab.KeycloakRealm,
 		ClientID:            clientID,
 		ClientName:          clientName,
@@ -274,6 +274,7 @@ func (r *ClientRegistrationReconciler) reconcileOne(
 		AudienceClientID:     clientID,
 		PlatformClientIDs:    parsePlatformClientIDs(ab.PlatformClientIDs),
 		AudienceScopeEnabled: audienceScopeOn,
+		AgentClientUUID:      agentClientUUID,
 	}); err != nil {
 		logger.Error(err, "Keycloak audience scope management failed (credentials will still be written)",
 			"clientId", clientID)

--- a/kagenti-operator/internal/keycloak/audience.go
+++ b/kagenti-operator/internal/keycloak/audience.go
@@ -16,6 +16,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // AudienceParams configures audience client-scope management (mirrors AuthBridge client_registration.py).
@@ -82,7 +84,10 @@ func (a *Admin) EnsureAudienceScope(ctx context.Context, token string, p Audienc
 	// not retroactively apply realm default-default-client-scopes to clients that already exist
 	// when the scope is added, and the agent's client is registered just before this call.
 	if p.AgentClientUUID != "" {
-		_ = a.putClientDefaultClientScope(ctx, token, p.Realm, p.AgentClientUUID, scopeID)
+		if err := a.putClientDefaultClientScope(ctx, token, p.Realm, p.AgentClientUUID, scopeID); err != nil {
+			log.FromContext(ctx).V(1).Info("agent client scope attach failed",
+				"clientUUID", p.AgentClientUUID, "scope", scopeName, "err", err.Error())
+		}
 	}
 	for _, plat := range p.PlatformClientIDs {
 		plat = strings.TrimSpace(plat)

--- a/kagenti-operator/internal/keycloak/audience.go
+++ b/kagenti-operator/internal/keycloak/audience.go
@@ -25,6 +25,13 @@ type AudienceParams struct {
 	AudienceClientID     string   // OAuth clientId / SPIFFE ID used as custom audience in the mapper
 	PlatformClientIDs    []string // Keycloak clientId strings (e.g. UI client), not internal UUIDs
 	AudienceScopeEnabled bool     // when false, EnsureAudienceScope is a no-op
+
+	// AgentClientUUID is the internal Keycloak UUID of the agent's own client. When non-empty,
+	// the audience scope is explicitly attached to this client as a default-client-scope, so
+	// tokens issued via client_credentials carry the audience claim. Without this, agents
+	// registered before the realm-level default-default scope existed won't have it attached
+	// (Keycloak only auto-attaches default-defaults to newly-created clients).
+	AgentClientUUID string
 }
 
 type clientScopeListItem struct {
@@ -71,6 +78,12 @@ func (a *Admin) EnsureAudienceScope(ctx context.Context, token string, p Audienc
 		return fmt.Errorf("verify audience mapper for scope %q: %w", scopeName, err)
 	}
 	_ = a.putRealmDefaultDefaultClientScope(ctx, token, p.Realm, scopeID)
+	// Attach the audience scope to the agent's own client. Required because Keycloak does
+	// not retroactively apply realm default-default-client-scopes to clients that already exist
+	// when the scope is added, and the agent's client is registered just before this call.
+	if p.AgentClientUUID != "" {
+		_ = a.putClientDefaultClientScope(ctx, token, p.Realm, p.AgentClientUUID, scopeID)
+	}
 	for _, plat := range p.PlatformClientIDs {
 		plat = strings.TrimSpace(plat)
 		if plat == "" {

--- a/kagenti-operator/internal/keycloak/audience_test.go
+++ b/kagenti-operator/internal/keycloak/audience_test.go
@@ -79,6 +79,127 @@ func TestEnsureAudienceScope(t *testing.T) {
 	}
 }
 
+// TestEnsureAudienceScope_AttachesToAgentClient verifies that when AgentClientUUID is set,
+// the audience scope is explicitly attached to the agent's own client as a default-client-scope
+// (in addition to the realm default-default registration). This is required because Keycloak
+// does not retroactively attach realm default-defaults to clients that already exist.
+func TestEnsureAudienceScope_AttachesToAgentClient(t *testing.T) {
+	var putAgentClientCalls, putPlatformClientCalls int
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch {
+		case path == testMasterRealmTokenPath:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"access_token": "tok"})
+		case path == "/admin/realms/kagenti/client-scopes" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode([]clientScopeListItem{})
+		case path == "/admin/realms/kagenti/client-scopes" && r.Method == http.MethodPost:
+			w.Header().Set("Location", srv.URL+"/admin/realms/kagenti/client-scopes/new-scope-id")
+			w.WriteHeader(http.StatusCreated)
+		case strings.Contains(path, "/client-scopes/new-scope-id/protocol-mappers/models") && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+		case strings.Contains(path, "/client-scopes/new-scope-id/protocol-mappers/models") && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode([]protocolMapperRep{{
+				ID: "m1", Name: "agent-ns-wl-aud", Protocol: "openid-connect",
+				ProtocolMapper: "oidc-audience-mapper",
+				Config:         map[string]string{"included.custom.audience": "ns/wl"},
+			}})
+		case path == "/admin/realms/kagenti/default-default-client-scopes/new-scope-id" && r.Method == http.MethodPut:
+			w.WriteHeader(http.StatusNoContent)
+		case strings.HasPrefix(path, "/admin/realms/kagenti/clients") && r.Method == http.MethodGet && r.URL.Query().Get("clientId") == "kagenti":
+			_ = json.NewEncoder(w).Encode([]map[string]string{{"id": "plat-int", "clientId": "kagenti"}})
+		case path == "/admin/realms/kagenti/clients/agent-uuid-123/default-client-scopes/new-scope-id" && r.Method == http.MethodPut:
+			putAgentClientCalls++
+			w.WriteHeader(http.StatusNoContent)
+		case path == "/admin/realms/kagenti/clients/plat-int/default-client-scopes/new-scope-id" && r.Method == http.MethodPut:
+			putPlatformClientCalls++
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, path)
+		}
+	}))
+	defer srv.Close()
+
+	a := Admin{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	token, err := a.PasswordGrantToken(context.Background(), "u", "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = a.EnsureAudienceScope(context.Background(), token, AudienceParams{
+		Realm:                "kagenti",
+		ClientName:           "ns/wl",
+		AudienceClientID:     "ns/wl",
+		PlatformClientIDs:    []string{"kagenti"},
+		AudienceScopeEnabled: true,
+		AgentClientUUID:      "agent-uuid-123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if putAgentClientCalls != 1 {
+		t.Fatalf("expected 1 PUT to agent client default-client-scopes, got %d", putAgentClientCalls)
+	}
+	if putPlatformClientCalls != 1 {
+		t.Fatalf("expected 1 PUT to platform client default-client-scopes, got %d", putPlatformClientCalls)
+	}
+}
+
+// TestEnsureAudienceScope_NoAgentAttachWhenUUIDEmpty verifies that omitting AgentClientUUID
+// preserves the prior behavior — only platform clients receive explicit scope attachment.
+func TestEnsureAudienceScope_NoAgentAttachWhenUUIDEmpty(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch {
+		case path == testMasterRealmTokenPath:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"access_token": "tok"})
+		case path == "/admin/realms/kagenti/client-scopes" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode([]clientScopeListItem{})
+		case path == "/admin/realms/kagenti/client-scopes" && r.Method == http.MethodPost:
+			w.Header().Set("Location", srv.URL+"/admin/realms/kagenti/client-scopes/new-scope-id")
+			w.WriteHeader(http.StatusCreated)
+		case strings.Contains(path, "/client-scopes/new-scope-id/protocol-mappers/models") && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+		case strings.Contains(path, "/client-scopes/new-scope-id/protocol-mappers/models") && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode([]protocolMapperRep{{
+				ID: "m1", Name: "agent-ns-wl-aud", Protocol: "openid-connect",
+				ProtocolMapper: "oidc-audience-mapper",
+				Config:         map[string]string{"included.custom.audience": "ns/wl"},
+			}})
+		case path == "/admin/realms/kagenti/default-default-client-scopes/new-scope-id" && r.Method == http.MethodPut:
+			w.WriteHeader(http.StatusNoContent)
+		case strings.HasPrefix(path, "/admin/realms/kagenti/clients") && r.Method == http.MethodGet && r.URL.Query().Get("clientId") == "kagenti":
+			_ = json.NewEncoder(w).Encode([]map[string]string{{"id": "plat-int", "clientId": "kagenti"}})
+		case path == "/admin/realms/kagenti/clients/plat-int/default-client-scopes/new-scope-id" && r.Method == http.MethodPut:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			// Critical: any PUT to /clients/<uuid>/default-client-scopes/... where uuid != plat-int
+			// would mean we attached to an unintended client.
+			t.Fatalf("unexpected %s %s", r.Method, path)
+		}
+	}))
+	defer srv.Close()
+
+	a := Admin{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	token, err := a.PasswordGrantToken(context.Background(), "u", "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = a.EnsureAudienceScope(context.Background(), token, AudienceParams{
+		Realm:                "kagenti",
+		ClientName:           "ns/wl",
+		AudienceClientID:     "ns/wl",
+		PlatformClientIDs:    []string{"kagenti"},
+		AudienceScopeEnabled: true,
+		// AgentClientUUID intentionally empty
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 // TestEnsureAudienceScope_UpdatesStaleMapper verifies that when an audience scope mapper
 // already exists with a different audience (e.g. short-form "ns/wl" instead of SPIFFE URI),
 // ensureAudienceMapper detects the mismatch and updates it via PUT.


### PR DESCRIPTION
## Summary

`EnsureAudienceScope` creates the audience client-scope and registers it as a realm `default-default-client-scope`, expecting Keycloak to auto-attach it to every client. **But Keycloak only auto-attaches default-default scopes to *newly-created* clients.** The agent's client is registered just before `EnsureAudienceScope` is called, so by the time the realm-default is set up, the agent client has already been minted without it.

As a result, `client_credentials` tokens for the agent carry `aud=<realm-URL>` instead of `aud=<SPIFFE-ID>`, and AuthBridge's `jwt-validation` plugin rejects them with `"aud" not satisfied`.

This affects the basic weather-agent demo (kagenti-extensions [`demo-ui.md` step 6d](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/weather-agent/demo-ui.md)) end-to-end test, and any other workflow that issues `client_credentials` tokens directly to operator-managed agent clients.

## Fix

- Add `AgentClientUUID` to `AudienceParams`. When set, `EnsureAudienceScope` explicitly `PUT`s `clients/<uuid>/default-client-scopes/<scope-id>` for the agent's own client (alongside the existing platform-client and realm-default attachments).
- `ClientRegistrationReconciler` captures the internal UUID returned by `RegisterOrFetchClientWithToken` and passes it through.
- Two new unit tests in `audience_test.go`:
  - `TestEnsureAudienceScope_AttachesToAgentClient` — asserts the agent attachment happens when the UUID is set.
  - `TestEnsureAudienceScope_NoAgentAttachWhenUUIDEmpty` — asserts prior behavior is preserved (no spurious `PUT`s) when the UUID is empty.

## Verification

End-to-end on a Kind cluster running `kagenti-operator` v0.2.0-rc.5:

**Before** the fix (manually applied — bare client, no scope attached):
```json
{
  "iss": "http://keycloak.localtest.me:8080/realms/kagenti",
  "aud": "http://keycloak.localtest.me:8080/realms/kagenti"
}
```
Agent: `{"error":"auth.unauthorized","message":"token validation failed","plugin":"jwt-validation"}`
AuthBridge log: `"JWT validation failed" error="validating JWT: \"aud\" not satisfied"`

**After** the fix (proven by manually applying the equivalent two API calls in-cluster as a proof-of-concept):
```json
{
  "iss": "http://keycloak.localtest.me:8080/realms/kagenti",
  "aud": [
    "spiffe://localtest.me/ns/team1/sa/weather-service",
    "http://keycloak.localtest.me:8080/realms/kagenti"
  ],
  "azp": "spiffe://localtest.me/ns/team1/sa/weather-service"
}
```
Agent accepts the token and returns a normal A2A response.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/keycloak/...` (existing + 2 new tests pass)
- [x] `go test $(go list ./... | grep -v /e2e)` with envtest binaries (all green)
- [x] Manual in-cluster verification via the equivalent REST calls (token now contains the SPIFFE audience; agent accepts the request)

Fixes #394
