### PR TITLE
feat: remove enableTracing and tracingBackend from platform config

### DIFF
--- a/kagenti-operator/internal/webhook/config/defaults.go
+++ b/kagenti-operator/internal/webhook/config/defaults.go
@@ -75,7 +75,6 @@ func CompiledDefaults() *PlatformConfig {
 		Observability: ObservabilityConfig{
 			LogLevel:      "info",
 			EnableMetrics: true,
-			EnableTracing: false,
 		},
 	}
 }

--- a/kagenti-operator/internal/webhook/config/types.go
+++ b/kagenti-operator/internal/webhook/config/types.go
@@ -65,10 +65,8 @@ type SpiffeConfig struct {
 }
 
 type ObservabilityConfig struct {
-	LogLevel       string `json:"logLevel" yaml:"logLevel"`
-	EnableMetrics  bool   `json:"enableMetrics" yaml:"enableMetrics"`
-	EnableTracing  bool   `json:"enableTracing" yaml:"enableTracing"`
-	TracingBackend string `json:"tracingBackend" yaml:"tracingBackend"`
+	LogLevel      string `json:"logLevel" yaml:"logLevel"`
+	EnableMetrics bool   `json:"enableMetrics" yaml:"enableMetrics"`
 }
 
 // DeepCopy creates a copy of the config


### PR DESCRIPTION
## Summary

Removes the `observability.enableTracing` and `observability.tracingBackend` fields from the kagenti-platform-config schema. Tracing is deferred and MLflow connection is now based on MLF CR presence, so these fields are dangling configuration with no consumer.

The YAML unmarshaller silently ignores unknown keys, so existing ConfigMaps that still carry these fields continue to load without error (backward compat during upgrade).

## Changes

- `internal/webhook/config/types.go` — removed `EnableTracing` and `TracingBackend` fields from `ObservabilityConfig` struct
- `internal/webhook/config/defaults.go` — removed `EnableTracing: false` from compiled defaults

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./internal/webhook/config/...` passes
- [x] `rg` confirms zero remaining references to removed fields
- [ ] CI passes (e2e requires cluster)