### PR TITLE
fix(chart): grant cert-manager certificates RBAC to the operator ClusterRole

### DIFF
--- a/charts/kagenti-operator/templates/rbac/role.yaml
+++ b/charts/kagenti-operator/templates/rbac/role.yaml
@@ -63,6 +63,15 @@ rules:
   - get
   - update
 - apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  - clusterissuers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - agent.kagenti.dev
   resources:
   - agentcards


### PR DESCRIPTION
## Problem

On a fresh chart install, the operator (`kagenti-controller-manager`) **crashloops** and never becomes Ready, which silently breaks agent onboarding: agent pods hang in `Init` with

```
MountVolume.SetUp failed for volume "kagenti-keycloak-client-credentials-<hash>": secret not found
```

## Root cause

The Helm chart's **hand-maintained** ClusterRole (`charts/kagenti-operator/templates/rbac/role.yaml`) drifted from the kubebuilder-generated `config/rbac/role.yaml`: it is **missing the `cert-manager.io` `certificates`/`clusterissuers` `get;list;watch` rules**.

[#383](https://github.com/kagenti/kagenti-operator/pull/383) (SharedTrust controller) added `Watches(&cmv1.Certificate{})` plus the `+kubebuilder:rbac:groups=cert-manager.io,resources=certificates` marker and regenerated `config/rbac/role.yaml` — but did **not** update the chart's separate ClusterRole. Since installs render RBAC from the chart, the deployed ServiceAccount `kagenti-system:controller-manager` cannot list/watch cert-manager `Certificates`:

```
failed to list *v1.Certificate: certificates.cert-manager.io is forbidden:
User "system:serviceaccount:kagenti-system:controller-manager" cannot list resource "certificates" ...
```

That informer never syncs → the manager misses its cache-sync deadline and **exits 1 (~2.5 min crashloop)** → **no controllers run**, including `ClientRegistrationReconciler`. So agents are never registered in Keycloak, their per-agent client-credentials secrets are never created, and the webhook-mounted secret volume never resolves → permanent `FailedMount`.

Reproduced on `weather-agent` (team1) on a fresh install of `main`; matches a user report (#383-era). Confirmed the fix on a live cluster: granting these rules + restarting the operator → Ready → reconciler creates the secret → agent reaches `2/2 Running`.

## Fix

Add the `cert-manager.io` `certificates`/`clusterissuers` `get;list;watch` rules to the chart ClusterRole to match the generated `config/rbac/role.yaml`. `helm lint` + `helm template` verified.

## Follow-up (separate)

The chart ClusterRole is maintained **independently** of `config/rbac/role.yaml` with no sync step, so any future `+kubebuilder:rbac` marker can silently drift again (this is the second controller bitten — see also the MLflow/OTEL RBAC edits in #404/#378 that hand-patch the same file). Worth generating the chart role from the kubebuilder role, or adding a CI check that fails on drift.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
