### PR TITLE
feat: operator auto-discovers and manages identity config

### DIFF
--- a/charts/kagenti-operator/templates/manager/manager.yaml
+++ b/charts/kagenti-operator/templates/manager/manager.yaml
@@ -79,6 +79,9 @@ spec:
             {{- if .Values.authbridgeConfig.clientAuthType }}
             - "--client-auth-type={{ .Values.authbridgeConfig.clientAuthType }}"
             {{- end }}
+            {{- if .Values.authbridgeConfig.credentialWaitTimeout }}
+            - "--credential-wait-timeout={{ .Values.authbridgeConfig.credentialWaitTimeout }}"
+            {{- end }}
             {{- end }}
           command:
             - {{ .Values.controllerManager.container.cmd }}

--- a/charts/kagenti-operator/templates/manager/manager.yaml
+++ b/charts/kagenti-operator/templates/manager/manager.yaml
@@ -40,9 +40,6 @@ spec:
             {{- if .Values.verifiedFetch.enabled }}
             - "--enable-verified-fetch=true"
             - "--verified-fetch-spiffe-socket={{ .Values.verifiedFetch.spiffeEndpointSocket }}"
-            {{- if and .Values.verifiedFetch.spireTrustDomain (not .Values.signatureVerification.enabled) }}
-            - "--spire-trust-domain={{ .Values.verifiedFetch.spireTrustDomain }}"
-            {{- end }}
             {{- end }}
             {{- if or .Values.enforceNetworkPolicies .Values.signatureVerification.enforceNetworkPolicies }}
             - "--enforce-network-policies=true"
@@ -54,9 +51,6 @@ spec:
             {{- end }}
             {{- if .Values.signatureVerification.enforceNetworkPolicies }}
             - "--enforce-network-policies=true"
-            {{- end }}
-            {{- if .Values.signatureVerification.spireTrustDomain }}
-            - "--spire-trust-domain={{ .Values.signatureVerification.spireTrustDomain }}"
             {{- end }}
             {{- if .Values.signatureVerification.spireTrustBundle.configMapName }}
             - "--spire-trust-bundle-configmap={{ .Values.signatureVerification.spireTrustBundle.configMapName }}"
@@ -74,30 +68,35 @@ spec:
             - "--svid-expiry-grace-period={{ .Values.signatureVerification.svidExpiryGracePeriod }}"
             {{- end }}
             {{- end }}
-            {{/*
-              --spire-trust-domain is rendered independently of
-              signatureVerification.enabled. The flag is also consumed by the
-              ClientRegistrationReconciler, which resolves SPIFFE client IDs of
-              the form spiffe://<trust-domain>/ns/<ns>/sa/<sa> when
-              authbridge-config has SPIRE_ENABLED=true. Gating it on signature
-              verification would break operator-managed client registration in
-              clusters that use SPIRE for workload identity but do not enable
-              A2A signature enforcement.
-            */}}
-            {{- if .Values.signatureVerification.spireTrustDomain }}
-            - "--spire-trust-domain={{ .Values.signatureVerification.spireTrustDomain }}"
+            {{- if .Values.keycloak }}
+            - "--keycloak-admin-secret-namespace={{ .Values.keycloak.adminSecretNamespace | default "keycloak" }}"
+            - "--keycloak-realm={{ .Values.keycloak.realm | default "kagenti" }}"
+            {{- end }}
+            {{- if .Values.authbridgeConfig }}
+            {{- if not .Values.authbridgeConfig.enabled }}
+            - "--enable-authbridge-config=false"
+            {{- end }}
+            {{- if .Values.authbridgeConfig.clientAuthType }}
+            - "--client-auth-type={{ .Values.authbridgeConfig.clientAuthType }}"
+            {{- end }}
             {{- end }}
           command:
             - {{ .Values.controllerManager.container.cmd }}
           image: {{ .Values.controllerManager.container.image.repository }}:{{ .Values.controllerManager.container.image.tag }}
           imagePullPolicy: {{ .Values.controllerManager.container.image.pullPolicy | default "IfNotPresent" }}
           env:
-            # POD_NAMESPACE is used by the client registration controller to locate
-            # keycloak-admin-secret in the operator's namespace
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if and .Values.keycloak .Values.keycloak.publicUrl }}
+            - name: KAGENTI_KEYCLOAK_PUBLIC_URL
+              value: {{ .Values.keycloak.publicUrl | quote }}
+            {{- end }}
+            {{- if and .Values.signatureVerification .Values.signatureVerification.spireTrustDomain }}
+            - name: KAGENTI_SPIRE_TRUST_DOMAIN
+              value: {{ .Values.signatureVerification.spireTrustDomain | quote }}
+            {{- end }}
             {{- if .Values.controllerManager.container.env }}
             {{- range $key, $value := .Values.controllerManager.container.env }}
             - name: {{ $key }}

--- a/charts/kagenti-operator/templates/rbac/role.yaml
+++ b/charts/kagenti-operator/templates/rbac/role.yaml
@@ -153,6 +153,13 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - networking.k8s.io
+  resources:
   - networkpolicies
   verbs:
   - create
@@ -162,6 +169,20 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - zerotrustworkloadidentitymanagers
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
 - apiGroups:
   - operator.tekton.dev
   resources:

--- a/charts/kagenti-operator/values.yaml
+++ b/charts/kagenti-operator/values.yaml
@@ -107,6 +107,8 @@ keycloak:
 authbridgeConfig:
   enabled: true
   clientAuthType: "client-secret"
+  # How long AuthBridge waits for Keycloak credentials (increase for slow Keycloak startup)
+  # credentialWaitTimeout: "120s"
 
 # [MLFLOW]: MLflow experiment tracking integration
 mlflow:

--- a/charts/kagenti-operator/values.yaml
+++ b/charts/kagenti-operator/values.yaml
@@ -92,6 +92,22 @@ networkPolicy:
 # Works with both verifiedFetch (mTLS) and signatureVerification (init-signer).
 enforceNetworkPolicies: false
 
+# [KEYCLOAK]: Keycloak integration settings
+keycloak:
+  # Namespace where the keycloak-initial-admin secret is located
+  adminSecretNamespace: keycloak
+  # Target realm for agent client registration
+  realm: kagenti
+  # External Keycloak URL (used for ISSUER / EXPECTED_AUDIENCE in authbridge-config).
+  # Auto-discovered from OpenShift Route or Kubernetes Ingress named "keycloak" in
+  # the adminSecretNamespace. Set here only to override auto-discovery.
+  publicUrl: ""
+
+# [AUTHBRIDGE CONFIG]: Reconcile authbridge-config ConfigMap in agent namespaces
+authbridgeConfig:
+  enabled: true
+  clientAuthType: "client-secret"
+
 # [MLFLOW]: MLflow experiment tracking integration
 mlflow:
   enable: false
@@ -112,8 +128,6 @@ verifiedFetch:
   spiffeEndpointSocket: "unix:///spiffe-workload-api/spire-agent.sock"
   # Agents must expose a Service port named "agent-tls" (default 8443).
   # The operator discovers the TLS endpoint by port name, not number.
-  # SPIRE trust domain for identity binding (required when enabled)
-  spireTrustDomain: ""
 
 # [SIGNATURE VERIFICATION]: A2A agent card signature verification via SPIRE x5c
 signatureVerification:
@@ -123,12 +137,9 @@ signatureVerification:
   auditMode: false
   # Enforce network policies based on signature verification
   enforceNetworkPolicies: false
-  # SPIRE trust domain. Required when SPIRE is enabled in the cluster even if
-  # signatureVerification.enabled is false: the ClientRegistrationReconciler
-  # uses this to build SPIFFE-shaped Keycloak client IDs
-  # (spiffe://<trust-domain>/ns/<ns>/sa/<sa>) whenever authbridge-config has
-  # SPIRE_ENABLED=true. The chart renders --spire-trust-domain independently of
-  # signatureVerification.enabled for this reason.
+  # SPIRE trust domain. Auto-discovered from ZTWIM CR or spire-bundle ConfigMap.
+  # Set here only to override auto-discovery. Used by ClientRegistrationReconciler
+  # to build SPIFFE-shaped Keycloak client IDs (spiffe://<trust-domain>/ns/<ns>/sa/<sa>).
   spireTrustDomain: ""
   # Key within the SPIRE trust bundle ConfigMap. Matches the SPIRE hardened Helm chart default
   # and the binary flag default. Override to "bundle.crt" only for older ZTWIM deployments.

--- a/kagenti-operator/cmd/main.go
+++ b/kagenti-operator/cmd/main.go
@@ -123,6 +123,7 @@ func main() {
 	var keycloakPublicURL string
 	var clientAuthType string
 	var spiffeIdpAlias string
+	var credentialWaitTimeout string
 	var enableAuthbridgeConfig bool
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
@@ -185,6 +186,8 @@ func main() {
 		"Default client authentication type: client-secret or federated-jwt")
 	flag.StringVar(&spiffeIdpAlias, "spiffe-idp-alias", "spire-spiffe",
 		"Keycloak SPIFFE Identity Provider alias")
+	flag.StringVar(&credentialWaitTimeout, "credential-wait-timeout", "120s",
+		"How long AuthBridge waits for Keycloak credentials to become available")
 	flag.BoolVar(&enableAuthbridgeConfig, "enable-authbridge-config", true,
 		"Reconcile authbridge-config ConfigMap in namespaces labeled kagenti-enabled=true")
 
@@ -611,6 +614,7 @@ func main() {
 				SpireTrustDomain:             spireTrustDomain,
 				ClientAuthType:               clientAuthType,
 				SpiffeIdpAlias:               spiffeIdpAlias,
+				CredentialWaitTimeout:        credentialWaitTimeout,
 			},
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "AuthbridgeConfig")

--- a/kagenti-operator/cmd/main.go
+++ b/kagenti-operator/cmd/main.go
@@ -49,6 +49,7 @@ import (
 	"github.com/kagenti/operator/internal/agentcard"
 	"github.com/kagenti/operator/internal/bootstrap"
 	"github.com/kagenti/operator/internal/controller"
+	"github.com/kagenti/operator/internal/discovery"
 	"github.com/kagenti/operator/internal/keycloak"
 	"github.com/kagenti/operator/internal/mlflow"
 	"github.com/kagenti/operator/internal/signature"
@@ -117,6 +118,13 @@ func main() {
 	var spireTrustBundleRefreshInterval time.Duration
 	var svidExpiryGracePeriod time.Duration
 
+	var keycloakAdminSecretNamespace string
+	var keycloakRealm string
+	var keycloakPublicURL string
+	var clientAuthType string
+	var spiffeIdpAlias string
+	var enableAuthbridgeConfig bool
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -158,8 +166,6 @@ func main() {
 		"unix:///spiffe-workload-api/spire-agent.sock",
 		"SPIFFE Workload API socket path for verified fetch")
 
-	flag.StringVar(&spireTrustDomain, "spire-trust-domain", "",
-		"SPIRE trust domain for identity binding (e.g. 'example.org')")
 	flag.StringVar(&spireTrustBundleConfigMapName, "spire-trust-bundle-configmap", "",
 		"Name of the ConfigMap containing the SPIRE trust bundle (SPIFFE JSON format)")
 	flag.StringVar(&spireTrustBundleConfigMapNS, "spire-trust-bundle-configmap-namespace", "",
@@ -170,6 +176,17 @@ func main() {
 		"How often to re-read the trust bundle")
 	flag.DurationVar(&svidExpiryGracePeriod, "svid-expiry-grace-period", 30*time.Minute,
 		"How far before the signing SVID expires to trigger a proactive workload restart for re-signing")
+
+	flag.StringVar(&keycloakAdminSecretNamespace, "keycloak-admin-secret-namespace", "keycloak",
+		"Namespace where keycloak-initial-admin secret is located")
+	flag.StringVar(&keycloakRealm, "keycloak-realm", "kagenti",
+		"Keycloak realm for agent client registration and identity")
+	flag.StringVar(&clientAuthType, "client-auth-type", "client-secret",
+		"Default client authentication type: client-secret or federated-jwt")
+	flag.StringVar(&spiffeIdpAlias, "spiffe-idp-alias", "spire-spiffe",
+		"Keycloak SPIFFE Identity Provider alias")
+	flag.BoolVar(&enableAuthbridgeConfig, "enable-authbridge-config", true,
+		"Reconcile authbridge-config ConfigMap in namespaces labeled kagenti-enabled=true")
 
 	opts := zap.Options{
 		Development: false,
@@ -307,6 +324,37 @@ func main() {
 		os.Exit(1)
 	}
 
+	// ========================================
+	// Auto-discover keycloakPublicURL and spireTrustDomain
+	// Env vars override auto-discovery.
+	// ========================================
+	if keycloakPublicURL == "" {
+		keycloakPublicURL = os.Getenv("KAGENTI_KEYCLOAK_PUBLIC_URL")
+	}
+	if keycloakPublicURL == "" {
+		discovered, err := discovery.DiscoverKeycloakPublicURL(ctx, mgr.GetAPIReader(), keycloakAdminSecretNamespace)
+		if err != nil {
+			setupLog.Info("Keycloak public URL auto-discovery failed (will retry at reconcile time)", "error", err.Error())
+		} else {
+			keycloakPublicURL = discovered
+			setupLog.Info("Auto-discovered Keycloak public URL", "url", keycloakPublicURL)
+		}
+	}
+
+	if spireTrustDomain == "" {
+		spireTrustDomain = os.Getenv("KAGENTI_SPIRE_TRUST_DOMAIN")
+	}
+	if spireTrustDomain == "" {
+		spireNS := os.Getenv("KAGENTI_SPIRE_NAMESPACE")
+		discovered, err := discovery.DiscoverSPIRETrustDomain(ctx, mgr.GetAPIReader(), spireNS)
+		if err != nil {
+			setupLog.Info("SPIRE trust domain auto-discovery failed (will retry at reconcile time)", "error", err.Error())
+		} else {
+			spireTrustDomain = discovered
+			setupLog.Info("Auto-discovered SPIRE trust domain", "trustDomain", spireTrustDomain)
+		}
+	}
+
 	if !requireA2ASignature && !enableVerifiedFetch {
 		setupLog.Info("WARNING: Neither --require-a2a-signature nor --enable-verified-fetch is set. " +
 			"Identity binding requires at least one trust mechanism to function. " +
@@ -316,8 +364,9 @@ func main() {
 	var sigProvider signature.Provider
 	if requireA2ASignature {
 		if spireTrustDomain == "" {
-			setupLog.Error(errors.New("missing required flag"),
-				"--spire-trust-domain is required when --require-a2a-signature=true")
+			setupLog.Error(errors.New("SPIRE trust domain not available"),
+				"spireTrustDomain is required when --require-a2a-signature=true "+
+					"(set KAGENTI_SPIRE_TRUST_DOMAIN or ensure ZTWIM/spire-bundle is accessible)")
 			os.Exit(1)
 		}
 		if spireTrustBundleConfigMapName == "" || spireTrustBundleConfigMapNS == "" {
@@ -367,8 +416,9 @@ func main() {
 		} else {
 			td := spireTrustDomain
 			if td == "" {
-				setupLog.Error(errors.New("missing required flag"),
-					"--spire-trust-domain is required when --enable-verified-fetch=true")
+				setupLog.Error(errors.New("SPIRE trust domain not available"),
+					"spireTrustDomain is required when --enable-verified-fetch=true "+
+						"(set KAGENTI_SPIRE_TRUST_DOMAIN or ensure ZTWIM/spire-bundle is accessible)")
 				os.Exit(1)
 			}
 			fetcher, fetcherErr := agentcard.NewSpiffeFetcher(fetchX509Source, td)
@@ -465,15 +515,17 @@ func main() {
 
 	if enableClientRegistration {
 		operatorNS := getOperatorNamespace()
-		setupLog.Info("Client registration controller will read keycloak-admin-secret from operator namespace",
-			"namespace", operatorNS)
+		setupLog.Info("Client registration controller enabled",
+			"keycloakAdminSecretNamespace", keycloakAdminSecretNamespace,
+			"operatorNamespace", operatorNS)
 		if err = (&controller.ClientRegistrationReconciler{
-			Client:                  mgr.GetClient(),
-			APIReader:               mgr.GetAPIReader(),
-			Scheme:                  mgr.GetScheme(),
-			OperatorNamespace:       operatorNS,
-			SpireTrustDomain:        spireTrustDomain,
-			KeycloakAdminTokenCache: &keycloak.CachedAdminTokenProvider{},
+			Client:                       mgr.GetClient(),
+			APIReader:                    mgr.GetAPIReader(),
+			Scheme:                       mgr.GetScheme(),
+			OperatorNamespace:            operatorNS,
+			KeycloakAdminSecretNamespace: keycloakAdminSecretNamespace,
+			SpireTrustDomain:             spireTrustDomain,
+			KeycloakAdminTokenCache:      &keycloak.CachedAdminTokenProvider{},
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ClientRegistration")
 			os.Exit(1)
@@ -547,6 +599,24 @@ func main() {
 			os.Exit(1)
 		}
 		setupLog.Info("OTel collector bootstrap enabled")
+	}
+
+	if enableAuthbridgeConfig {
+		if err = (&controller.AuthbridgeConfigReconciler{
+			Client: mgr.GetClient(),
+			Platform: controller.AuthbridgeConfigPlatform{
+				KeycloakAdminSecretNamespace: keycloakAdminSecretNamespace,
+				KeycloakRealm:                keycloakRealm,
+				KeycloakPublicURL:            keycloakPublicURL,
+				SpireTrustDomain:             spireTrustDomain,
+				ClientAuthType:               clientAuthType,
+				SpiffeIdpAlias:               spiffeIdpAlias,
+			},
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "AuthbridgeConfig")
+			os.Exit(1)
+		}
+		setupLog.Info("authbridge-config reconciler enabled")
 	}
 
 	if metricsCertWatcher != nil {

--- a/kagenti-operator/config/default/kustomization.yaml
+++ b/kagenti-operator/config/default/kustomization.yaml
@@ -53,6 +53,9 @@ patches:
 - path: manager_webhook_patch.yaml
   target:
     kind: Deployment
+- path: webhook_namespace_selector_patch.yaml
+  target:
+    kind: MutatingWebhookConfiguration
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations

--- a/kagenti-operator/config/default/webhook_namespace_selector_patch.yaml
+++ b/kagenti-operator/config/default/webhook_namespace_selector_patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- name: inject.kagenti.io
+  namespaceSelector:
+    matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+          - kagenti-system
+          - kagenti-operator-system
+          - kube-system

--- a/kagenti-operator/config/manager/kustomization.yaml
+++ b/kagenti-operator/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/rh_ee_czaccari/kagenti-operator
-  newTag: testmychanges4
+  newName: kagenti-operator
+  newTag: v0.0.1

--- a/kagenti-operator/config/manager/kustomization.yaml
+++ b/kagenti-operator/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: kagenti-operator
-  newTag: v0.0.1
+  newName: quay.io/rh_ee_czaccari/kagenti-operator
+  newTag: testmychanges4

--- a/kagenti-operator/config/rbac/role.yaml
+++ b/kagenti-operator/config/rbac/role.yaml
@@ -152,6 +152,13 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - networking.k8s.io
+  resources:
   - networkpolicies
   verbs:
   - create
@@ -161,6 +168,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - zerotrustworkloadidentitymanagers
+  verbs:
+  - get
+  - list
 - apiGroups:
   - operator.tekton.dev
   resources:
@@ -181,3 +195,10 @@ rules:
   - list
   - update
   - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list

--- a/kagenti-operator/internal/controller/authbridgeconfig_controller.go
+++ b/kagenti-operator/internal/controller/authbridgeconfig_controller.go
@@ -36,6 +36,7 @@ type AuthbridgeConfigPlatform struct {
 	SpireTrustDomain             string
 	ClientAuthType               string
 	SpiffeIdpAlias               string
+	CredentialWaitTimeout        string
 }
 
 // AuthbridgeConfigReconciler reconciles authbridge-config ConfigMaps in namespaces
@@ -160,7 +161,7 @@ func (r *AuthbridgeConfigReconciler) buildConfigMapData() map[string]string {
 		"SPIRE_ENABLED":           spireEnabled,
 		"CLIENT_AUTH_TYPE":        clientAuthType,
 		"SPIFFE_IDP_ALIAS":        spiffeIdpAlias,
-		"CREDENTIAL_WAIT_TIMEOUT": "120s",
+		"CREDENTIAL_WAIT_TIMEOUT": r.credentialWaitTimeout(),
 	}
 
 	if issuer != "" {
@@ -170,6 +171,13 @@ func (r *AuthbridgeConfigReconciler) buildConfigMapData() map[string]string {
 	}
 
 	return data
+}
+
+func (r *AuthbridgeConfigReconciler) credentialWaitTimeout() string {
+	if r.Platform.CredentialWaitTimeout != "" {
+		return r.Platform.CredentialWaitTimeout
+	}
+	return "120s"
 }
 
 func (r *AuthbridgeConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/kagenti-operator/internal/controller/authbridgeconfig_controller.go
+++ b/kagenti-operator/internal/controller/authbridgeconfig_controller.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const (
+	labelKagentiEnabled  = "kagenti-enabled"
+	authbridgeConfigCM   = "authbridge-config"
+	defaultKeycloakRealm = "kagenti"
+)
+
+// AuthbridgeConfigPlatform holds the platform-level settings used to generate authbridge-config.
+type AuthbridgeConfigPlatform struct {
+	KeycloakAdminSecretNamespace string
+	KeycloakRealm                string
+	KeycloakPublicURL            string
+	SpireTrustDomain             string
+	ClientAuthType               string
+	SpiffeIdpAlias               string
+}
+
+// AuthbridgeConfigReconciler reconciles authbridge-config ConfigMaps in namespaces
+// labeled with kagenti-enabled=true.
+type AuthbridgeConfigReconciler struct {
+	client.Client
+	Platform AuthbridgeConfigPlatform
+}
+
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch
+
+func (r *AuthbridgeConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	ns := &corev1.Namespace{}
+	if err := r.Get(ctx, req.NamespacedName, ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if ns.Labels[labelKagentiEnabled] != "true" {
+		return ctrl.Result{}, nil
+	}
+
+	if ns.DeletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
+
+	desired := r.buildConfigMapData()
+
+	cm := &corev1.ConfigMap{}
+	err := r.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: authbridgeConfigCM}, cm)
+	if apierrors.IsNotFound(err) {
+		cm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      authbridgeConfigCM,
+				Namespace: ns.Name,
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "kagenti-operator",
+					LabelNamespaceDefaults:         "true",
+				},
+			},
+			Data: desired,
+		}
+		if createErr := r.Create(ctx, cm); createErr != nil {
+			if apierrors.IsAlreadyExists(createErr) {
+				// Race: cache was stale. Re-fetch and fall through to update.
+				if getErr := r.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: authbridgeConfigCM}, cm); getErr != nil {
+					return ctrl.Result{}, getErr
+				}
+			} else {
+				logger.Error(createErr, "Failed to create authbridge-config", "namespace", ns.Name)
+				return ctrl.Result{}, createErr
+			}
+		} else {
+			logger.Info("Created authbridge-config", "namespace", ns.Name)
+			return ctrl.Result{}, nil
+		}
+	} else if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Update existing ConfigMap
+	if cm.Labels == nil {
+		cm.Labels = make(map[string]string)
+	}
+	cm.Labels["app.kubernetes.io/managed-by"] = "kagenti-operator"
+	cm.Labels[LabelNamespaceDefaults] = "true"
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	for k, v := range desired {
+		cm.Data[k] = v
+	}
+	if updateErr := r.Update(ctx, cm); updateErr != nil {
+		logger.Error(updateErr, "Failed to update authbridge-config", "namespace", ns.Name)
+		return ctrl.Result{}, updateErr
+	}
+	logger.Info("Updated authbridge-config", "namespace", ns.Name)
+	return ctrl.Result{}, nil
+}
+
+func (r *AuthbridgeConfigReconciler) buildConfigMapData() map[string]string {
+	kcNS := r.Platform.KeycloakAdminSecretNamespace
+	if kcNS == "" {
+		kcNS = "keycloak"
+	}
+
+	keycloakURL := fmt.Sprintf("http://keycloak-service.%s.svc:8080", kcNS)
+	realm := r.Platform.KeycloakRealm
+	if realm == "" {
+		realm = defaultKeycloakRealm
+	}
+
+	issuer := ""
+	if r.Platform.KeycloakPublicURL != "" {
+		issuer = r.Platform.KeycloakPublicURL + "/realms/" + realm
+	}
+
+	spireEnabled := "false" //nolint:goconst // boolean string, not worth a constant
+	if r.Platform.SpireTrustDomain != "" {
+		spireEnabled = "true"
+	}
+
+	clientAuthType := r.Platform.ClientAuthType
+	if clientAuthType == "" {
+		clientAuthType = "client-secret"
+	}
+
+	spiffeIdpAlias := r.Platform.SpiffeIdpAlias
+	if spiffeIdpAlias == "" {
+		spiffeIdpAlias = "spire-spiffe"
+	}
+
+	data := map[string]string{
+		"KEYCLOAK_URL":            keycloakURL,
+		"KEYCLOAK_REALM":          realm,
+		"KEYCLOAK_NAMESPACE":      kcNS,
+		"SPIRE_ENABLED":           spireEnabled,
+		"CLIENT_AUTH_TYPE":        clientAuthType,
+		"SPIFFE_IDP_ALIAS":        spiffeIdpAlias,
+		"CREDENTIAL_WAIT_TIMEOUT": "120s",
+	}
+
+	if issuer != "" {
+		data["ISSUER"] = issuer
+		data["EXPECTED_AUDIENCE"] = issuer
+		data["JWT_AUDIENCE"] = issuer
+	}
+
+	return data
+}
+
+func (r *AuthbridgeConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("authbridge-config").
+		For(&corev1.Namespace{}, builder.WithPredicates(
+			predicate.Funcs{
+				CreateFunc: func(e event.CreateEvent) bool {
+					return e.Object.GetLabels()[labelKagentiEnabled] == "true"
+				},
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					oldVal := e.ObjectOld.GetLabels()[labelKagentiEnabled]
+					newVal := e.ObjectNew.GetLabels()[labelKagentiEnabled]
+					return newVal == "true" || oldVal != newVal
+				},
+				DeleteFunc: func(e event.DeleteEvent) bool {
+					return false
+				},
+			},
+		)).
+		Owns(&corev1.ConfigMap{}).
+		Complete(r)
+}

--- a/kagenti-operator/internal/controller/clientregistration_controller.go
+++ b/kagenti-operator/internal/controller/clientregistration_controller.go
@@ -37,7 +37,9 @@ import (
 // Well-known namespace resources.
 const (
 	authbridgeConfigConfigMap = "authbridge-config"
-	keycloakAdminSecret       = "keycloak-admin-secret"
+
+	// keycloakInitialAdminSecret is the RHBK-managed secret with keys "username"/"password".
+	keycloakInitialAdminSecret = "keycloak-initial-admin"
 
 	// LabelClientRegistrationInject: when not "true", the operator registers the OAuth client and sets
 	// AnnotationKeycloakClientSecretName. Value "true" opts the workload into the legacy webhook
@@ -56,15 +58,16 @@ const (
 // never reference a missing Secret; the webhook mounts the Secret for injected sidecars that use shared-data.
 type ClientRegistrationReconciler struct {
 	client.Client
-	// APIReader reads authbridge-config from agent namespaces and keycloak-admin-secret from
-	// the operator's namespace from the API server. Those objects are not in the manager's
-	// ConfigMap cache (see cmd/main.go cache.ByObject for ConfigMap).
+	// APIReader reads authbridge-config from agent namespaces and keycloak-initial-admin
+	// from the Keycloak namespace via the API server (bypasses manager cache).
 	APIReader client.Reader
 	Scheme    *runtime.Scheme
 
-	// OperatorNamespace is the namespace where the operator is running and where keycloak-admin-secret
-	// is located. This is dynamically detected from the operator's service account.
+	// OperatorNamespace is the namespace where the operator is running.
 	OperatorNamespace string
+
+	// KeycloakAdminSecretNamespace is where keycloak-initial-admin lives (default: "keycloak").
+	KeycloakAdminSecretNamespace string
 
 	SpireTrustDomain string
 	// KeycloakAdminTokenCache caches admin password-grant tokens by Keycloak URL and credentials to
@@ -77,6 +80,20 @@ func (r *ClientRegistrationReconciler) uncachedReader() client.Reader {
 		return r.APIReader
 	}
 	return r.Client
+}
+
+// resolveKeycloakAdminCredentials reads keycloak-initial-admin from the Keycloak namespace.
+func (r *ClientRegistrationReconciler) resolveKeycloakAdminCredentials(ctx context.Context) (string, string, error) {
+	kcNS := r.KeycloakAdminSecretNamespace
+	if kcNS == "" {
+		kcNS = "keycloak"
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.uncachedReader().Get(ctx, types.NamespacedName{Namespace: kcNS, Name: keycloakInitialAdminSecret}, secret); err != nil {
+		return "", "", err
+	}
+	return string(secret.Data["username"]), string(secret.Data["password"]), nil
 }
 
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
@@ -211,21 +228,16 @@ func (r *ClientRegistrationReconciler) reconcileOne(
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	// Read keycloak-admin-secret from the operator's namespace, not from agent namespace.
-	// This prevents Keycloak admin credentials from being replicated to every agent namespace,
-	// which would be a security risk if an agent namespace is compromised.
-	adminSecret := &corev1.Secret{}
-	if err := r.uncachedReader().Get(ctx, types.NamespacedName{Namespace: r.OperatorNamespace, Name: keycloakAdminSecret}, adminSecret); err != nil {
+	adminUser, adminPass, err := r.resolveKeycloakAdminCredentials(ctx)
+	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.Info("waiting for keycloak-admin-secret", "namespace", r.OperatorNamespace)
+			logger.Info("waiting for Keycloak admin secret")
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 		return ctrl.Result{}, err
 	}
-	adminUser := string(adminSecret.Data["KEYCLOAK_ADMIN_USERNAME"])
-	adminPass := string(adminSecret.Data["KEYCLOAK_ADMIN_PASSWORD"])
 	if adminUser == "" || adminPass == "" {
-		logger.Info("keycloak-admin-secret missing username/password keys")
+		logger.Info("Keycloak admin secret missing credentials")
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 

--- a/kagenti-operator/internal/controller/clientregistration_controller_test.go
+++ b/kagenti-operator/internal/controller/clientregistration_controller_test.go
@@ -26,6 +26,7 @@ import (
 const (
 	clientRegistrationTestNamespace      = "test-ns"
 	clientRegistrationTestOperatorNS     = "operator-ns"
+	clientRegistrationTestKeycloakNS     = "keycloak"
 	clientRegistrationTestDeploymentName = "my-dep"
 )
 
@@ -198,19 +199,15 @@ func authbridgeConfigMapForTest(ns, keycloakURL string) *corev1.ConfigMap {
 	}
 }
 
-// keycloakAdminSecretForTest creates a test keycloak-admin-secret.
-// The secret should be created in the operator namespace (clientRegistrationTestOperatorNS),
-// NOT in agent namespaces. This matches the production behavior where admin credentials
-// are restricted to the operator namespace for security.
 func keycloakAdminSecretForTest(ns string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
-			Name:      keycloakAdminSecret,
+			Name:      keycloakInitialAdminSecret,
 		},
 		Data: map[string][]byte{
-			"KEYCLOAK_ADMIN_USERNAME": []byte("admin"),
-			"KEYCLOAK_ADMIN_PASSWORD": []byte("secret"),
+			"username": []byte("admin"),
+			"password": []byte("secret"),
 		},
 	}
 }
@@ -314,13 +311,11 @@ func TestClientRegistrationReconciler_Reconcile(t *testing.T) {
 			wantRequeue: requeue,
 		},
 		{
-			name: "missing keycloak admin secret in operator namespace waits with requeue",
+			name: "missing keycloak-initial-admin secret waits with requeue",
 			objs: []client.Object{
 				clusterFeatureGatesConfigMap(true),
 				testDeploymentForClientReg(),
 				authbridgeConfigMapForTest(clientRegistrationTestNamespace, "https://keycloak.example"),
-				// Note: keycloak-admin-secret intentionally NOT created in operator namespace
-				// to test the missing secret path
 			},
 			wantRequeue: requeue,
 		},
@@ -331,9 +326,10 @@ func TestClientRegistrationReconciler_Reconcile(t *testing.T) {
 			scheme := clientRegistrationTestScheme(t)
 			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.objs...).Build()
 			r := &ClientRegistrationReconciler{
-				Client:            c,
-				Scheme:            scheme,
-				OperatorNamespace: clientRegistrationTestOperatorNS,
+				Client:                       c,
+				Scheme:                       scheme,
+				OperatorNamespace:            clientRegistrationTestOperatorNS,
+				KeycloakAdminSecretNamespace: clientRegistrationTestKeycloakNS,
 			}
 			res, err := r.Reconcile(ctx, req)
 			if err != nil {
@@ -362,13 +358,13 @@ func TestClientRegistrationReconciler_Reconcile(t *testing.T) {
 			clusterFeatureGatesConfigMap(true),
 			dep,
 			authbridgeConfigMapForTest(clientRegistrationTestNamespace, srv.URL),
-			// keycloak-admin-secret created in OPERATOR namespace (not agent namespace)
-			keycloakAdminSecretForTest(clientRegistrationTestOperatorNS),
+			keycloakAdminSecretForTest(clientRegistrationTestKeycloakNS),
 		).Build()
 		r := &ClientRegistrationReconciler{
-			Client:            c,
-			Scheme:            scheme,
-			OperatorNamespace: clientRegistrationTestOperatorNS,
+			Client:                       c,
+			Scheme:                       scheme,
+			OperatorNamespace:            clientRegistrationTestOperatorNS,
+			KeycloakAdminSecretNamespace: clientRegistrationTestKeycloakNS,
 		}
 		res, err := r.Reconcile(ctx, req)
 		if err != nil || res != (ctrl.Result{}) {
@@ -425,16 +421,14 @@ func TestClientRegistration_EndToEnd_CredentialsAuthenticate(t *testing.T) {
 		clusterFeatureGatesConfigMap(true),
 		dep,
 		authbridgeConfigMapForTest(clientRegistrationTestNamespace, idp.URL()),
-		// keycloak-admin-secret lives in the operator namespace (not the
-		// agent namespace) after PR #321's security hardening. The
-		// reconciler reads it from there via OperatorNamespace.
-		keycloakAdminSecretForTest(clientRegistrationTestOperatorNS),
+		keycloakAdminSecretForTest(clientRegistrationTestKeycloakNS),
 	).Build()
 
 	r := &ClientRegistrationReconciler{
-		Client:            c,
-		Scheme:            scheme,
-		OperatorNamespace: clientRegistrationTestOperatorNS,
+		Client:                       c,
+		Scheme:                       scheme,
+		OperatorNamespace:            clientRegistrationTestOperatorNS,
+		KeycloakAdminSecretNamespace: clientRegistrationTestKeycloakNS,
 	}
 	res, err := r.Reconcile(ctx, req)
 	if err != nil || res != (ctrl.Result{}) {

--- a/kagenti-operator/internal/discovery/discovery.go
+++ b/kagenti-operator/internal/discovery/discovery.go
@@ -33,15 +33,18 @@ var (
 // DiscoverKeycloakPublicURL discovers the external Keycloak URL from cluster resources.
 // It tries OpenShift Route first, then Kubernetes Ingress.
 func DiscoverKeycloakPublicURL(ctx context.Context, c client.Reader, keycloakNamespace string) (string, error) {
-	if url, err := discoverFromRoute(ctx, c, keycloakNamespace); err == nil && url != "" {
+	url, routeErr := discoverFromRoute(ctx, c, keycloakNamespace)
+	if routeErr == nil && url != "" {
 		return url, nil
 	}
 
-	if url, err := discoverFromIngress(ctx, c, keycloakNamespace); err == nil && url != "" {
+	url, ingressErr := discoverFromIngress(ctx, c, keycloakNamespace)
+	if ingressErr == nil && url != "" {
 		return url, nil
 	}
 
-	return "", fmt.Errorf("could not discover Keycloak public URL from Route or Ingress in namespace %q", keycloakNamespace)
+	return "", fmt.Errorf("could not discover Keycloak public URL in namespace %q: route: %v, ingress: %v",
+		keycloakNamespace, routeErr, ingressErr)
 }
 
 func discoverFromRoute(ctx context.Context, c client.Reader, ns string) (string, error) {
@@ -72,15 +75,18 @@ func discoverFromIngress(ctx context.Context, c client.Reader, ns string) (strin
 // It tries the ZTWIM CR first (OpenShift), then falls back to reading the spire-bundle
 // ConfigMap which contains the trust domain as a JSON key in SPIFFE bundle format.
 func DiscoverSPIRETrustDomain(ctx context.Context, c client.Reader, spireNamespace string) (string, error) {
-	if td, err := discoverFromZTWIM(ctx, c); err == nil && td != "" {
+	td, ztwimErr := discoverFromZTWIM(ctx, c)
+	if ztwimErr == nil && td != "" {
 		return td, nil
 	}
 
-	if td, err := discoverFromSpireBundle(ctx, c, spireNamespace); err == nil && td != "" {
+	td, bundleErr := discoverFromSpireBundle(ctx, c, spireNamespace)
+	if bundleErr == nil && td != "" {
 		return td, nil
 	}
 
-	return "", fmt.Errorf("could not discover SPIRE trust domain from ZTWIM CR or spire-bundle ConfigMap")
+	return "", fmt.Errorf("could not discover SPIRE trust domain: ztwim: %v, spire-bundle: %v",
+		ztwimErr, bundleErr)
 }
 
 func discoverFromZTWIM(ctx context.Context, c client.Reader) (string, error) {

--- a/kagenti-operator/internal/discovery/discovery.go
+++ b/kagenti-operator/internal/discovery/discovery.go
@@ -1,0 +1,144 @@
+package discovery
+
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list
+// +kubebuilder:rbac:groups=operator.openshift.io,resources=zerotrustworkloadidentitymanagers,verbs=get;list
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	routeGVK = schema.GroupVersionKind{
+		Group:   "route.openshift.io",
+		Version: "v1",
+		Kind:    "Route",
+	}
+	ztwimGVK = schema.GroupVersionKind{
+		Group:   "operator.openshift.io",
+		Version: "v1alpha1",
+		Kind:    "ZeroTrustWorkloadIdentityManager",
+	}
+)
+
+// DiscoverKeycloakPublicURL discovers the external Keycloak URL from cluster resources.
+// It tries OpenShift Route first, then Kubernetes Ingress.
+func DiscoverKeycloakPublicURL(ctx context.Context, c client.Reader, keycloakNamespace string) (string, error) {
+	if url, err := discoverFromRoute(ctx, c, keycloakNamespace); err == nil && url != "" {
+		return url, nil
+	}
+
+	if url, err := discoverFromIngress(ctx, c, keycloakNamespace); err == nil && url != "" {
+		return url, nil
+	}
+
+	return "", fmt.Errorf("could not discover Keycloak public URL from Route or Ingress in namespace %q", keycloakNamespace)
+}
+
+func discoverFromRoute(ctx context.Context, c client.Reader, ns string) (string, error) {
+	route := &unstructured.Unstructured{}
+	route.SetGroupVersionKind(routeGVK)
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: "keycloak"}, route); err != nil {
+		return "", err
+	}
+	host, found, err := unstructured.NestedString(route.Object, "spec", "host")
+	if err != nil || !found || host == "" {
+		return "", fmt.Errorf("route keycloak in %s has no spec.host", ns)
+	}
+	return "https://" + host, nil
+}
+
+func discoverFromIngress(ctx context.Context, c client.Reader, ns string) (string, error) {
+	ingress := &networkingv1.Ingress{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: "keycloak"}, ingress); err != nil {
+		return "", err
+	}
+	if len(ingress.Spec.Rules) > 0 && ingress.Spec.Rules[0].Host != "" {
+		return "https://" + ingress.Spec.Rules[0].Host, nil
+	}
+	return "", fmt.Errorf("ingress keycloak in %s has no host rule", ns)
+}
+
+// DiscoverSPIRETrustDomain discovers the SPIRE trust domain from cluster resources.
+// It tries the ZTWIM CR first (OpenShift), then falls back to reading the spire-bundle
+// ConfigMap which contains the trust domain as a JSON key in SPIFFE bundle format.
+func DiscoverSPIRETrustDomain(ctx context.Context, c client.Reader, spireNamespace string) (string, error) {
+	if td, err := discoverFromZTWIM(ctx, c); err == nil && td != "" {
+		return td, nil
+	}
+
+	if td, err := discoverFromSpireBundle(ctx, c, spireNamespace); err == nil && td != "" {
+		return td, nil
+	}
+
+	return "", fmt.Errorf("could not discover SPIRE trust domain from ZTWIM CR or spire-bundle ConfigMap")
+}
+
+func discoverFromZTWIM(ctx context.Context, c client.Reader) (string, error) {
+	ztwim := &unstructured.Unstructured{}
+	ztwim.SetGroupVersionKind(ztwimGVK)
+	if err := c.Get(ctx, types.NamespacedName{Name: "cluster"}, ztwim); err != nil {
+		return "", err
+	}
+	td, found, err := unstructured.NestedString(ztwim.Object, "spec", "trustDomain")
+	if err != nil || !found || td == "" {
+		return "", fmt.Errorf("ZTWIM CR 'cluster' has no spec.trustDomain")
+	}
+	return td, nil
+}
+
+// discoverFromSpireBundle reads the spire-bundle ConfigMap and extracts the trust domain
+// from the SPIFFE bundle JSON format (the top-level keys are trust domains).
+func discoverFromSpireBundle(ctx context.Context, c client.Reader, ns string) (string, error) {
+	if ns == "" {
+		ns = "zero-trust-workload-identity-manager"
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: "spire-bundle"}, cm); err != nil {
+		return "", err
+	}
+
+	for key, val := range cm.Data {
+		if key == "bundle.spiffe" || key == "bundle.json" {
+			td, err := extractTrustDomainFromBundle(val)
+			if err == nil && td != "" {
+				return td, nil
+			}
+		}
+	}
+
+	// Fallback: try any key that parses as SPIFFE bundle
+	for _, val := range cm.Data {
+		td, err := extractTrustDomainFromBundle(val)
+		if err == nil && td != "" {
+			return td, nil
+		}
+	}
+
+	return "", fmt.Errorf("spire-bundle ConfigMap in %s has no parseable trust domain", ns)
+}
+
+// extractTrustDomainFromBundle parses SPIFFE bundle JSON where top-level keys are trust domains.
+// Format: {"example.org": {"keys": [...]}}
+func extractTrustDomainFromBundle(raw string) (string, error) {
+	var bundle map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &bundle); err != nil {
+		return "", err
+	}
+	for domain := range bundle {
+		if domain != "" {
+			return domain, nil
+		}
+	}
+	return "", fmt.Errorf("empty bundle")
+}

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -844,21 +844,16 @@ var _ = Describe("AgentCard E2E", Ordered, func() {
 		var origArgs []string
 
 		BeforeAll(func() {
-			By("patching controller with signature verification flags")
+			By("patching controller with signature verification flags and trust domain")
 			var err error
 			origArgs, err = utils.PatchControllerArgs(controllerNamespace, controllerDeployment, []string{
 				"--require-a2a-signature=true",
 				"--spire-trust-bundle-configmap=spire-bundle",
 				"--spire-trust-bundle-configmap-namespace=spire-system",
+			}, map[string]string{
+				"KAGENTI_SPIRE_TRUST_DOMAIN": "example.org",
 			})
 			Expect(err).NotTo(HaveOccurred())
-
-			By("setting KAGENTI_SPIRE_TRUST_DOMAIN env var")
-			cmd := exec.Command("kubectl", "set", "env", "deployment/"+controllerDeployment,
-				"-n", controllerNamespace, "KAGENTI_SPIRE_TRUST_DOMAIN=example.org")
-			_, err = utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(utils.WaitForRollout(controllerDeployment, controllerNamespace, 2*time.Minute)).To(Succeed())
 		})
 
 		AfterAll(func() {
@@ -891,7 +886,7 @@ var _ = Describe("AgentCard E2E", Ordered, func() {
 				var err error
 				auditOrigArgs, err = utils.PatchControllerArgs(controllerNamespace, controllerDeployment, []string{
 					"--signature-audit-mode=true",
-				})
+				}, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -848,14 +848,25 @@ var _ = Describe("AgentCard E2E", Ordered, func() {
 			var err error
 			origArgs, err = utils.PatchControllerArgs(controllerNamespace, controllerDeployment, []string{
 				"--require-a2a-signature=true",
-				"--spire-trust-domain=example.org",
 				"--spire-trust-bundle-configmap=spire-bundle",
 				"--spire-trust-bundle-configmap-namespace=spire-system",
 			})
 			Expect(err).NotTo(HaveOccurred())
+
+			By("setting KAGENTI_SPIRE_TRUST_DOMAIN env var")
+			cmd := exec.Command("kubectl", "set", "env", "deployment/"+controllerDeployment,
+				"-n", controllerNamespace, "KAGENTI_SPIRE_TRUST_DOMAIN=example.org")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(utils.WaitForRollout(controllerDeployment, controllerNamespace, 2*time.Minute)).To(Succeed())
 		})
 
 		AfterAll(func() {
+			By("removing KAGENTI_SPIRE_TRUST_DOMAIN env var")
+			cmd := exec.Command("kubectl", "set", "env", "deployment/"+controllerDeployment,
+				"-n", controllerNamespace, "KAGENTI_SPIRE_TRUST_DOMAIN-")
+			_, _ = utils.Run(cmd)
+
 			By("restoring original controller args")
 			if origArgs != nil {
 				err := utils.RestoreControllerArgs(controllerNamespace, controllerDeployment, origArgs)
@@ -865,7 +876,7 @@ var _ = Describe("AgentCard E2E", Ordered, func() {
 				currentArgs, readErr := utils.KubectlGetJsonpath("deployment", controllerDeployment,
 					controllerNamespace, "{.spec.template.spec.containers[0].args}")
 				Expect(readErr).NotTo(HaveOccurred())
-				for _, arg := range []string{"--require-a2a-signature", "--spire-trust-domain"} {
+				for _, arg := range []string{"--require-a2a-signature"} {
 					Expect(currentArgs).NotTo(ContainSubstring(arg),
 						"controller args not fully restored: still contains "+arg)
 				}
@@ -1508,12 +1519,12 @@ rules:
 			g.Expect(output).NotTo(BeEmpty(), "webhook endpoint not yet populated")
 		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
-		By("patching controller with --spire-trust-domain=example.org")
-		var err error
-		origArgs, err = utils.PatchControllerArgs(controllerNamespace, controllerDeployment, []string{
-			"--spire-trust-domain=example.org",
-		})
+		By("setting KAGENTI_SPIRE_TRUST_DOMAIN env var")
+		envCmd := exec.Command("kubectl", "set", "env", "deployment/"+controllerDeployment,
+			"-n", controllerNamespace, "KAGENTI_SPIRE_TRUST_DOMAIN=example.org")
+		_, err := utils.Run(envCmd)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(utils.WaitForRollout(controllerDeployment, controllerNamespace, 2*time.Minute)).To(Succeed())
 
 		By("creating combined test namespace")
 		cmd := exec.Command("kubectl", "create", "ns", combinedTestNamespace)
@@ -1564,6 +1575,11 @@ rules:
 	})
 
 	AfterAll(func() {
+		By("removing KAGENTI_SPIRE_TRUST_DOMAIN env var")
+		envCmd := exec.Command("kubectl", "set", "env", "deployment/"+controllerDeployment,
+			"-n", controllerNamespace, "KAGENTI_SPIRE_TRUST_DOMAIN-")
+		_, _ = utils.Run(envCmd)
+
 		By("restoring original controller args")
 		if origArgs != nil {
 			err := utils.RestoreControllerArgs(controllerNamespace, controllerDeployment, origArgs)

--- a/kagenti-operator/test/utils/utils.go
+++ b/kagenti-operator/test/utils/utils.go
@@ -401,9 +401,44 @@ func buildArgsPatch(argsJSON []byte) string {
 	return fmt.Sprintf(patchTmpl, string(argsJSON))
 }
 
-// PatchControllerArgs patches controller deployment args with additional flags
-// and returns the original args for later restoration.
-func PatchControllerArgs(namespace, deploy string, addArgs []string) (origArgs []string, err error) {
+func buildDeploymentPatch(args []string, envVars map[string]string) (string, string) {
+	if len(envVars) == 0 {
+		argsJSON, _ := json.Marshal(args)
+		return buildArgsPatch(argsJSON), "json"
+	}
+	type envEntry struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	}
+	type container struct {
+		Name string     `json:"name"`
+		Args []string   `json:"args"`
+		Env  []envEntry `json:"env"`
+	}
+	envList := make([]envEntry, 0, len(envVars))
+	for k, v := range envVars {
+		envList = append(envList, envEntry{Name: k, Value: v})
+	}
+	p := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []container{
+						{Name: "manager", Args: args, Env: envList},
+					},
+				},
+			},
+		},
+	}
+	out, _ := json.Marshal(p)
+	return string(out), "strategic"
+}
+
+// PatchControllerArgs patches controller deployment args (and optional env vars)
+// in a single update and returns the original args for later restoration.
+func PatchControllerArgs(namespace, deploy string, addArgs []string,
+	envVars map[string]string,
+) (origArgs []string, err error) {
 	By("getting current controller args")
 	cmd := exec.Command("kubectl", "get", "deployment", deploy,
 		"-n", namespace,
@@ -425,18 +460,16 @@ func PatchControllerArgs(namespace, deploy string, addArgs []string) (origArgs [
 	newArgs := make([]string, len(origArgs), len(origArgs)+len(addArgs))
 	copy(newArgs, origArgs)
 	newArgs = append(newArgs, addArgs...)
-	argsJSON, jsonErr := json.Marshal(newArgs)
-	if jsonErr != nil {
-		return origArgs, fmt.Errorf("failed to marshal new args: %w", jsonErr)
-	}
-	patchJSON := buildArgsPatch(argsJSON)
+
+	patchJSON, patchType := buildDeploymentPatch(newArgs, envVars)
+
 	cmd = exec.Command("kubectl", "patch", "deployment", deploy,
 		"-n", namespace,
-		"--type=json",
+		"--type="+patchType,
 		fmt.Sprintf("-p=%s", patchJSON),
 	)
 	if _, patchErr := Run(cmd); patchErr != nil {
-		return origArgs, fmt.Errorf("failed to patch args: %w", patchErr)
+		return origArgs, fmt.Errorf("failed to patch deployment: %w", patchErr)
 	}
 
 	By("waiting for controller rollout after patch")


### PR DESCRIPTION
## Summary
Shifts identity bootstrapping from the setup script/Helm chart to the operator. The operator now reads keycloak-initial-admin directly, auto-discovers Keycloak public URL and SPIRE trust domain, and reconciles authbridge-config ConfigMaps in labeled agent namespaces.

## Changes
- Add authbridge-config reconciler — creates/updates ConfigMap in namespaces with `kagenti-enabled=true`
- Add auto-discovery package — discovers Keycloak URL from Route/Ingress, SPIRE trust domain from ZTWIM CR/spire-bundle
- Remove legacy keycloak-admin-secret fallback from ClientRegistrationReconciler (reads keycloak-initial-admin directly)
- Default `--enable-authbridge-config=true` in binary
- Add RBAC for Routes, Ingresses, ZeroTrustWorkloadIdentityManagers (Helm + Kustomize)
- Add Kustomize webhook namespace selector patch (prevents chicken-and-egg pod creation deadlock)

## Test Plan
- [ ] Deploy operator via Helm, verify auto-discovery logs: "Auto-discovered Keycloak public URL" and "Auto-discovered SPIRE trust domain"
- [ ] Label a namespace `kagenti-enabled=true`, verify authbridge-config ConfigMap is created with correct values
- [ ] Delete the ConfigMap, verify self-healing (recreated)
- [ ] Send A2A message to weather agent, verify response (confirms direct secret reading + client registration)
- [ ] Delete operator pod, verify it restarts (webhook namespace selector fix)