### PR TITLE
Fix: add TLS connectivity probe to webhook readiness checks

### DIFF
--- a/kagenti-operator/cmd/main.go
+++ b/kagenti-operator/cmd/main.go
@@ -688,6 +688,10 @@ func main() {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
+	if err := mgr.AddReadyzCheck("webhook", webhookServer.StartedChecker()); err != nil {
+		setupLog.Error(err, "unable to set up webhook ready check")
+		os.Exit(1)
+	}
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctx); err != nil {

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -344,10 +344,10 @@ var _ = Describe("AuthBridge Injection E2E", Ordered, func() {
 			g.Expect(output).NotTo(BeEmpty(), "webhook endpoint not yet populated")
 		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
-		By("waiting for webhook TLS to accept connections")
+		By("waiting for controller pod to be fully Ready")
 		Eventually(func() error {
-			return utils.ProbeWebhookTLS(controllerNamespace)
-		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+			return utils.ProbeWebhookReady(controllerNamespace)
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
 		By("creating auth bridge test namespace")
 		cmd := exec.Command("kubectl", "create", "ns", authBridgeTestNamespace)
@@ -701,10 +701,10 @@ var _ = Describe("AgentCard E2E", Ordered, func() {
 			g.Expect(output).NotTo(BeEmpty(), "webhook endpoint not yet populated")
 		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
-		By("waiting for webhook TLS to accept connections")
+		By("waiting for controller pod to be fully Ready")
 		Eventually(func() error {
-			return utils.ProbeWebhookTLS(controllerNamespace)
-		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+			return utils.ProbeWebhookReady(controllerNamespace)
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
 		By("creating test namespace with labels")
 		cmd := exec.Command("kubectl", "create", "ns", testNamespace)
@@ -1049,10 +1049,10 @@ rules:
 			g.Expect(output).NotTo(BeEmpty(), "webhook endpoint not yet populated")
 		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
-		By("waiting for webhook TLS to accept connections")
+		By("waiting for controller pod to be fully Ready")
 		Eventually(func() error {
-			return utils.ProbeWebhookTLS(controllerNamespace)
-		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+			return utils.ProbeWebhookReady(controllerNamespace)
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
 		By("creating test namespace")
 		cmd := exec.Command("kubectl", "create", "ns", agentRuntimeTestNamespace)
@@ -1528,10 +1528,10 @@ rules:
 			g.Expect(output).NotTo(BeEmpty(), "webhook endpoint not yet populated")
 		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
-		By("waiting for webhook TLS to accept connections")
+		By("waiting for controller pod to be fully Ready")
 		Eventually(func() error {
-			return utils.ProbeWebhookTLS(controllerNamespace)
-		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+			return utils.ProbeWebhookReady(controllerNamespace)
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
 		By("setting KAGENTI_SPIRE_TRUST_DOMAIN env var")
 		envCmd := exec.Command("kubectl", "set", "env", "deployment/"+controllerDeployment,
@@ -1994,10 +1994,10 @@ rules:
 			g.Expect(output).NotTo(BeEmpty(), "webhook endpoint not yet populated")
 		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
-		By("waiting for webhook TLS to accept connections")
+		By("waiting for controller pod to be fully Ready")
 		Eventually(func() error {
-			return utils.ProbeWebhookTLS(controllerNamespace)
-		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+			return utils.ProbeWebhookReady(controllerNamespace)
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
 		By("creating skill discovery test namespace")
 		cmd := exec.Command("kubectl", "create", "ns", skillDiscoveryTestNamespace)
@@ -2160,10 +2160,10 @@ rules:
 				g.Expect(output).NotTo(BeEmpty(), "webhook endpoint not yet populated")
 			}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
-			By("waiting for webhook TLS to accept connections after restart")
+			By("waiting for controller pod to be fully Ready after restart")
 			Eventually(func() error {
-				return utils.ProbeWebhookTLS(controllerNamespace)
-			}, 2*time.Minute, 5*time.Second).Should(Succeed())
+				return utils.ProbeWebhookReady(controllerNamespace)
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
 		})
 
 		It("should populate linkedSkills from annotation", func() {
@@ -2468,10 +2468,10 @@ var _ = Describe("Istio Mesh Enrollment E2E", Ordered, func() {
 			g.Expect(output).NotTo(BeEmpty(), "webhook endpoint not yet populated")
 		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
-		By("waiting for webhook TLS to accept connections")
+		By("waiting for controller pod to be fully Ready")
 		Eventually(func() error {
-			return utils.ProbeWebhookTLS(controllerNamespace)
-		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+			return utils.ProbeWebhookReady(controllerNamespace)
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
 		By("creating test namespace")
 		cmd := exec.Command("kubectl", "create", "ns", istioMeshTestNamespace)

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -344,6 +344,11 @@ var _ = Describe("AuthBridge Injection E2E", Ordered, func() {
 			g.Expect(output).NotTo(BeEmpty(), "webhook endpoint not yet populated")
 		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
+		By("waiting for webhook TLS to accept connections")
+		Eventually(func() error {
+			return utils.ProbeWebhookTLS(controllerNamespace)
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
 		By("creating auth bridge test namespace")
 		cmd := exec.Command("kubectl", "create", "ns", authBridgeTestNamespace)
 		_, err := utils.Run(cmd)
@@ -696,6 +701,11 @@ var _ = Describe("AgentCard E2E", Ordered, func() {
 			g.Expect(output).NotTo(BeEmpty(), "webhook endpoint not yet populated")
 		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
+		By("waiting for webhook TLS to accept connections")
+		Eventually(func() error {
+			return utils.ProbeWebhookTLS(controllerNamespace)
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
 		By("creating test namespace with labels")
 		cmd := exec.Command("kubectl", "create", "ns", testNamespace)
 		_, err := utils.Run(cmd)
@@ -1038,6 +1048,11 @@ rules:
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(output).NotTo(BeEmpty(), "webhook endpoint not yet populated")
 		}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+		By("waiting for webhook TLS to accept connections")
+		Eventually(func() error {
+			return utils.ProbeWebhookTLS(controllerNamespace)
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
 
 		By("creating test namespace")
 		cmd := exec.Command("kubectl", "create", "ns", agentRuntimeTestNamespace)
@@ -1513,6 +1528,11 @@ rules:
 			g.Expect(output).NotTo(BeEmpty(), "webhook endpoint not yet populated")
 		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
+		By("waiting for webhook TLS to accept connections")
+		Eventually(func() error {
+			return utils.ProbeWebhookTLS(controllerNamespace)
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
 		By("setting KAGENTI_SPIRE_TRUST_DOMAIN env var")
 		envCmd := exec.Command("kubectl", "set", "env", "deployment/"+controllerDeployment,
 			"-n", controllerNamespace, "KAGENTI_SPIRE_TRUST_DOMAIN=example.org")
@@ -1974,6 +1994,11 @@ rules:
 			g.Expect(output).NotTo(BeEmpty(), "webhook endpoint not yet populated")
 		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
+		By("waiting for webhook TLS to accept connections")
+		Eventually(func() error {
+			return utils.ProbeWebhookTLS(controllerNamespace)
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
 		By("creating skill discovery test namespace")
 		cmd := exec.Command("kubectl", "create", "ns", skillDiscoveryTestNamespace)
 		_, err := utils.Run(cmd)
@@ -2134,6 +2159,11 @@ rules:
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(output).NotTo(BeEmpty(), "webhook endpoint not yet populated")
 			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("waiting for webhook TLS to accept connections after restart")
+			Eventually(func() error {
+				return utils.ProbeWebhookTLS(controllerNamespace)
+			}, 2*time.Minute, 5*time.Second).Should(Succeed())
 		})
 
 		It("should populate linkedSkills from annotation", func() {
@@ -2437,6 +2467,11 @@ var _ = Describe("Istio Mesh Enrollment E2E", Ordered, func() {
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(output).NotTo(BeEmpty(), "webhook endpoint not yet populated")
 		}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+		By("waiting for webhook TLS to accept connections")
+		Eventually(func() error {
+			return utils.ProbeWebhookTLS(controllerNamespace)
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
 
 		By("creating test namespace")
 		cmd := exec.Command("kubectl", "create", "ns", istioMeshTestNamespace)

--- a/kagenti-operator/test/utils/utils.go
+++ b/kagenti-operator/test/utils/utils.go
@@ -752,21 +752,21 @@ func UncommentCode(filename, target, prefix string) error {
 	return os.WriteFile(filename, out.Bytes(), 0644)
 }
 
-// ProbeWebhookTLS runs a temporary curl pod that attempts a TLS connection to the
-// webhook service. Returns nil if the webhook is accepting TLS connections, or an
-// error if it is not yet ready. Intended for use inside an Eventually() block.
+// ProbeWebhookTLS runs a temporary curl pod that verifies the webhook service
+// TLS handshake succeeds. Uses --connect-only to avoid waiting for an HTTP
+// response (the webhook only handles admission POST requests). Returns nil if
+// the TLS connection succeeds, or an error if not yet ready.
 func ProbeWebhookTLS(namespace string) error {
 	podName := fmt.Sprintf("webhook-probe-%d", time.Now().UnixNano()%100000)
-	svcURL := fmt.Sprintf("https://kagenti-operator-webhook-service.%s.svc:443/", namespace)
+	svcURL := fmt.Sprintf("https://kagenti-operator-webhook-service.%s.svc:443", namespace)
 
-	// Security context required for clusters with "restricted" PodSecurity enforcement.
 	overrides := `{
 		"spec": {
 			"securityContext": {"runAsNonRoot": true, "seccompProfile": {"type": "RuntimeDefault"}},
 			"containers": [{
 				"name": "` + podName + `",
 				"image": "curlimages/curl:latest",
-				"command": ["curl", "-sk", "-o", "/dev/null", "-w", "%{http_code}", "--max-time", "5", "` + svcURL + `"],
+				"command": ["curl", "-sk", "--connect-only", "--connect-timeout", "5", "` + svcURL + `"],
 				"securityContext": {
 					"allowPrivilegeEscalation": false,
 					"capabilities": {"drop": ["ALL"]},
@@ -782,12 +782,9 @@ func ProbeWebhookTLS(namespace string) error {
 		"--image=curlimages/curl:latest",
 		"--overrides", overrides,
 		"-n", namespace)
-	output, err := Run(cmd)
+	_, err := Run(cmd)
 	if err != nil {
 		return fmt.Errorf("webhook TLS probe failed: %w", err)
-	}
-	if strings.TrimSpace(output) == "000" {
-		return fmt.Errorf("webhook TLS probe got HTTP 000 (connection refused)")
 	}
 	return nil
 }

--- a/kagenti-operator/test/utils/utils.go
+++ b/kagenti-operator/test/utils/utils.go
@@ -752,20 +752,18 @@ func UncommentCode(filename, target, prefix string) error {
 	return os.WriteFile(filename, out.Bytes(), 0644)
 }
 
-// ProbeWebhookReady checks that the controller pod is fully Ready (all
-// containers passing readiness probes). The manager's readiness probe gates
-// on full initialization including the webhook server startup.
+// ProbeWebhookReady checks that the controller pod is fully Ready.
+// The readyz endpoint gates on webhookServer.StartedChecker(), so Ready
+// means the webhook TLS server is accepting connections on :9443.
 func ProbeWebhookReady(namespace string) error {
-	cmd := exec.Command("kubectl", "get", "pods",
-		"-l", "control-plane=controller-manager",
+	cmd := exec.Command("kubectl", "wait",
+		"--for=condition=Ready",
+		"pod", "-l", "control-plane=controller-manager",
 		"-n", namespace,
-		"-o", "jsonpath={.items[0].status.conditions[?(@.type==\"Ready\")].status}")
-	output, err := Run(cmd)
+		"--timeout=5s")
+	_, err := Run(cmd)
 	if err != nil {
-		return fmt.Errorf("failed to check controller pod readiness: %w", err)
-	}
-	if strings.TrimSpace(output) != "True" {
-		return fmt.Errorf("controller pod not yet Ready (status=%q)", output)
+		return fmt.Errorf("controller pod not yet Ready: %w", err)
 	}
 	return nil
 }

--- a/kagenti-operator/test/utils/utils.go
+++ b/kagenti-operator/test/utils/utils.go
@@ -752,39 +752,20 @@ func UncommentCode(filename, target, prefix string) error {
 	return os.WriteFile(filename, out.Bytes(), 0644)
 }
 
-// ProbeWebhookTLS runs a temporary curl pod that verifies the webhook service
-// TLS handshake succeeds. Uses --connect-only to avoid waiting for an HTTP
-// response (the webhook only handles admission POST requests). Returns nil if
-// the TLS connection succeeds, or an error if not yet ready.
-func ProbeWebhookTLS(namespace string) error {
-	podName := fmt.Sprintf("webhook-probe-%d", time.Now().UnixNano()%100000)
-	svcURL := fmt.Sprintf("https://kagenti-operator-webhook-service.%s.svc:443", namespace)
-
-	overrides := `{
-		"spec": {
-			"securityContext": {"runAsNonRoot": true, "seccompProfile": {"type": "RuntimeDefault"}},
-			"containers": [{
-				"name": "` + podName + `",
-				"image": "curlimages/curl:latest",
-				"command": ["curl", "-sk", "--connect-only", "--connect-timeout", "5", "` + svcURL + `"],
-				"securityContext": {
-					"allowPrivilegeEscalation": false,
-					"capabilities": {"drop": ["ALL"]},
-					"runAsNonRoot": true,
-					"seccompProfile": {"type": "RuntimeDefault"}
-				}
-			}]
-		}
-	}`
-
-	cmd := exec.Command("kubectl", "run", podName,
-		"--rm", "-i", "--restart=Never",
-		"--image=curlimages/curl:latest",
-		"--overrides", overrides,
-		"-n", namespace)
-	_, err := Run(cmd)
+// ProbeWebhookReady checks that the controller pod is fully Ready (all
+// containers passing readiness probes). The manager's readiness probe gates
+// on full initialization including the webhook server startup.
+func ProbeWebhookReady(namespace string) error {
+	cmd := exec.Command("kubectl", "get", "pods",
+		"-l", "control-plane=controller-manager",
+		"-n", namespace,
+		"-o", "jsonpath={.items[0].status.conditions[?(@.type==\"Ready\")].status}")
+	output, err := Run(cmd)
 	if err != nil {
-		return fmt.Errorf("webhook TLS probe failed: %w", err)
+		return fmt.Errorf("failed to check controller pod readiness: %w", err)
+	}
+	if strings.TrimSpace(output) != "True" {
+		return fmt.Errorf("controller pod not yet Ready (status=%q)", output)
 	}
 	return nil
 }

--- a/kagenti-operator/test/utils/utils.go
+++ b/kagenti-operator/test/utils/utils.go
@@ -759,12 +759,29 @@ func ProbeWebhookTLS(namespace string) error {
 	podName := fmt.Sprintf("webhook-probe-%d", time.Now().UnixNano()%100000)
 	svcURL := fmt.Sprintf("https://kagenti-operator-webhook-service.%s.svc:443/", namespace)
 
+	// Security context required for clusters with "restricted" PodSecurity enforcement.
+	overrides := `{
+		"spec": {
+			"securityContext": {"runAsNonRoot": true, "seccompProfile": {"type": "RuntimeDefault"}},
+			"containers": [{
+				"name": "` + podName + `",
+				"image": "curlimages/curl:latest",
+				"command": ["curl", "-sk", "-o", "/dev/null", "-w", "%{http_code}", "--max-time", "5", "` + svcURL + `"],
+				"securityContext": {
+					"allowPrivilegeEscalation": false,
+					"capabilities": {"drop": ["ALL"]},
+					"runAsNonRoot": true,
+					"seccompProfile": {"type": "RuntimeDefault"}
+				}
+			}]
+		}
+	}`
+
 	cmd := exec.Command("kubectl", "run", podName,
 		"--rm", "-i", "--restart=Never",
 		"--image=curlimages/curl:latest",
-		"-n", namespace,
-		"--", "curl", "-sk", "-o", "/dev/null", "-w", "%{http_code}",
-		"--max-time", "5", svcURL)
+		"--overrides", overrides,
+		"-n", namespace)
 	output, err := Run(cmd)
 	if err != nil {
 		return fmt.Errorf("webhook TLS probe failed: %w", err)

--- a/kagenti-operator/test/utils/utils.go
+++ b/kagenti-operator/test/utils/utils.go
@@ -751,3 +751,26 @@ func UncommentCode(filename, target, prefix string) error {
 	// nolint:gosec
 	return os.WriteFile(filename, out.Bytes(), 0644)
 }
+
+// ProbeWebhookTLS runs a temporary curl pod that attempts a TLS connection to the
+// webhook service. Returns nil if the webhook is accepting TLS connections, or an
+// error if it is not yet ready. Intended for use inside an Eventually() block.
+func ProbeWebhookTLS(namespace string) error {
+	podName := fmt.Sprintf("webhook-probe-%d", time.Now().UnixNano()%100000)
+	svcURL := fmt.Sprintf("https://kagenti-operator-webhook-service.%s.svc:443/", namespace)
+
+	cmd := exec.Command("kubectl", "run", podName,
+		"--rm", "-i", "--restart=Never",
+		"--image=curlimages/curl:latest",
+		"-n", namespace,
+		"--", "curl", "-sk", "-o", "/dev/null", "-w", "%{http_code}",
+		"--max-time", "5", svcURL)
+	output, err := Run(cmd)
+	if err != nil {
+		return fmt.Errorf("webhook TLS probe failed: %w", err)
+	}
+	if strings.TrimSpace(output) == "000" {
+		return fmt.Errorf("webhook TLS probe got HTTP 000 (connection refused)")
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Adds `webhookServer.StartedChecker()` as a readyz check in `cmd/main.go` so the pod Ready condition gates on the webhook TLS server actually listening on `:9443`
- Adds `ProbeWebhookReady()` utility in `test/utils/utils.go` that uses `kubectl wait --for=condition=Ready` on controller pods
- Adds the readiness probe as a second phase after the existing endpoint IP check at all 7 locations in `test/e2e/e2e_test.go`
- Fixes the race condition where the endpoint IP populates before the webhook TLS server is ready, causing pod creation failures

## Root Cause

After a controller restart, the Kubernetes `Endpoints` object gets the pod IP immediately, but the webhook's TLS server needs additional time to initialize (read certs, bind port 9443). The existing readyz check was `healthz.Ping` (a no-op), so the pod reported Ready before the webhook was accepting connections. The E2E tests only verified the endpoint IP was present, not that TLS was ready.

## Fix

1. **Runtime fix**: Add `mgr.AddReadyzCheck("webhook", webhookServer.StartedChecker())` — the controller-runtime webhook server exposes `StartedChecker()` which returns healthy only after the TLS listener is bound.
2. **Test fix**: `ProbeWebhookReady()` uses `kubectl wait --for=condition=Ready` which now reflects true webhook readiness, and handles rolling restarts (multiple pods) correctly.

## Test Plan

- [ ] CI E2E tests pass — specifically the "Skill Discovery > Feature gate enabled > should populate linkedSkills from annotation" test that was consistently failing
- [ ] No regression in other test blocks that also use the readiness probe

Fixes #420

Assisted-By: Claude Code