### PR TITLE
Feat: Expose configurable iptables backend (IPTABLES_CMD) for proxy-init

### DIFF
--- a/charts/kagenti-operator/values.yaml
+++ b/charts/kagenti-operator/values.yaml
@@ -228,6 +228,11 @@ defaults:
     # Cluster DNS is kept direct by proxy-init itself (it reads the pod's
     # /etc/resolv.conf nameservers), so there is no in-cluster CIDR knob to set —
     # works on Kind / OpenShift / EKS / NodeLocal-DNSCache with no per-cluster config.
+    # iptables backend override, injected as IPTABLES_CMD. Empty (default) lets
+    # proxy-init auto-detect from /proc/modules (iptable_nat loaded => legacy, as
+    # on Kind/kubeadm; absent => nft, as on OpenShift/ROSA). Set to "iptables"
+    # (nft) or "iptables-legacy" to force a backend where detection is undesired.
+    iptablesCmd: ""
 
   # Resource defaults (conservative for dev)
   # Note: requests must be <= limits

--- a/kagenti-operator/internal/webhook/config/defaults.go
+++ b/kagenti-operator/internal/webhook/config/defaults.go
@@ -35,6 +35,9 @@ func CompiledDefaults() *PlatformConfig {
 			// Transparent listener port — must match the authbridge proxy-sidecar
 			// preset (listener.transparent_proxy_addr default :8082).
 			TransparentPort: 8082,
+			// Empty by default: proxy-init auto-detects the iptables backend from
+			// /proc/modules. Set (e.g. "iptables") to force a backend per-platform.
+			IptablesCmd: "",
 		},
 		Resources: ResourcesConfig{
 			EnvoyProxy: corev1.ResourceRequirements{

--- a/kagenti-operator/internal/webhook/config/loader.go
+++ b/kagenti-operator/internal/webhook/config/loader.go
@@ -199,6 +199,8 @@ func logConfig(cfg *PlatformConfig, source string) {
 		"uid", cfg.Proxy.UID,
 		"inboundProxyPort", cfg.Proxy.InboundProxyPort,
 		"adminPort", cfg.Proxy.AdminPort,
+		"transparentPort", cfg.Proxy.TransparentPort,
+		"iptablesCmd", cfg.Proxy.IptablesCmd,
 	)
 	log.Info("[config] resources.envoyProxy",
 		"requests", cfg.Resources.EnvoyProxy.Requests,

--- a/kagenti-operator/internal/webhook/config/types.go
+++ b/kagenti-operator/internal/webhook/config/types.go
@@ -139,6 +139,15 @@ func (c *PlatformConfig) Validate() error {
 	if c.Proxy.UID < 1 {
 		return fmt.Errorf("proxy.uid must be >= 1 (got %d): the proxy must not run as root and the egress-enforcement exemption keys on this UID", c.Proxy.UID)
 	}
+	// IptablesCmd, when set, pins the proxy-init iptables backend (IPTABLES_CMD).
+	// Restrict overrides to the binaries shipped in the proxy-init image so a
+	// chart typo fails fast at operator startup rather than as a per-injected-pod
+	// init crash. Empty is the default — proxy-init auto-detects from /proc/modules.
+	switch c.Proxy.IptablesCmd {
+	case "", "iptables", "iptables-nft", "iptables-legacy":
+	default:
+		return fmt.Errorf("proxy.iptablesCmd %q is not a recognized backend (want one of: \"\" (auto-detect), iptables, iptables-nft, iptables-legacy)", c.Proxy.IptablesCmd)
+	}
 	if c.Images.EnvoyProxy == "" {
 		return fmt.Errorf("images.envoyProxy is required")
 	}

--- a/kagenti-operator/internal/webhook/config/types.go
+++ b/kagenti-operator/internal/webhook/config/types.go
@@ -51,6 +51,14 @@ type ProxyConfig struct {
 	// external TCP egress to. It MUST match the authbridge proxy-sidecar
 	// listener.transparent_proxy_addr (default :8082).
 	TransparentPort int32 `json:"transparentPort" yaml:"transparentPort"`
+
+	// IptablesCmd optionally pins the iptables backend the proxy-init script
+	// uses, injected as the IPTABLES_CMD env var (omitted when empty). Empty
+	// (default) lets the script auto-detect from /proc/modules (iptable_nat
+	// loaded => legacy, as on Kind/kubeadm; absent => nft, as on OpenShift/
+	// ROSA). Set to "iptables" (nft) or "iptables-legacy" to force a backend
+	// where auto-detection is wrong or undesired.
+	IptablesCmd string `json:"iptablesCmd" yaml:"iptablesCmd"`
 }
 
 type ResourcesConfig struct {

--- a/kagenti-operator/internal/webhook/config/types_test.go
+++ b/kagenti-operator/internal/webhook/config/types_test.go
@@ -29,3 +29,34 @@ func TestValidate_TransparentPort(t *testing.T) {
 		})
 	}
 }
+
+// IptablesCmd pins the proxy-init backend; only the binaries shipped in the
+// image (plus "" = auto-detect) are accepted, so a chart typo fails at operator
+// startup rather than as a per-injected-pod init crash.
+func TestValidate_IptablesCmd(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmd     string
+		wantErr bool
+	}{
+		{"empty (auto-detect) ok", "", false},
+		{"iptables (nft) ok", "iptables", false},
+		{"iptables-nft ok", "iptables-nft", false},
+		{"iptables-legacy ok", "iptables-legacy", false},
+		{"typo rejected", "iptable", true},
+		{"arbitrary rejected", "nft", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := CompiledDefaults()
+			c.Proxy.IptablesCmd = tt.cmd
+			err := c.Validate()
+			if tt.wantErr && err == nil {
+				t.Errorf("expected validation error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected validation error: %v", err)
+			}
+		})
+	}
+}

--- a/kagenti-operator/internal/webhook/injector/container_builder.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder.go
@@ -534,6 +534,14 @@ func (b *ContainerBuilder) BuildProxyInitContainer(mode ProxyInitMode, outboundP
 		return corev1.Container{}
 	}
 
+	// Optional explicit iptables backend override (applies to both modes). Empty
+	// by default: the init script auto-detects from /proc/modules (iptable_nat
+	// loaded => legacy, else nft). Set b.cfg.Proxy.IptablesCmd (e.g. "iptables"
+	// on nft-only platforms) to force a backend.
+	if b.cfg.Proxy.IptablesCmd != "" {
+		env = append(env, corev1.EnvVar{Name: "IPTABLES_CMD", Value: b.cfg.Proxy.IptablesCmd})
+	}
+
 	return corev1.Container{
 		Name:            ProxyInitContainerName,
 		Image:           b.cfg.Images.ProxyInit,

--- a/kagenti-operator/internal/webhook/injector/container_builder_test.go
+++ b/kagenti-operator/internal/webhook/injector/container_builder_test.go
@@ -336,6 +336,45 @@ func TestBuildProxyInitContainer_EnforceRedirect(t *testing.T) {
 	if _, ok := got["OUTBOUND_PORTS_EXCLUDE"]; ok {
 		t.Error("enforce-redirect must not set OUTBOUND_PORTS_EXCLUDE")
 	}
+	if _, ok := got["IPTABLES_CMD"]; ok {
+		t.Error("enforce-redirect must not set IPTABLES_CMD by default (proxy-init auto-detects from /proc/modules)")
+	}
+}
+
+// IPTABLES_CMD is injected only when Proxy.IptablesCmd is configured, in both
+// modes, so the init script's /proc/modules auto-detection stays the default
+// and the backend override is strictly opt-in.
+func TestBuildProxyInitContainer_IptablesCmd(t *testing.T) {
+	modes := []ProxyInitMode{ProxyInitModeRedirect, ProxyInitModeEnforceRedirect}
+
+	// Default (empty): env var absent in both modes.
+	def := NewContainerBuilder(config.CompiledDefaults())
+	for _, mode := range modes {
+		for _, e := range def.BuildProxyInitContainer(mode, "", "").Env {
+			if e.Name == "IPTABLES_CMD" {
+				t.Errorf("mode %q: IPTABLES_CMD must be absent when unset, got %q", mode, e.Value)
+			}
+		}
+	}
+
+	// Configured: env var present with the configured value in both modes.
+	cfg := config.CompiledDefaults()
+	cfg.Proxy.IptablesCmd = "iptables"
+	b := NewContainerBuilder(cfg)
+	for _, mode := range modes {
+		found := false
+		for _, e := range b.BuildProxyInitContainer(mode, "", "").Env {
+			if e.Name == "IPTABLES_CMD" {
+				found = true
+				if e.Value != "iptables" {
+					t.Errorf("mode %q: IPTABLES_CMD = %q, want %q", mode, e.Value, "iptables")
+				}
+			}
+		}
+		if !found {
+			t.Errorf("mode %q: IPTABLES_CMD env not set when configured", mode)
+		}
+	}
 }
 
 // An unknown mode must fail closed: BuildProxyInitContainer returns a


### PR DESCRIPTION
## What

Exposes an optional, configurable iptables backend for the injected `proxy-init`
container. New `ProxyConfig.IptablesCmd` is injected as the `IPTABLES_CMD` env
var (both `redirect` and `enforce-redirect` modes), **omitted when empty**.

## Why

Companion to **kagenti/kagenti-extensions#518**, which switches `proxy-init`'s
`detect_iptables_cmd()` to a `/proc/modules` functional check (`iptable_nat`
loaded → legacy, as on Kind/kubeadm; absent → nft, as on OpenShift/ROSA) and
adds loud-fail on misprogram. That script change is self-sufficient — it
auto-detects correctly without operator input. This PR adds the **deterministic
per-platform override**: an operator/admin can pin the backend (e.g.
`iptables` on nft-only platforms) where auto-detection is wrong or undesired,
without rebuilding the image.

Default is empty, so behavior is unchanged unless explicitly set.

## Changes

- `config`: `ProxyConfig.IptablesCmd` (json/yaml tags), empty compiled default, logged in `logConfig`.
- `injector`: append `IPTABLES_CMD` env only when non-empty, after the mode switch (covers both modes); default injection unchanged.
- `chart`: `defaults.proxy.iptablesCmd: ""` in `values.yaml`, documented.
- `tests`: `IPTABLES_CMD` absent by default; present with the configured value in both modes.

## Testing

- `go build ./...`, `go vet ./internal/webhook/...`, `go test ./internal/webhook/{config,injector}/...` — all pass (incl. the new `TestBuildProxyInitContainer_IptablesCmd`).
- `gofmt` clean; `helm lint charts/kagenti-operator` passes.
- golangci-lint: no new findings in changed files. (Pre-existing findings in untouched `pod_mutator.go` / `volume_builder_test.go` are out of scope.)

## Notes

- This is **not** a ROSA enablement on its own — see extensions#518. On ROSA, selecting nft still hits the `container_t` → nf_tables SELinux denial; the SELinux/SCC track is separate (kagenti-extensions#502).
- A follow-up could auto-default this to `iptables` when the operator detects OpenShift (detection already exists in `internal/bootstrap/otel.go`), but it's intentionally left as an explicit knob here since the script auto-detects.

Refs kagenti/kagenti-extensions#518, kagenti/kagenti-extensions#502

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
