### PR TITLE
feat: Always-on proxy-sidecar egress enforcement (enforce-redirect), remove flag

### DIFF
--- a/charts/kagenti-operator/values.yaml
+++ b/charts/kagenti-operator/values.yaml
@@ -188,7 +188,7 @@ featureGates:
 #                                              parsers dropped) + spiffe-helper. Same listener layout
 #                                              as authbridge; for size-constrained deployments.
 # proxy-init applies to envoy-sidecar mode (transparent redirect) and to
-# proxy-sidecar mode when proxy.egressEnforcement is "enforce" (enforce-drop).
+# proxy-sidecar / lite mode (always-on enforce-redirect egress capture).
 defaults:
   images:
     envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:latest
@@ -203,16 +203,15 @@ defaults:
     uid: 1337
     adminPort: 9901
     inboundProxyPort: 15124
-    # Proxy-sidecar fail-closed egress enforcement. "off" (default) keeps egress
-    # cooperative (HTTP_PROXY only); "enforce" injects a proxy-init enforce-drop
-    # guard so direct egress is dropped. envoy-sidecar is unaffected (it already
-    # enforces via transparent redirect).
-    egressEnforcement: "off"
-    # In-cluster CIDRs (pods/services/DNS) allowed direct by the enforce-drop
-    # guard; everything else egressing the pod is dropped. The default is
-    # Kind-shaped (pods 10.244/16 + services 10.96/16). OpenShift/EKS MUST
-    # override — e.g. OCP services 172.30.0.0/16 (outside 10/8) + pods
-    # 10.128.0.0/14 — or in-cluster service traffic will be dropped.
+    # Forward proxy's transparent listener port — the REDIRECT target for the
+    # always-on enforce-redirect egress guard (proxy-sidecar / lite). MUST match
+    # the authbridge listener.transparent_proxy_addr (default :8082).
+    transparentPort: 8082
+    # In-cluster CIDRs (pods/services/DNS) left direct by the enforce-redirect
+    # guard; external TCP is REDIRECTed to the transparent listener and external
+    # non-TCP is dropped. The default is Kind-shaped (pods 10.244/16 + services
+    # 10.96/16). OpenShift/EKS MUST override — e.g. OCP services 172.30.0.0/16
+    # (outside 10/8) + pods 10.128.0.0/14 — or in-cluster service traffic breaks.
     clusterCIDRs:
       - "10.0.0.0/8"
 

--- a/kagenti-operator/internal/webhook/config/defaults.go
+++ b/kagenti-operator/internal/webhook/config/defaults.go
@@ -32,9 +32,9 @@ func CompiledDefaults() *PlatformConfig {
 			UID:              1337,
 			InboundProxyPort: 15124,
 			AdminPort:        9901,
-			// Off by default — proxy-sidecar stays cooperative (HTTP_PROXY only)
-			// until an operator opts in. Migrate to "enforce" in a future release.
-			EgressEnforcement: EgressEnforcementOff,
+			// Transparent listener port — must match the authbridge proxy-sidecar
+			// preset (listener.transparent_proxy_addr default :8082).
+			TransparentPort: 8082,
 			// Kind-shaped default (pods 10.244/16 + services 10.96/16). OCP/EKS
 			// MUST override (see ProxyConfig.ClusterCIDRs doc).
 			ClusterCIDRs: []string{"10.0.0.0/8"},

--- a/kagenti-operator/internal/webhook/config/types.go
+++ b/kagenti-operator/internal/webhook/config/types.go
@@ -41,36 +41,26 @@ type ImageConfig struct {
 	PullPolicy corev1.PullPolicy `json:"pullPolicy" yaml:"pullPolicy"`
 }
 
-// EgressEnforcement values for ProxyConfig.EgressEnforcement.
-const (
-	EgressEnforcementOff     = "off"
-	EgressEnforcementEnforce = "enforce"
-)
-
 type ProxyConfig struct {
 	Port             int32 `json:"port" yaml:"port"`
 	UID              int64 `json:"uid" yaml:"uid"`
 	InboundProxyPort int32 `json:"inboundProxyPort" yaml:"inboundProxyPort"`
 	AdminPort        int32 `json:"adminPort" yaml:"adminPort"`
 
-	// EgressEnforcement controls the proxy-sidecar fail-closed egress guard.
-	//   "off" (default): the workload routes egress through the forward proxy
-	//     via HTTP_PROXY only — cooperative and bypassable.
-	//   "enforce": a proxy-init container installs the enforce-drop iptables
-	//     guard, forcing all external egress through the forward proxy regardless
-	//     of whether the workload honors HTTP_PROXY.
-	// envoy-sidecar mode is unaffected — it already enforces egress structurally
-	// via the transparent redirect, so this knob is consulted only on the
-	// proxy-sidecar / lite path. Migrate the default off->enforce in a future
-	// release once ClusterCIDRs sourcing is validated across distros.
-	EgressEnforcement string `json:"egressEnforcement" yaml:"egressEnforcement"`
+	// TransparentPort is the forward proxy's transparent listener port — the
+	// REDIRECT target the enforce-redirect proxy-init guard sends captured
+	// external TCP egress to. It MUST match the authbridge proxy-sidecar
+	// listener.transparent_proxy_addr (default :8082).
+	TransparentPort int32 `json:"transparentPort" yaml:"transparentPort"`
 
 	// ClusterCIDRs are the in-cluster ranges (pods / services / DNS) that the
-	// enforce-drop guard allows direct; everything else egressing the pod is
-	// dropped. The default 10.0.0.0/8 is Kind-shaped (pods 10.244/16 + services
-	// 10.96/16). OCP/EKS MUST override this (e.g. OCP services 172.30.0.0/16,
-	// pods 10.128.0.0/14 — 172.30/16 is outside 10/8) or in-cluster service
-	// traffic will be dropped. Only used when EgressEnforcement == "enforce".
+	// enforce-redirect guard allows direct; external TCP is REDIRECTed to the
+	// transparent listener and external non-TCP is dropped. The default
+	// 10.0.0.0/8 is Kind-shaped (pods 10.244/16 + services 10.96/16). OCP/EKS
+	// MUST override this (e.g. OCP services 172.30.0.0/16, pods 10.128.0.0/14 —
+	// 172.30/16 is outside 10/8) or in-cluster service traffic will be dropped.
+	// Egress enforcement is always-on for proxy-sidecar / lite, so this is
+	// always consumed there; envoy-sidecar (transparent redirect) does not use it.
 	ClusterCIDRs []string `json:"clusterCIDRs" yaml:"clusterCIDRs"`
 }
 
@@ -151,32 +141,29 @@ func (c *PlatformConfig) Validate() error {
 	if c.Proxy.AdminPort < 1024 || c.Proxy.AdminPort > 65535 {
 		return fmt.Errorf("proxy.adminPort must be between 1024 and 65535")
 	}
-	// The enforce-drop guard exempts this UID (--uid-owner) and the proxy
+	if c.Proxy.TransparentPort < 1024 || c.Proxy.TransparentPort > 65535 {
+		return fmt.Errorf("proxy.transparentPort must be between 1024 and 65535")
+	}
+	// The enforce-redirect guard exempts this UID (--uid-owner) and the proxy
 	// container runs as it; it must be a real non-root user.
 	if c.Proxy.UID < 1 {
-		return fmt.Errorf("proxy.uid must be >= 1 (got %d): the proxy must not run as root and the enforce-drop exemption keys on this UID", c.Proxy.UID)
+		return fmt.Errorf("proxy.uid must be >= 1 (got %d): the proxy must not run as root and the egress-enforcement exemption keys on this UID", c.Proxy.UID)
 	}
-	switch c.Proxy.EgressEnforcement {
-	case "", EgressEnforcementOff, EgressEnforcementEnforce:
-	default:
-		return fmt.Errorf("proxy.egressEnforcement must be \"off\" or \"enforce\" (got %q)", c.Proxy.EgressEnforcement)
+	// ClusterCIDRs drive the only in-cluster allowance in the enforce-redirect
+	// guard, which is always-on for proxy-sidecar / lite. Validate at load time so
+	// a misconfig fails fast with a clear message rather than: (a) an empty list
+	// silently falling back to the Kind-shaped 10.0.0.0/8 default in
+	// init-iptables.sh, or (b) a malformed entry crashing the proxy-init container
+	// under `set -e` with a cryptic iptables error.
+	if len(c.Proxy.ClusterCIDRs) == 0 {
+		return fmt.Errorf("proxy.clusterCIDRs must be non-empty (set the cluster's pod+service CIDRs)")
 	}
-	// When enforce is on, ClusterCIDRs drive the only in-cluster allowance in the
-	// enforce-drop guard. Validate them at load time so a misconfig fails fast with
-	// a clear message rather than: (a) an empty list silently falling back to the
-	// Kind-shaped 10.0.0.0/8 default in init-iptables.sh, or (b) a malformed entry
-	// crashing the proxy-init container under `set -e` with a cryptic iptables error.
-	if c.Proxy.EgressEnforcement == EgressEnforcementEnforce {
-		if len(c.Proxy.ClusterCIDRs) == 0 {
-			return fmt.Errorf("proxy.clusterCIDRs must be non-empty when proxy.egressEnforcement is %q (set the cluster's pod+service CIDRs)", EgressEnforcementEnforce)
-		}
-		// Syntactic validation only — overlapping ranges and IPv4/IPv6 mixing are
-		// accepted (iptables handles both, and the init script splits v4/v6 itself);
-		// we only reject malformed strings here.
-		for _, cidr := range c.Proxy.ClusterCIDRs {
-			if _, _, err := net.ParseCIDR(cidr); err != nil {
-				return fmt.Errorf("proxy.clusterCIDRs entry %q is not a valid CIDR: %w", cidr, err)
-			}
+	// Syntactic validation only — overlapping ranges and IPv4/IPv6 mixing are
+	// accepted (iptables handles both, and the init script splits v4/v6 itself);
+	// we only reject malformed strings here.
+	for _, cidr := range c.Proxy.ClusterCIDRs {
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			return fmt.Errorf("proxy.clusterCIDRs entry %q is not a valid CIDR: %w", cidr, err)
 		}
 	}
 	if c.Images.EnvoyProxy == "" {

--- a/kagenti-operator/internal/webhook/config/types_test.go
+++ b/kagenti-operator/internal/webhook/config/types_test.go
@@ -2,15 +2,11 @@ package config
 
 import "testing"
 
-// When egressEnforcement is "enforce", ClusterCIDRs must be present and valid —
-// an empty list (silent 10/8 fallback in the init script) or a malformed entry
+// ClusterCIDRs drive the only in-cluster allowance in the always-on
+// enforce-redirect guard, so they must always be present and valid — an empty
+// list (silent 10/8 fallback in the init script) or a malformed entry
 // (init-container CrashLoop under set -e) must be rejected at config load.
-func TestValidate_ClusterCIDRs_EnforceMode(t *testing.T) {
-	base := func() *PlatformConfig {
-		c := CompiledDefaults()
-		c.Proxy.EgressEnforcement = EgressEnforcementEnforce
-		return c
-	}
+func TestValidate_ClusterCIDRs(t *testing.T) {
 	tests := []struct {
 		name    string
 		mutate  func(*PlatformConfig)
@@ -27,7 +23,7 @@ func TestValidate_ClusterCIDRs_EnforceMode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := base()
+			c := CompiledDefaults()
 			tt.mutate(c)
 			err := c.Validate()
 			if tt.wantErr && err == nil {
@@ -40,12 +36,30 @@ func TestValidate_ClusterCIDRs_EnforceMode(t *testing.T) {
 	}
 }
 
-// When enforcement is off, ClusterCIDRs is unused and must not be validated.
-func TestValidate_ClusterCIDRs_OffMode_NotValidated(t *testing.T) {
-	c := CompiledDefaults()
-	c.Proxy.EgressEnforcement = EgressEnforcementOff
-	c.Proxy.ClusterCIDRs = []string{"garbage"}
-	if err := c.Validate(); err != nil {
-		t.Errorf("off mode must not validate ClusterCIDRs, got: %v", err)
+// TransparentPort is the REDIRECT target for the enforce-redirect guard; it must
+// be a valid, non-privileged port (the proxy binds it as a non-root user).
+func TestValidate_TransparentPort(t *testing.T) {
+	tests := []struct {
+		name    string
+		port    int32
+		wantErr bool
+	}{
+		{"default 8082 ok", 8082, false},
+		{"zero rejected", 0, true},
+		{"privileged rejected", 80, true},
+		{"too large rejected", 70000, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := CompiledDefaults()
+			c.Proxy.TransparentPort = tt.port
+			err := c.Validate()
+			if tt.wantErr && err == nil {
+				t.Errorf("expected validation error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected validation error: %v", err)
+			}
+		})
 	}
 }

--- a/kagenti-operator/internal/webhook/injector/constants.go
+++ b/kagenti-operator/internal/webhook/injector/constants.go
@@ -55,11 +55,6 @@ const (
 	// transparent listener (captured, not dropped) and DROPs non-TCP external
 	// egress. Always-on for proxy-sidecar / lite.
 	ProxyInitModeEnforceRedirect ProxyInitMode = "enforce-redirect"
-	// ProxyInitModeEnforceDrop installs the fail-closed egress guard that DROPs
-	// any egress bypassing the forward proxy. Predates enforce-redirect; the
-	// init image retains it as a no-transparent-listener fallback, but the
-	// operator no longer emits it.
-	ProxyInitModeEnforceDrop ProxyInitMode = "enforce-drop"
 )
 
 // mTLS modes for the proxy-sidecar / lite paths. Selected per workload

--- a/kagenti-operator/internal/webhook/injector/constants.go
+++ b/kagenti-operator/internal/webhook/injector/constants.go
@@ -50,8 +50,15 @@ const (
 	// ProxyInitModeRedirect transparently REDIRECTs pod traffic to the Envoy
 	// listeners (envoy-sidecar mode).
 	ProxyInitModeRedirect ProxyInitMode = "redirect"
+	// ProxyInitModeEnforceRedirect installs the fail-closed egress guard that
+	// REDIRECTs external TCP bypassing the forward proxy to AuthBridge's
+	// transparent listener (captured, not dropped) and DROPs non-TCP external
+	// egress. Always-on for proxy-sidecar / lite.
+	ProxyInitModeEnforceRedirect ProxyInitMode = "enforce-redirect"
 	// ProxyInitModeEnforceDrop installs the fail-closed egress guard that DROPs
-	// any egress bypassing the forward proxy (proxy-sidecar egress enforcement).
+	// any egress bypassing the forward proxy. Predates enforce-redirect; the
+	// init image retains it as a no-transparent-listener fallback, but the
+	// operator no longer emits it.
 	ProxyInitModeEnforceDrop ProxyInitMode = "enforce-drop"
 )
 

--- a/kagenti-operator/internal/webhook/injector/container_builder.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder.go
@@ -300,7 +300,7 @@ func (b *ContainerBuilder) BuildProxySidecarContainerWithPorts(spireEnabled bool
 		Resources: b.cfg.Resources.AuthBridge,
 		SecurityContext: &corev1.SecurityContext{
 			// Run as the dedicated proxy UID (default 1337), the SAME value the
-			// proxy-init enforce-drop guard exempts via `--uid-owner $PROXY_UID`.
+			// proxy-init enforce-redirect guard exempts via `--uid-owner $PROXY_UID`.
 			// Deriving both from b.cfg.Proxy.UID keeps the exempted UID in lockstep
 			// with the process it exempts (a hardcoded literal could drift and
 			// silently break the proxy's own egress). Matches the envoy builder.
@@ -463,9 +463,6 @@ const mandatoryOutboundExclude = "8080"
 //     REDIRECTs external TCP bypassing the forward proxy to the transparent
 //     listener (TRANSPARENT_PORT) and DROPs non-TCP. Driven by PROXY_UID +
 //     CLUSTER_CIDRS + TRANSPARENT_PORT; the exclude args do not apply.
-//   - "enforce-drop" (proxy-sidecar): a fail-closed egress guard that DROPs any
-//     egress bypassing the forward proxy. Driven by PROXY_UID + CLUSTER_CIDRS;
-//     the exclude args do not apply (the script ignores them in this mode).
 func (b *ContainerBuilder) BuildProxyInitContainer(mode ProxyInitMode, outboundPortsExclude, inboundPortsExclude string) corev1.Container {
 	var env []corev1.EnvVar
 	switch mode {
@@ -486,21 +483,6 @@ func (b *ContainerBuilder) BuildProxyInitContainer(mode ProxyInitMode, outboundP
 			"mode", "enforce-redirect",
 			"proxyUID", b.cfg.Proxy.UID,
 			"transparentPort", b.cfg.Proxy.TransparentPort,
-			"clusterCIDRs", clusterCIDRs)
-	case ProxyInitModeEnforceDrop:
-		// PROXY_UID is exempted from the DROP and MUST match the proxy
-		// container's RunAsUser (both derive from b.cfg.Proxy.UID). CLUSTER_CIDRS
-		// are allowed direct; everything else egressing the pod is dropped.
-		// POD_IP and the redirect-only exclude vars are unused in this mode.
-		clusterCIDRs := strings.Join(b.cfg.Proxy.ClusterCIDRs, ",")
-		env = []corev1.EnvVar{
-			{Name: "MODE", Value: string(ProxyInitModeEnforceDrop)},
-			{Name: "PROXY_UID", Value: fmt.Sprintf("%d", b.cfg.Proxy.UID)},
-			{Name: "CLUSTER_CIDRS", Value: clusterCIDRs},
-		}
-		builderLog.Info("building ProxyInit Container",
-			"mode", "enforce-drop",
-			"proxyUID", b.cfg.Proxy.UID,
 			"clusterCIDRs", clusterCIDRs)
 	case ProxyInitModeRedirect:
 		outboundValue := buildOutboundExcludeValue(outboundPortsExclude)

--- a/kagenti-operator/internal/webhook/injector/container_builder.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder.go
@@ -459,12 +459,34 @@ const mandatoryOutboundExclude = "8080"
 //     Envoy listeners. outboundPortsExclude / inboundPortsExclude (from the
 //     kagenti.io/outbound-ports-exclude and kagenti.io/inbound-ports-exclude
 //     pod annotations; mandatory 8080 always included outbound) tune it.
+//   - "enforce-redirect" (proxy-sidecar): a fail-closed egress guard that
+//     REDIRECTs external TCP bypassing the forward proxy to the transparent
+//     listener (TRANSPARENT_PORT) and DROPs non-TCP. Driven by PROXY_UID +
+//     CLUSTER_CIDRS + TRANSPARENT_PORT; the exclude args do not apply.
 //   - "enforce-drop" (proxy-sidecar): a fail-closed egress guard that DROPs any
 //     egress bypassing the forward proxy. Driven by PROXY_UID + CLUSTER_CIDRS;
 //     the exclude args do not apply (the script ignores them in this mode).
 func (b *ContainerBuilder) BuildProxyInitContainer(mode ProxyInitMode, outboundPortsExclude, inboundPortsExclude string) corev1.Container {
 	var env []corev1.EnvVar
 	switch mode {
+	case ProxyInitModeEnforceRedirect:
+		// PROXY_UID is exempted (its egress is not redirected) and MUST match the
+		// proxy container's RunAsUser (both derive from b.cfg.Proxy.UID).
+		// CLUSTER_CIDRS are allowed direct; external TCP is REDIRECTed to
+		// TRANSPARENT_PORT (the proxy's transparent listener), external non-TCP is
+		// dropped. The redirect-only exclude vars are unused in this mode.
+		clusterCIDRs := strings.Join(b.cfg.Proxy.ClusterCIDRs, ",")
+		env = []corev1.EnvVar{
+			{Name: "MODE", Value: string(ProxyInitModeEnforceRedirect)},
+			{Name: "PROXY_UID", Value: fmt.Sprintf("%d", b.cfg.Proxy.UID)},
+			{Name: "CLUSTER_CIDRS", Value: clusterCIDRs},
+			{Name: "TRANSPARENT_PORT", Value: fmt.Sprintf("%d", b.cfg.Proxy.TransparentPort)},
+		}
+		builderLog.Info("building ProxyInit Container",
+			"mode", "enforce-redirect",
+			"proxyUID", b.cfg.Proxy.UID,
+			"transparentPort", b.cfg.Proxy.TransparentPort,
+			"clusterCIDRs", clusterCIDRs)
 	case ProxyInitModeEnforceDrop:
 		// PROXY_UID is exempted from the DROP and MUST match the proxy
 		// container's RunAsUser (both derive from b.cfg.Proxy.UID). CLUSTER_CIDRS

--- a/kagenti-operator/internal/webhook/injector/container_builder_test.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder_test.go
@@ -285,8 +285,8 @@ func TestBuildProxyInitContainer_WithBothExcludes(t *testing.T) {
 }
 
 // The proxy-sidecar container must run as the configured Proxy.UID — the same
-// value the enforce-drop guard exempts via --uid-owner. If these drift, the
-// proxy's own egress would be dropped (or the agent would share the exempt UID).
+// value the enforce-redirect guard exempts via --uid-owner. If these drift, the
+// proxy's own egress would be redirected back (or the agent would share the exempt UID).
 func TestBuildProxySidecarContainer_RunAsProxyUID(t *testing.T) {
 	cfg := config.CompiledDefaults()
 	builder := NewContainerBuilder(cfg)
@@ -301,37 +301,6 @@ func TestBuildProxySidecarContainer_RunAsProxyUID(t *testing.T) {
 	}
 	if sc.RunAsGroup == nil || *sc.RunAsGroup != cfg.Proxy.UID {
 		t.Errorf("proxy-sidecar RunAsGroup = %v, want Proxy.UID %d", sc.RunAsGroup, cfg.Proxy.UID)
-	}
-}
-
-// enforce-drop mode emits MODE / PROXY_UID / CLUSTER_CIDRS and none of the
-// redirect-only vars (POD_IP, OUTBOUND_PORTS_EXCLUDE).
-func TestBuildProxyInitContainer_EnforceDrop(t *testing.T) {
-	cfg := config.CompiledDefaults()
-	builder := NewContainerBuilder(cfg)
-	container := builder.BuildProxyInitContainer("enforce-drop", "", "")
-
-	got := map[string]string{}
-	for _, e := range container.Env {
-		if e.ValueFrom != nil {
-			t.Errorf("enforce-drop env %q must be a literal, not ValueFrom", e.Name)
-		}
-		got[e.Name] = e.Value
-	}
-	if got["MODE"] != "enforce-drop" {
-		t.Errorf("MODE = %q, want enforce-drop", got["MODE"])
-	}
-	if want := strconv.FormatInt(cfg.Proxy.UID, 10); got["PROXY_UID"] != want {
-		t.Errorf("PROXY_UID = %q, want %q", got["PROXY_UID"], want)
-	}
-	if want := strings.Join(cfg.Proxy.ClusterCIDRs, ","); got["CLUSTER_CIDRS"] != want {
-		t.Errorf("CLUSTER_CIDRS = %q, want %q", got["CLUSTER_CIDRS"], want)
-	}
-	if _, ok := got["POD_IP"]; ok {
-		t.Error("enforce-drop must not set POD_IP")
-	}
-	if _, ok := got["OUTBOUND_PORTS_EXCLUDE"]; ok {
-		t.Error("enforce-drop must not set OUTBOUND_PORTS_EXCLUDE")
 	}
 }
 

--- a/kagenti-operator/internal/webhook/injector/container_builder_test.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder_test.go
@@ -335,6 +335,40 @@ func TestBuildProxyInitContainer_EnforceDrop(t *testing.T) {
 	}
 }
 
+// enforce-redirect mode emits MODE / PROXY_UID / CLUSTER_CIDRS / TRANSPARENT_PORT
+// and none of the redirect-only vars (POD_IP, OUTBOUND_PORTS_EXCLUDE).
+func TestBuildProxyInitContainer_EnforceRedirect(t *testing.T) {
+	cfg := config.CompiledDefaults()
+	builder := NewContainerBuilder(cfg)
+	container := builder.BuildProxyInitContainer("enforce-redirect", "", "")
+
+	got := map[string]string{}
+	for _, e := range container.Env {
+		if e.ValueFrom != nil {
+			t.Errorf("enforce-redirect env %q must be a literal, not ValueFrom", e.Name)
+		}
+		got[e.Name] = e.Value
+	}
+	if got["MODE"] != "enforce-redirect" {
+		t.Errorf("MODE = %q, want enforce-redirect", got["MODE"])
+	}
+	if want := strconv.FormatInt(cfg.Proxy.UID, 10); got["PROXY_UID"] != want {
+		t.Errorf("PROXY_UID = %q, want %q", got["PROXY_UID"], want)
+	}
+	if want := strings.Join(cfg.Proxy.ClusterCIDRs, ","); got["CLUSTER_CIDRS"] != want {
+		t.Errorf("CLUSTER_CIDRS = %q, want %q", got["CLUSTER_CIDRS"], want)
+	}
+	if want := strconv.FormatInt(int64(cfg.Proxy.TransparentPort), 10); got["TRANSPARENT_PORT"] != want {
+		t.Errorf("TRANSPARENT_PORT = %q, want %q", got["TRANSPARENT_PORT"], want)
+	}
+	if _, ok := got["POD_IP"]; ok {
+		t.Error("enforce-redirect must not set POD_IP")
+	}
+	if _, ok := got["OUTBOUND_PORTS_EXCLUDE"]; ok {
+		t.Error("enforce-redirect must not set OUTBOUND_PORTS_EXCLUDE")
+	}
+}
+
 // An unknown mode must fail closed: BuildProxyInitContainer returns a
 // zero-value container (no name/image/env) rather than silently degrading to
 // redirect, which would ship a proxy-init with no egress guard (fail-open).

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -525,18 +525,18 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 			injectHTTPProxyEnv(c, forwardProxyPort)
 		}
 
-		// Fail-closed egress enforcement (opt-in via proxy.egressEnforcement,
-		// default "off"). HTTP_PROXY above is cooperative — an app that ignores
-		// it egresses directly. When enforcement is on, inject the proxy-init
-		// enforce-drop guard so any direct egress is dropped. envoy-sidecar
-		// already enforces structurally via transparent redirect, so this is the
+		// Fail-closed egress enforcement (always-on for proxy-sidecar / lite).
+		// HTTP_PROXY above is cooperative — an app that ignores it egresses
+		// directly. The enforce-redirect proxy-init guard transparently REDIRECTs
+		// any bypass egress to the forward proxy's transparent listener, so it is
+		// captured rather than dropped and nothing breaks. envoy-sidecar enforces
+		// structurally via its own transparent redirect, so this is the
 		// proxy-sidecar / lite path only. The exempted PROXY_UID equals the proxy
 		// container's RunAsUser (both b.cfg.Proxy.UID).
-		if currentConfig.Proxy.EgressEnforcement == config.EgressEnforcementEnforce &&
-			!containerExists(podSpec.InitContainers, ProxyInitContainerName) {
+		if !containerExists(podSpec.InitContainers, ProxyInitContainerName) {
 			podSpec.InitContainers = append(podSpec.InitContainers,
-				builder.BuildProxyInitContainer(ProxyInitModeEnforceDrop, "", ""))
-			mutatorLog.Info("proxy-sidecar egress enforcement enabled (enforce-drop)",
+				builder.BuildProxyInitContainer(ProxyInitModeEnforceRedirect, "", ""))
+			mutatorLog.Info("proxy-sidecar egress enforcement enabled (enforce-redirect)",
 				"namespace", namespace, "crName", crName)
 		}
 

--- a/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
@@ -167,16 +167,16 @@ func TestInjectAuthBridge_NoAgentRuntime_InjectsWithDefaults(t *testing.T) {
 		t.Fatal("expected InjectAuthBridge to return true with defaults-only config")
 	}
 
-	// Default mode is proxy-sidecar — expect authbridge-proxy container,
-	// no envoy-proxy / proxy-init / standalone spiffe-helper.
+	// Default mode is proxy-sidecar — expect authbridge-proxy container and the
+	// always-on enforce-redirect proxy-init guard; no envoy-proxy.
 	if !containerExists(podSpec.Containers, AuthBridgeProxyContainerName) {
 		t.Errorf("expected %s container to be injected", AuthBridgeProxyContainerName)
 	}
 	if containerExists(podSpec.Containers, EnvoyProxyContainerName) {
 		t.Errorf("unexpected %s container in proxy-sidecar mode", EnvoyProxyContainerName)
 	}
-	if containerExists(podSpec.InitContainers, ProxyInitContainerName) {
-		t.Errorf("unexpected %s init container in proxy-sidecar mode", ProxyInitContainerName)
+	if !containerExists(podSpec.InitContainers, ProxyInitContainerName) {
+		t.Errorf("expected %s init container in proxy-sidecar mode (always-on enforce-redirect)", ProxyInitContainerName)
 	}
 }
 
@@ -781,9 +781,9 @@ func TestInjectAuthBridge_WaypointMode_SkipsInjection(t *testing.T) {
 	}
 }
 
-// Egress enforcement for proxy-sidecar is gated by proxy.egressEnforcement
-// (default "off"). When "enforce", a proxy-init container is injected in
-// enforce-drop mode; envoy-sidecar is unaffected (tested elsewhere).
+// Egress enforcement is always-on for proxy-sidecar: a proxy-init container is
+// always injected in enforce-redirect mode; envoy-sidecar is unaffected (it
+// uses redirect mode, tested elsewhere).
 func TestInjectAuthBridge_ProxySidecar_EgressEnforcement(t *testing.T) {
 	ctx := context.Background()
 	labels := map[string]string{KagentiTypeLabel: KagentiTypeAgent}
@@ -802,48 +802,35 @@ func TestInjectAuthBridge_ProxySidecar_EgressEnforcement(t *testing.T) {
 		return nil
 	}
 
-	t.Run("enforce injects proxy-init in enforce-drop mode", func(t *testing.T) {
+	t.Run("always injects proxy-init in enforce-redirect mode", func(t *testing.T) {
 		m := newTestMutator(newAgentRuntimeWithMode("team1", "my-agent", ModeProxySidecar))
-		cfg := config.CompiledDefaults()
-		cfg.Proxy.EgressEnforcement = "enforce"
-		m.GetPlatformConfig = func() *config.PlatformConfig { return cfg }
-
 		spec := makePod()
 		if _, err := m.InjectAuthBridge(ctx, spec, "team1", "my-agent", labels, nil); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		ic := findProxyInit(spec)
 		if ic == nil {
-			t.Fatal("proxy-init should be injected when egressEnforcement=enforce")
+			t.Fatal("proxy-init should always be injected for proxy-sidecar")
 		}
-		var mode string
+		var mode, transparentPort string
 		for _, e := range ic.Env {
-			if e.Name == "MODE" {
+			switch e.Name {
+			case "MODE":
 				mode = e.Value
+			case "TRANSPARENT_PORT":
+				transparentPort = e.Value
 			}
 		}
-		if mode != "enforce-drop" {
-			t.Errorf("proxy-init MODE = %q, want enforce-drop", mode)
+		if mode != "enforce-redirect" {
+			t.Errorf("proxy-init MODE = %q, want enforce-redirect", mode)
 		}
-	})
-
-	t.Run("default off does not inject proxy-init", func(t *testing.T) {
-		m := newTestMutator(newAgentRuntimeWithMode("team1", "my-agent", ModeProxySidecar))
-		spec := makePod()
-		if _, err := m.InjectAuthBridge(ctx, spec, "team1", "my-agent", labels, nil); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if findProxyInit(spec) != nil {
-			t.Error("proxy-init must not be injected when egressEnforcement is off (default)")
+		if transparentPort == "" {
+			t.Error("enforce-redirect must set TRANSPARENT_PORT")
 		}
 	})
 
 	t.Run("does not duplicate an existing proxy-init", func(t *testing.T) {
 		m := newTestMutator(newAgentRuntimeWithMode("team1", "my-agent", ModeProxySidecar))
-		cfg := config.CompiledDefaults()
-		cfg.Proxy.EgressEnforcement = "enforce"
-		m.GetPlatformConfig = func() *config.PlatformConfig { return cfg }
-
 		spec := makePod()
 		spec.InitContainers = []corev1.Container{{Name: ProxyInitContainerName, Image: "preexisting"}}
 		if _, err := m.InjectAuthBridge(ctx, spec, "team1", "my-agent", labels, nil); err != nil {
@@ -897,11 +884,15 @@ func TestInjectAuthBridge_ProxySidecarMode_InjectsCorrectly(t *testing.T) {
 		t.Error("authbridge-proxy container not found")
 	}
 
-	// Should NOT have proxy-init (no iptables in proxy-sidecar mode)
+	// Should have the always-on enforce-redirect proxy-init guard.
+	proxyInitFound := false
 	for _, c := range podSpec.InitContainers {
 		if c.Name == ProxyInitContainerName {
-			t.Error("proxy-init should not be injected in proxy-sidecar mode")
+			proxyInitFound = true
 		}
+	}
+	if !proxyInitFound {
+		t.Error("proxy-init (enforce-redirect) should be injected in proxy-sidecar mode")
 	}
 
 	// Should NOT have envoy-proxy container

--- a/kagenti-operator/internal/webhook/v1alpha1/authbridge_webhook_test.go
+++ b/kagenti-operator/internal/webhook/v1alpha1/authbridge_webhook_test.go
@@ -188,11 +188,11 @@ var _ = Describe("AuthBridge Pod Webhook", func() {
 			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Default mode is proxy-sidecar — expect authbridge-proxy, no
-			// envoy-proxy or proxy-init.
+			// Default mode is proxy-sidecar — expect authbridge-proxy and the
+			// always-on enforce-redirect proxy-init guard; no envoy-proxy.
 			Expect(containerNames(pod.Spec.Containers)).To(ContainElement(injector.AuthBridgeProxyContainerName))
 			Expect(containerNames(pod.Spec.Containers)).NotTo(ContainElement(injector.EnvoyProxyContainerName))
-			Expect(initContainerNames(pod.Spec.InitContainers)).NotTo(ContainElement(injector.ProxyInitContainerName))
+			Expect(initContainerNames(pod.Spec.InitContainers)).To(ContainElement(injector.ProxyInitContainerName))
 		})
 	})
 


### PR DESCRIPTION
## Summary

Makes proxy-sidecar egress enforcement **always-on** and **removes the `proxy.egressEnforcement` flag**.

PR #406 gated enforcement behind `egressEnforcement` (default `off`) because the only enforcement available was fail-closed **DROP**, which breaks agents that ignore `HTTP_PROXY`. [kagenti-extensions#485](https://github.com/kagenti/kagenti-extensions/pull/485) adds the missing half — a transparent listener + `MODE=enforce-redirect` that **captures** bypass egress (REDIRECT to the transparent listener, recovering the original destination via `SO_ORIGINAL_DST`) instead of dropping it. Because nothing breaks, enforcement can be on by default with no knob.

## Changes
- **constants**: add `ProxyInitModeEnforceRedirect`; keep `ProxyInitModeEnforceDrop` as a documented fallback the operator no longer emits.
- **container_builder**: enforce-redirect branch emits `MODE` / `PROXY_UID` / `CLUSTER_CIDRS` / `TRANSPARENT_PORT` (new `ProxyConfig.TransparentPort`, default `8082`, matching the authbridge `listener.transparent_proxy_addr` preset).
- **pod_mutator**: the proxy-sidecar / lite branch now **always** injects the enforce-redirect proxy-init (no flag check); envoy-sidecar still uses `redirect`. Idempotent via the existing `containerExists` guard.
- **config**: **remove** `ProxyConfig.EgressEnforcement` (+ its constants, validation, and the Helm value). `ClusterCIDRs` is now validated **unconditionally** (always consumed by the always-on guard); `TransparentPort` gets a port-range check.
- **Helm values**: replace `egressEnforcement` with `transparentPort`; update comments. Rendered platform-defaults ConfigMap verified.

## Tests
- builder emits enforce-redirect env incl. `TRANSPARENT_PORT`;
- proxy-sidecar **always** injects proxy-init (enforce-redirect), idempotent; default-off subtest removed;
- `ClusterCIDRs` always validated; new `TransparentPort` validation test;
- webhook envtest now expects proxy-init in proxy-sidecar defaults.

`go build` / `go vet` / `gofmt` / full `go test ./internal/webhook/...` green. The one `golangci-lint` finding (`pod_mutator.go:187` goconst) is pre-existing and unrelated.

## ⚠️ Do not merge until images ship
Depends on kagenti-extensions#485 being released in the `proxy-init` **and** `authbridge`/`authbridge-lite` images (the init script's `enforce-redirect` mode + the proxy's transparent listener). The install chart owns image versions; this PR does not pin them.

## Preconditions for the always-on guarantee (documented, not enforced here)
- **UID separation** — agents must not run as `Proxy.UID` (1337) nor hold `CAP_SETUID`, else they bypass the `--uid-owner` exemption. Confirm via PSA `restricted`/SCC or an admission check.
- **Name-vs-IP policy** — captured traffic gates on the recovered SNI/Host name (extensions#485), which an agent controls independently of the IP it dials; reliable against a cooperative/misconfigured agent, not a hostile one. Hard enforcement would need IP-set allowlists or SNI/cert cross-checks.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
