### PR TITLE
Fix(mlflow): add --mlflow-ca-file flag for custom TLS CA verification

### DIFF
--- a/kagenti-operator/cmd/main.go
+++ b/kagenti-operator/cmd/main.go
@@ -532,7 +532,7 @@ func main() {
 		if err = (&controller.MLflowReconciler{
 			Client:       mgr.GetClient(),
 			Scheme:       mgr.GetScheme(),
-			Recorder:     mgr.GetEventRecorderFor("mlflow-controller"),
+			Recorder:     mgr.GetEventRecorderFor("mlflow-controller"), //nolint:staticcheck
 			MLflowCAFile: mlflowCAFile,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "MLflow")

--- a/kagenti-operator/cmd/main.go
+++ b/kagenti-operator/cmd/main.go
@@ -109,6 +109,7 @@ func main() {
 	var enableOtelBootstrap bool
 	var mlflowWorkspace string
 	var mlflowExperimentName string
+	var mlflowCAFile string
 
 	var enableCardDiscovery bool
 
@@ -166,6 +167,8 @@ func main() {
 		"Kubernetes namespace used as the x-mlflow-workspace header value (RHOAI only)")
 	flag.StringVar(&mlflowExperimentName, "mlflow-experiment-name", "kagenti-traces",
 		"MLflow experiment name; created automatically if it doesn't exist")
+	flag.StringVar(&mlflowCAFile, "mlflow-ca-file", "",
+		"Path to PEM-encoded CA bundle for MLflow TLS verification (appended to system pool)")
 
 	flag.BoolVar(&enableCardDiscovery, "enable-card-discovery", false,
 		"Enable automatic agent card discovery from AgentRuntime workloads into status.card")
@@ -527,9 +530,10 @@ func main() {
 
 	if enableMLflow {
 		if err = (&controller.MLflowReconciler{
-			Client:   mgr.GetClient(),
-			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorderFor("mlflow-controller"),
+			Client:       mgr.GetClient(),
+			Scheme:       mgr.GetScheme(),
+			Recorder:     mgr.GetEventRecorderFor("mlflow-controller"),
+			MLflowCAFile: mlflowCAFile,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "MLflow")
 			os.Exit(1)

--- a/kagenti-operator/internal/controller/mlflow_controller.go
+++ b/kagenti-operator/internal/controller/mlflow_controller.go
@@ -67,6 +67,12 @@ type MLflowReconciler struct {
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
 
+	// MLflowCAFile is the path to a PEM-encoded CA bundle for verifying the
+	// MLflow gateway TLS certificate. When set, the CA is appended to the
+	// system cert pool. Required on clusters where the MLflow Route uses a
+	// non-publicly-trusted certificate (e.g., HyperShift ingress CA).
+	MLflowCAFile string
+
 	// NewMLflowClient creates an MLflow client for the given base URL.
 	// If nil, a default client is used.
 	NewMLflowClient func(baseURL string) *mlflow.Client
@@ -159,7 +165,7 @@ func (r *MLflowReconciler) mlflowClient(baseURL string) *mlflow.Client {
 	if r.NewMLflowClient != nil {
 		return r.NewMLflowClient(baseURL)
 	}
-	return &mlflow.Client{BaseURL: baseURL}
+	return &mlflow.Client{BaseURL: baseURL, CAFile: r.MLflowCAFile}
 }
 
 // trackingURI returns the MLflow tracking URI, using the override if set.

--- a/kagenti-operator/internal/mlflow/client.go
+++ b/kagenti-operator/internal/mlflow/client.go
@@ -158,36 +158,50 @@ func (c *Client) retryBaseDelay() time.Duration {
 	return DefaultRetryBaseDelay
 }
 
-func (c *Client) httpClient() *http.Client {
+func (c *Client) httpClient() (*http.Client, error) {
+	var initErr error
 	c.httpOnce.Do(func() {
 		if c.HTTPClient == nil {
+			transport, err := c.buildTransport()
+			if err != nil {
+				initErr = err
+				return
+			}
 			c.HTTPClient = &http.Client{
 				Timeout:   c.timeout(),
-				Transport: c.buildTransport(),
+				Transport: transport,
 			}
 		}
 	})
-	return c.HTTPClient
+	if initErr != nil {
+		return nil, initErr
+	}
+	if c.HTTPClient == nil {
+		return nil, fmt.Errorf("http client initialization failed")
+	}
+	return c.HTTPClient, nil
 }
 
-func (c *Client) buildTransport() http.RoundTripper {
+func (c *Client) buildTransport() (http.RoundTripper, error) {
 	if c.CAFile == "" {
-		return nil
+		return nil, nil
 	}
 	caPEM, err := os.ReadFile(c.CAFile)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("reading CA file %q: %w", c.CAFile, err)
 	}
 	pool, err := x509.SystemCertPool()
 	if err != nil {
 		pool = x509.NewCertPool()
 	}
-	pool.AppendCertsFromPEM(caPEM)
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("CA file %q contains no valid PEM certificates", c.CAFile)
+	}
 	return &http.Transport{
 		TLSClientConfig: &tls.Config{
 			RootCAs: pool,
 		},
-	}
+	}, nil
 }
 
 func (c *Client) tokenPath() string {
@@ -398,7 +412,12 @@ func (c *Client) doRequest(ctx context.Context, method, path, workspace string, 
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	resp, err := c.httpClient().Do(req)
+	httpClient, err := c.httpClient()
+	if err != nil {
+		return nil, fmt.Errorf("initializing HTTP client: %w", err)
+	}
+
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("executing request: %w", err)
 	}

--- a/kagenti-operator/internal/mlflow/client.go
+++ b/kagenti-operator/internal/mlflow/client.go
@@ -22,6 +22,8 @@ package mlflow
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -63,6 +65,12 @@ type Client struct {
 
 	// TokenPath is the path to the SA token file. Defaults to DefaultTokenPath.
 	TokenPath string
+
+	// CAFile is an optional path to a PEM-encoded CA certificate bundle to
+	// append to the system cert pool for TLS verification. Used on clusters
+	// where the MLflow gateway uses a non-publicly-trusted certificate
+	// (e.g., HyperShift ingress CA).
+	CAFile string
 
 	// HTTPClient is the HTTP client to use. If nil, a default client is created
 	// on first use with Timeout applied. Must be set before the first request.
@@ -154,11 +162,32 @@ func (c *Client) httpClient() *http.Client {
 	c.httpOnce.Do(func() {
 		if c.HTTPClient == nil {
 			c.HTTPClient = &http.Client{
-				Timeout: c.timeout(),
+				Timeout:   c.timeout(),
+				Transport: c.buildTransport(),
 			}
 		}
 	})
 	return c.HTTPClient
+}
+
+func (c *Client) buildTransport() http.RoundTripper {
+	if c.CAFile == "" {
+		return nil
+	}
+	caPEM, err := os.ReadFile(c.CAFile)
+	if err != nil {
+		return nil
+	}
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		pool = x509.NewCertPool()
+	}
+	pool.AppendCertsFromPEM(caPEM)
+	return &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: pool,
+		},
+	}
 }
 
 func (c *Client) tokenPath() string {

--- a/kagenti-operator/internal/mlflow/client_test.go
+++ b/kagenti-operator/internal/mlflow/client_test.go
@@ -431,3 +431,50 @@ func TestRetry_NoRetryOn4xx(t *testing.T) {
 		t.Errorf("expected 1 request (no retries on 4xx), got %d", got)
 	}
 }
+
+func TestBuildTransport_NoCAFile(t *testing.T) {
+	c := &Client{BaseURL: "https://example.com"}
+	transport := c.buildTransport()
+	if transport != nil {
+		t.Error("expected nil transport when CAFile is empty")
+	}
+}
+
+func TestBuildTransport_InvalidCAFile(t *testing.T) {
+	c := &Client{BaseURL: "https://example.com", CAFile: "/nonexistent/ca.pem"}
+	transport := c.buildTransport()
+	if transport != nil {
+		t.Error("expected nil transport when CAFile does not exist")
+	}
+}
+
+func TestBuildTransport_ValidCAFile(t *testing.T) {
+	// Create a temp PEM file with a dummy CA cert
+	caPath := filepath.Join(t.TempDir(), "ca.pem")
+	// Use a self-signed cert PEM (just needs to be parseable)
+	dummyPEM := []byte(`-----BEGIN CERTIFICATE-----
+MIIBkTCB+wIJALRiMLAhBHkfMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBnRl
+c3RjYTAeFw0yNDA2MTAxNjAwMDBaFw0yNTA2MTAxNjAwMDBaMBExDzANBgNVBAMM
+BnRlc3RjYTBcMA0GCSqGSIb3DQEBAQUAAwsAMEgCQQC7o96d34FHON3QS39tnWWP
+fm5XO0K5fN5u8S1w7FYQFR18bNLdP3J0u2iAcLGGf3rkUddU2LRBB3qe7YESQQ3
+AgMBAAEwDQYJKoZIhvcNAQELBQADQQBi5xVL+nqUSHmsm15FYkZrJnOXtQj2PT7S
+GgPXqM1T3iA0oBe+n6PBnH7cL9fJcXl9Yl0NWqt8ByPNmNrWJ5R
+-----END CERTIFICATE-----
+`)
+	if err := os.WriteFile(caPath, dummyPEM, 0600); err != nil {
+		t.Fatalf("writing test CA: %v", err)
+	}
+
+	c := &Client{BaseURL: "https://example.com", CAFile: caPath}
+	transport := c.buildTransport()
+	if transport == nil {
+		t.Fatal("expected non-nil transport with valid CA file")
+	}
+	httpTransport, ok := transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+	if httpTransport.TLSClientConfig == nil || httpTransport.TLSClientConfig.RootCAs == nil {
+		t.Fatal("expected TLS config with custom RootCAs")
+	}
+}

--- a/kagenti-operator/internal/mlflow/client_test.go
+++ b/kagenti-operator/internal/mlflow/client_test.go
@@ -18,8 +18,15 @@ package mlflow
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -434,7 +441,10 @@ func TestRetry_NoRetryOn4xx(t *testing.T) {
 
 func TestBuildTransport_NoCAFile(t *testing.T) {
 	c := &Client{BaseURL: "https://example.com"}
-	transport := c.buildTransport()
+	transport, err := c.buildTransport()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if transport != nil {
 		t.Error("expected nil transport when CAFile is empty")
 	}
@@ -442,31 +452,38 @@ func TestBuildTransport_NoCAFile(t *testing.T) {
 
 func TestBuildTransport_InvalidCAFile(t *testing.T) {
 	c := &Client{BaseURL: "https://example.com", CAFile: "/nonexistent/ca.pem"}
-	transport := c.buildTransport()
-	if transport != nil {
-		t.Error("expected nil transport when CAFile does not exist")
+	_, err := c.buildTransport()
+	if err == nil {
+		t.Fatal("expected error for missing CA file")
+	}
+}
+
+func TestBuildTransport_InvalidPEM(t *testing.T) {
+	caPath := filepath.Join(t.TempDir(), "bad.pem")
+	if err := os.WriteFile(caPath, []byte("not a pem"), 0600); err != nil {
+		t.Fatalf("writing test file: %v", err)
+	}
+
+	c := &Client{BaseURL: "https://example.com", CAFile: caPath}
+	_, err := c.buildTransport()
+	if err == nil {
+		t.Fatal("expected error for invalid PEM content")
 	}
 }
 
 func TestBuildTransport_ValidCAFile(t *testing.T) {
-	// Create a temp PEM file with a dummy CA cert
+	// Generate a self-signed CA certificate for testing
 	caPath := filepath.Join(t.TempDir(), "ca.pem")
-	// Use a self-signed cert PEM (just needs to be parseable)
-	dummyPEM := []byte(`-----BEGIN CERTIFICATE-----
-MIIBkTCB+wIJALRiMLAhBHkfMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBnRl
-c3RjYTAeFw0yNDA2MTAxNjAwMDBaFw0yNTA2MTAxNjAwMDBaMBExDzANBgNVBAMM
-BnRlc3RjYTBcMA0GCSqGSIb3DQEBAQUAAwsAMEgCQQC7o96d34FHON3QS39tnWWP
-fm5XO0K5fN5u8S1w7FYQFR18bNLdP3J0u2iAcLGGf3rkUddU2LRBB3qe7YESQQ3
-AgMBAAEwDQYJKoZIhvcNAQELBQADQQBi5xVL+nqUSHmsm15FYkZrJnOXtQj2PT7S
-GgPXqM1T3iA0oBe+n6PBnH7cL9fJcXl9Yl0NWqt8ByPNmNrWJ5R
------END CERTIFICATE-----
-`)
-	if err := os.WriteFile(caPath, dummyPEM, 0600); err != nil {
+	caPEM := generateTestCACert(t)
+	if err := os.WriteFile(caPath, caPEM, 0600); err != nil {
 		t.Fatalf("writing test CA: %v", err)
 	}
 
 	c := &Client{BaseURL: "https://example.com", CAFile: caPath}
-	transport := c.buildTransport()
+	transport, err := c.buildTransport()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if transport == nil {
 		t.Fatal("expected non-nil transport with valid CA file")
 	}
@@ -477,4 +494,25 @@ GgPXqM1T3iA0oBe+n6PBnH7cL9fJcXl9Yl0NWqt8ByPNmNrWJ5R
 	if httpTransport.TLSClientConfig == nil || httpTransport.TLSClientConfig.RootCAs == nil {
 		t.Fatal("expected TLS config with custom RootCAs")
 	}
+}
+
+func generateTestCACert(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating certificate: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 }


### PR DESCRIPTION
## Summary

- Add `--mlflow-ca-file` flag to the operator binary that configures the MLflow REST client with a custom CA bundle
- The CA PEM is appended to the system cert pool, so both publicly-trusted and cluster-specific CAs work
- Fixes TLS verification failure on HyperShift clusters where the RHOAI MLflow gateway uses the cluster ingress CA

Closes kagenti/kagenti#1896

## Context

On HyperShift CI clusters, the operator's `MLflowReconciler` fails to create experiments:
```
Post "https://rh-ai.apps.*.*/mlflow/api/2.0/mlflow/experiments/create":
tls: failed to verify certificate: x509: certificate signed by unknown authority
```

The MLflow gateway URL (from `mlflows.mlflow.opendatahub.io` CR `.status.url`) uses an OpenShift Route whose TLS certificate is signed by the cluster's ingress CA — not a publicly-trusted CA.

## Changes

| File | Change |
|------|--------|
| `internal/mlflow/client.go` | Add `CAFile` field and `buildTransport()` to load custom CA |
| `internal/controller/mlflow_controller.go` | Add `MLflowCAFile` field, pass to client |
| `cmd/main.go` | Add `--mlflow-ca-file` flag, wire to reconciler |
| `internal/mlflow/client_test.go` | Unit tests for `buildTransport` |

## Test plan

- [x] Unit tests pass (`go test ./internal/mlflow/`)
- [x] Build succeeds (`go build ./...`)
- [ ] Integration: deploy with `--mlflow-ca-file=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` on HyperShift
- [ ] Companion PR in kagenti/kagenti mounts the trusted-ca-bundle ConfigMap

Assisted-By: Claude Code