### PR TITLE
Chore: Retire CLUSTER_CIDRS injection (DNS exemption is resolv.conf-driven)

### DIFF
--- a/charts/kagenti-operator/values.yaml
+++ b/charts/kagenti-operator/values.yaml
@@ -225,13 +225,9 @@ defaults:
     # always-on enforce-redirect egress guard (proxy-sidecar / lite). MUST match
     # the authbridge listener.transparent_proxy_addr (default :8082).
     transparentPort: 8082
-    # In-cluster CIDRs (pods/services/DNS) left direct by the enforce-redirect
-    # guard; external TCP is REDIRECTed to the transparent listener and external
-    # non-TCP is dropped. The default is Kind-shaped (pods 10.244/16 + services
-    # 10.96/16). OpenShift/EKS MUST override — e.g. OCP services 172.30.0.0/16
-    # (outside 10/8) + pods 10.128.0.0/14 — or in-cluster service traffic breaks.
-    clusterCIDRs:
-      - "10.0.0.0/8"
+    # Cluster DNS is kept direct by proxy-init itself (it reads the pod's
+    # /etc/resolv.conf nameservers), so there is no in-cluster CIDR knob to set —
+    # works on Kind / OpenShift / EKS / NodeLocal-DNSCache with no per-cluster config.
 
   # Resource defaults (conservative for dev)
   # Note: requests must be <= limits

--- a/kagenti-operator/internal/webhook/config/defaults.go
+++ b/kagenti-operator/internal/webhook/config/defaults.go
@@ -35,9 +35,6 @@ func CompiledDefaults() *PlatformConfig {
 			// Transparent listener port — must match the authbridge proxy-sidecar
 			// preset (listener.transparent_proxy_addr default :8082).
 			TransparentPort: 8082,
-			// Kind-shaped default (pods 10.244/16 + services 10.96/16). OCP/EKS
-			// MUST override (see ProxyConfig.ClusterCIDRs doc).
-			ClusterCIDRs: []string{"10.0.0.0/8"},
 		},
 		Resources: ResourcesConfig{
 			EnvoyProxy: corev1.ResourceRequirements{

--- a/kagenti-operator/internal/webhook/config/types.go
+++ b/kagenti-operator/internal/webhook/config/types.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"net"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -52,16 +51,6 @@ type ProxyConfig struct {
 	// external TCP egress to. It MUST match the authbridge proxy-sidecar
 	// listener.transparent_proxy_addr (default :8082).
 	TransparentPort int32 `json:"transparentPort" yaml:"transparentPort"`
-
-	// ClusterCIDRs are the in-cluster ranges (pods / services / DNS) that the
-	// enforce-redirect guard allows direct; external TCP is REDIRECTed to the
-	// transparent listener and external non-TCP is dropped. The default
-	// 10.0.0.0/8 is Kind-shaped (pods 10.244/16 + services 10.96/16). OCP/EKS
-	// MUST override this (e.g. OCP services 172.30.0.0/16, pods 10.128.0.0/14 —
-	// 172.30/16 is outside 10/8) or in-cluster service traffic will be dropped.
-	// Egress enforcement is always-on for proxy-sidecar / lite, so this is
-	// always consumed there; envoy-sidecar (transparent redirect) does not use it.
-	ClusterCIDRs []string `json:"clusterCIDRs" yaml:"clusterCIDRs"`
 }
 
 type ResourcesConfig struct {
@@ -96,11 +85,6 @@ func (c *PlatformConfig) DeepCopy() *PlatformConfig {
 	if c.TokenExchange.DefaultScopes != nil {
 		result.TokenExchange.DefaultScopes = make([]string, len(c.TokenExchange.DefaultScopes))
 		copy(result.TokenExchange.DefaultScopes, c.TokenExchange.DefaultScopes)
-	}
-
-	if c.Proxy.ClusterCIDRs != nil {
-		result.Proxy.ClusterCIDRs = make([]string, len(c.Proxy.ClusterCIDRs))
-		copy(result.Proxy.ClusterCIDRs, c.Proxy.ClusterCIDRs)
 	}
 
 	// Deep copy ResourceRequirements — ResourceList is a map that would be shared
@@ -146,23 +130,6 @@ func (c *PlatformConfig) Validate() error {
 	// container runs as it; it must be a real non-root user.
 	if c.Proxy.UID < 1 {
 		return fmt.Errorf("proxy.uid must be >= 1 (got %d): the proxy must not run as root and the egress-enforcement exemption keys on this UID", c.Proxy.UID)
-	}
-	// ClusterCIDRs drive the only in-cluster allowance in the enforce-redirect
-	// guard, which is always-on for proxy-sidecar / lite. Validate at load time so
-	// a misconfig fails fast with a clear message rather than: (a) an empty list
-	// silently falling back to the Kind-shaped 10.0.0.0/8 default in
-	// init-iptables.sh, or (b) a malformed entry crashing the proxy-init container
-	// under `set -e` with a cryptic iptables error.
-	if len(c.Proxy.ClusterCIDRs) == 0 {
-		return fmt.Errorf("proxy.clusterCIDRs must be non-empty (set the cluster's pod+service CIDRs)")
-	}
-	// Syntactic validation only — overlapping ranges and IPv4/IPv6 mixing are
-	// accepted (iptables handles both, and the init script splits v4/v6 itself);
-	// we only reject malformed strings here.
-	for _, cidr := range c.Proxy.ClusterCIDRs {
-		if _, _, err := net.ParseCIDR(cidr); err != nil {
-			return fmt.Errorf("proxy.clusterCIDRs entry %q is not a valid CIDR: %w", cidr, err)
-		}
 	}
 	if c.Images.EnvoyProxy == "" {
 		return fmt.Errorf("images.envoyProxy is required")

--- a/kagenti-operator/internal/webhook/config/types_test.go
+++ b/kagenti-operator/internal/webhook/config/types_test.go
@@ -2,40 +2,6 @@ package config
 
 import "testing"
 
-// ClusterCIDRs drive the only in-cluster allowance in the always-on
-// enforce-redirect guard, so they must always be present and valid — an empty
-// list (silent 10/8 fallback in the init script) or a malformed entry
-// (init-container CrashLoop under set -e) must be rejected at config load.
-func TestValidate_ClusterCIDRs(t *testing.T) {
-	tests := []struct {
-		name    string
-		mutate  func(*PlatformConfig)
-		wantErr bool
-	}{
-		{"default CIDRs ok", func(c *PlatformConfig) {}, false},
-		{"empty CIDRs rejected", func(c *PlatformConfig) { c.Proxy.ClusterCIDRs = nil }, true},
-		{"malformed CIDR rejected", func(c *PlatformConfig) {
-			c.Proxy.ClusterCIDRs = []string{"10.0.0.0/8", "garbage"}
-		}, true},
-		{"valid OCP-shaped CIDRs ok", func(c *PlatformConfig) {
-			c.Proxy.ClusterCIDRs = []string{"10.128.0.0/14", "172.30.0.0/16"}
-		}, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := CompiledDefaults()
-			tt.mutate(c)
-			err := c.Validate()
-			if tt.wantErr && err == nil {
-				t.Errorf("expected validation error, got nil")
-			}
-			if !tt.wantErr && err != nil {
-				t.Errorf("unexpected validation error: %v", err)
-			}
-		})
-	}
-}
-
 // TransparentPort is the REDIRECT target for the enforce-redirect guard; it must
 // be a valid, non-privileged port (the proxy binds it as a non-root user).
 func TestValidate_TransparentPort(t *testing.T) {

--- a/kagenti-operator/internal/webhook/injector/container_builder.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder.go
@@ -462,28 +462,27 @@ const mandatoryOutboundExclude = "8080"
 //   - "enforce-redirect" (proxy-sidecar): a fail-closed egress guard that
 //     REDIRECTs external TCP bypassing the forward proxy to the transparent
 //     listener (TRANSPARENT_PORT) and DROPs non-TCP. Driven by PROXY_UID +
-//     CLUSTER_CIDRS + TRANSPARENT_PORT; the exclude args do not apply.
+//     TRANSPARENT_PORT; the exclude args do not apply. Cluster DNS is kept
+//     direct by the init script reading the pod's resolv.conf nameservers.
 func (b *ContainerBuilder) BuildProxyInitContainer(mode ProxyInitMode, outboundPortsExclude, inboundPortsExclude string) corev1.Container {
 	var env []corev1.EnvVar
 	switch mode {
 	case ProxyInitModeEnforceRedirect:
 		// PROXY_UID is exempted (its egress is not redirected) and MUST match the
-		// proxy container's RunAsUser (both derive from b.cfg.Proxy.UID).
-		// CLUSTER_CIDRS are allowed direct; external TCP is REDIRECTed to
-		// TRANSPARENT_PORT (the proxy's transparent listener), external non-TCP is
-		// dropped. The redirect-only exclude vars are unused in this mode.
-		clusterCIDRs := strings.Join(b.cfg.Proxy.ClusterCIDRs, ",")
+		// proxy container's RunAsUser (both derive from b.cfg.Proxy.UID). External
+		// TCP is REDIRECTed to TRANSPARENT_PORT (the proxy's transparent listener),
+		// external non-TCP is dropped. Cluster DNS is left direct by the init script
+		// itself (it reads the pod's resolv.conf nameservers — no CIDR knob needed).
+		// The redirect-only exclude vars are unused in this mode.
 		env = []corev1.EnvVar{
 			{Name: "MODE", Value: string(ProxyInitModeEnforceRedirect)},
 			{Name: "PROXY_UID", Value: fmt.Sprintf("%d", b.cfg.Proxy.UID)},
-			{Name: "CLUSTER_CIDRS", Value: clusterCIDRs},
 			{Name: "TRANSPARENT_PORT", Value: fmt.Sprintf("%d", b.cfg.Proxy.TransparentPort)},
 		}
 		builderLog.Info("building ProxyInit Container",
 			"mode", "enforce-redirect",
 			"proxyUID", b.cfg.Proxy.UID,
-			"transparentPort", b.cfg.Proxy.TransparentPort,
-			"clusterCIDRs", clusterCIDRs)
+			"transparentPort", b.cfg.Proxy.TransparentPort)
 	case ProxyInitModeRedirect:
 		outboundValue := buildOutboundExcludeValue(outboundPortsExclude)
 		inboundValue := buildPortExcludeValue(inboundPortsExclude, "inbound-ports-exclude")

--- a/kagenti-operator/internal/webhook/injector/container_builder_test.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder_test.go
@@ -18,7 +18,6 @@ package injector
 
 import (
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/kagenti/operator/internal/webhook/config"
@@ -304,8 +303,9 @@ func TestBuildProxySidecarContainer_RunAsProxyUID(t *testing.T) {
 	}
 }
 
-// enforce-redirect mode emits MODE / PROXY_UID / CLUSTER_CIDRS / TRANSPARENT_PORT
-// and none of the redirect-only vars (POD_IP, OUTBOUND_PORTS_EXCLUDE).
+// enforce-redirect mode emits MODE / PROXY_UID / TRANSPARENT_PORT, no CLUSTER_CIDRS
+// (DNS exemption is resolv.conf-driven in the init script), and none of the
+// redirect-only vars (POD_IP, OUTBOUND_PORTS_EXCLUDE).
 func TestBuildProxyInitContainer_EnforceRedirect(t *testing.T) {
 	cfg := config.CompiledDefaults()
 	builder := NewContainerBuilder(cfg)
@@ -324,8 +324,8 @@ func TestBuildProxyInitContainer_EnforceRedirect(t *testing.T) {
 	if want := strconv.FormatInt(cfg.Proxy.UID, 10); got["PROXY_UID"] != want {
 		t.Errorf("PROXY_UID = %q, want %q", got["PROXY_UID"], want)
 	}
-	if want := strings.Join(cfg.Proxy.ClusterCIDRs, ","); got["CLUSTER_CIDRS"] != want {
-		t.Errorf("CLUSTER_CIDRS = %q, want %q", got["CLUSTER_CIDRS"], want)
+	if _, ok := got["CLUSTER_CIDRS"]; ok {
+		t.Error("enforce-redirect must not set CLUSTER_CIDRS (DNS exemption is resolv.conf-driven in the init script)")
 	}
 	if want := strconv.FormatInt(int64(cfg.Proxy.TransparentPort), 10); got["TRANSPARENT_PORT"] != want {
 		t.Errorf("TRANSPARENT_PORT = %q, want %q", got["TRANSPARENT_PORT"], want)


### PR DESCRIPTION
## Summary

Retire the `CLUSTER_CIDRS` knob from the operator now that proxy-init derives the DNS exemption from the pod's actual resolvers.

[kagenti-extensions#499](https://github.com/kagenti/kagenti-extensions/pull/499) changes the `enforce-redirect` egress guard to leave cluster DNS direct by exempting the `/etc/resolv.conf` `nameserver` IPs (`UDP/53` + `TCP/53`), instead of a guessed in-cluster CIDR. The old `CLUSTER_CIDRS` default was Kind-shaped `10.0.0.0/8` and **silently dropped DNS on OpenShift/HyperShift**, where the resolver lives in the service network (`172.30`/`172.31`, outside `10/8`) — the root cause of the kagenti#1911 e2e failure. The resolver is also unpredictable in general (any service ClusterIP, or a NodeLocal DNSCache at link-local `169.254.x`), so no CIDR guess covers it.

The init script no longer reads `CLUSTER_CIDRS`, making this operator wiring dead code.

## Changes

- **`container_builder.go`** — stop injecting the `CLUSTER_CIDRS` env on the `enforce-redirect` proxy-init container.
- **`config/types.go`** — drop `ProxyConfig.ClusterCIDRs`, its deep-copy, and the `Validate()` non-empty + CIDR-syntax checks (plus the now-unused `net` import).
- **`config/defaults.go`** — drop the `10.0.0.0/8` default.
- **`charts/kagenti-operator/values.yaml`** — drop `proxy.clusterCIDRs`; the comment now notes DNS is resolv.conf-driven with no per-cluster config.
- **tests** — remove `TestValidate_ClusterCIDRs`; the enforce-redirect container test now asserts `CLUSTER_CIDRS` is **not** set.

## Sequencing / compatibility

Safe to land independently: the updated init script ignores `CLUSTER_CIDRS` even if an older operator still injects it, and this operator drops the injection — neither requires the other. The end state needs both ext#499 (new proxy-init image) and this PR.

`go build` / `go vet` / `go test ./internal/webhook/...` all green.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
