### PR TITLE
Fix: use correct MLflow API group and resource for agent RBAC

### DIFF
--- a/charts/kagenti-operator/templates/rbac/role.yaml
+++ b/charts/kagenti-operator/templates/rbac/role.yaml
@@ -169,9 +169,9 @@ rules:
   - update
   - watch
 - apiGroups:
-  - mlflow.opendatahub.io
+  - mlflow.kubeflow.org
   resources:
-  - mlflowexperiments
+  - experiments
   verbs:
   - get
   - list

--- a/kagenti-operator/config/rbac/role.yaml
+++ b/kagenti-operator/config/rbac/role.yaml
@@ -141,9 +141,9 @@ rules:
   - list
   - watch
 - apiGroups:
-  - mlflow.opendatahub.io
+  - mlflow.kubeflow.org
   resources:
-  - mlflowexperiments
+  - experiments
   verbs:
   - get
   - list

--- a/kagenti-operator/docs/mlflow-integration.md
+++ b/kagenti-operator/docs/mlflow-integration.md
@@ -87,7 +87,7 @@ The MLflow controller uses Kubernetes namespace-scoped authentication with least
 1. **Operator access**: The controller-manager's ServiceAccount is bound (via a ClusterRoleBinding shipped in the Helm chart / kustomize) to the broad `mlflow-operator-mlflow-integration` ClusterRole. This lets the operator call the MLflow REST API to create experiments. The `X-MLFLOW-WORKSPACE` header is set to the agent's namespace, scoping the experiment to that workspace.
 
 2. **Agent access (scoped)**: For each agent Deployment the controller creates:
-   - A **Role** named `kagenti-mlflow-<deployment-name>` with `get` and `update` on the `mlflowexperiments` resource, scoped to the agent's own experiment via `resourceNames`. This means agents **cannot** create/delete experiments or access `registeredmodels` or `gatewayendpoints`.
+   - A **Role** named `kagenti-mlflow-<deployment-name>` with `get` and `update` on the `experiments` resource (API group `mlflow.kubeflow.org`), scoped to the agent's own experiment via `resourceNames`. This means agents **cannot** create/delete experiments or access `registeredmodels` or `gatewayendpoints`.
    - A **RoleBinding** with the same name that binds the agent's ServiceAccount to the scoped Role.
 
    The agent authenticates to MLflow using its projected SA token at `/var/run/secrets/kubernetes.io/serviceaccount/token`.

--- a/kagenti-operator/internal/controller/mlflow_controller.go
+++ b/kagenti-operator/internal/controller/mlflow_controller.go
@@ -40,13 +40,13 @@ import (
 )
 
 const (
-	// MLflowExperimentsAPIGroup is the API group used by the MLflow Kubernetes
-	// authorization plugin for SubjectAccessReview checks.
-	MLflowExperimentsAPIGroup = "mlflow.opendatahub.io"
+	// MLflowExperimentsAPIGroup is the API group used by the MLflow gateway's
+	// Kubernetes authorization plugin for SubjectAccessReview checks.
+	MLflowExperimentsAPIGroup = "mlflow.kubeflow.org"
 
 	// MLflowExperimentsResource is the virtual resource the MLflow gateway checks
-	// when authorizing experiment-level operations.
-	MLflowExperimentsResource = "mlflowexperiments"
+	// when authorizing experiment-level operations via SubjectAccessReview.
+	MLflowExperimentsResource = "experiments"
 
 	// MLflow annotation keys stored on the PodTemplateSpec.
 	AnnotationMLflowExperimentID   = "mlflow.kagenti.io/experiment-id"
@@ -77,7 +77,7 @@ type MLflowReconciler struct {
 }
 
 // +kubebuilder:rbac:groups=mlflow.opendatahub.io,resources=mlflows,verbs=create;get;list;update;watch
-// +kubebuilder:rbac:groups=mlflow.opendatahub.io,resources=mlflowexperiments,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=mlflow.kubeflow.org,resources=experiments,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=create;get;list;watch;update
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create;get;list;watch;update
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch


### PR DESCRIPTION
## Summary

Fixes the MLflow integration constants to use `mlflow.kubeflow.org` (API group) and `experiments` (resource) instead of the incorrect `mlflow.opendatahub.io` / `mlflowexperiments`. The MLflow gateway's Kubernetes authorization plugin performs SubjectAccessReview checks against `mlflow.kubeflow.org/experiments`, not the CRD's own API group — so agents were getting 403 PERMISSION_DENIED when exporting traces via the MLflow SDK.

This is a follow-up to #366. Further testing revealed that the Role permissions weren't properly configured, possibly because traces exported by the OTel collector masked failures in the agent's direct MLflow SDK path.

## Changes
- `MLflowExperimentsAPIGroup`: `mlflow.opendatahub.io` → `mlflow.kubeflow.org`
- `MLflowExperimentsResource`: `mlflowexperiments` → `experiments`
- Updated kubebuilder RBAC markers to match
- Updated `config/rbac/role.yaml` and `charts/kagenti-operator/templates/rbac/role.yaml`
- Updated `docs/mlflow-integration.md` to reflect correct values

## Testing
- Deployed an [agent](https://quay.io/repository/dnagornu_org/generic-agent) with MLFlow tracing enabled in code on a fresh ROSA cluster
- Removed `OTEL_EXPORTER_OTLP_ENDPOINT` to isolate the MLflow SDK path
- Verified `POST /mlflow/api/3.0/mlflow/traces` returns 200 with full span data (4 nested spans, token counts)

Made with [Cursor](https://cursor.com)