### PR TITLE
Fix: preserve explicitly-set authbridge-config keys per namespace (#433)

### DIFF
--- a/kagenti-operator/internal/controller/authbridgeconfig_controller.go
+++ b/kagenti-operator/internal/controller/authbridgeconfig_controller.go
@@ -111,7 +111,14 @@ func (r *AuthbridgeConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if cm.Data == nil {
 		cm.Data = make(map[string]string)
 	}
+	// Fill in defaults only for keys that are missing or empty; preserve any
+	// explicitly-set per-namespace value (e.g. KEYCLOAK_REALM). This ConfigMap
+	// is a namespace-defaults source (kagenti.io/defaults=true), so defaults
+	// must not clobber a value provided by an operator/admin/CI. See issue #433.
 	for k, v := range desired {
+		if existing, ok := cm.Data[k]; ok && existing != "" {
+			continue
+		}
 		cm.Data[k] = v
 	}
 	if updateErr := r.Update(ctx, cm); updateErr != nil {

--- a/kagenti-operator/internal/controller/authbridgeconfig_controller_test.go
+++ b/kagenti-operator/internal/controller/authbridgeconfig_controller_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const authbridgeConfigTestNamespace = "tx-e2e"
+
+// authbridgeTestPlatform returns a platform config whose default realm is the
+// platform-global "kagenti" — i.e. the value that would clobber a per-namespace
+// override if the reconciler overwrote existing keys.
+func authbridgeTestPlatform() AuthbridgeConfigPlatform {
+	return AuthbridgeConfigPlatform{
+		KeycloakAdminSecretNamespace: "keycloak",
+		KeycloakRealm:                "kagenti",
+		KeycloakPublicURL:            "https://keycloak.example",
+	}
+}
+
+func kagentiEnabledNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{labelKagentiEnabled: "true"},
+		},
+	}
+}
+
+func TestAuthbridgeConfigReconciler_Reconcile(t *testing.T) {
+	ctx := context.Background()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: authbridgeConfigTestNamespace}}
+
+	getCM := func(t *testing.T, c client.Client) *corev1.ConfigMap {
+		t.Helper()
+		cm := &corev1.ConfigMap{}
+		if err := c.Get(ctx, client.ObjectKey{Namespace: authbridgeConfigTestNamespace, Name: authbridgeConfigCM}, cm); err != nil {
+			t.Fatalf("get authbridge-config: %v", err)
+		}
+		return cm
+	}
+
+	cases := []struct {
+		name  string
+		objs  []client.Object
+		check func(t *testing.T, c client.Client)
+	}{
+		{
+			// Regression for #433: an explicitly-set per-namespace realm must
+			// survive reconciliation rather than being reset to the platform default.
+			name: "preserves explicitly-set KEYCLOAK_REALM on existing ConfigMap",
+			objs: []client.Object{
+				kagentiEnabledNamespace(authbridgeConfigTestNamespace),
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      authbridgeConfigCM,
+						Namespace: authbridgeConfigTestNamespace,
+					},
+					Data: map[string]string{
+						"KEYCLOAK_REALM":   "tx-e2e",
+						"KEYCLOAK_URL":     "https://keycloak.example",
+						"CLIENT_AUTH_TYPE": "client-secret",
+					},
+				},
+			},
+			check: func(t *testing.T, c client.Client) {
+				cm := getCM(t, c)
+				if got := cm.Data["KEYCLOAK_REALM"]; got != "tx-e2e" {
+					t.Fatalf("KEYCLOAK_REALM = %q, want %q (explicit per-namespace value must be preserved)", got, "tx-e2e")
+				}
+			},
+		},
+		{
+			name: "creates ConfigMap with platform defaults when none exists",
+			objs: []client.Object{
+				kagentiEnabledNamespace(authbridgeConfigTestNamespace),
+			},
+			check: func(t *testing.T, c client.Client) {
+				cm := getCM(t, c)
+				if got := cm.Data["KEYCLOAK_REALM"]; got != "kagenti" {
+					t.Fatalf("KEYCLOAK_REALM = %q, want platform default %q", got, "kagenti")
+				}
+				if got := cm.Data["KEYCLOAK_URL"]; got == "" {
+					t.Fatalf("KEYCLOAK_URL should be populated from platform defaults, got empty")
+				}
+				if cm.Labels["app.kubernetes.io/managed-by"] != "kagenti-operator" {
+					t.Fatalf("missing managed-by label, got %v", cm.Labels)
+				}
+				if cm.Labels[LabelNamespaceDefaults] != "true" {
+					t.Fatalf("missing %s label, got %v", LabelNamespaceDefaults, cm.Labels)
+				}
+			},
+		},
+		{
+			name: "fills missing/empty keys without overwriting present ones",
+			objs: []client.Object{
+				kagentiEnabledNamespace(authbridgeConfigTestNamespace),
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      authbridgeConfigCM,
+						Namespace: authbridgeConfigTestNamespace,
+					},
+					Data: map[string]string{
+						"KEYCLOAK_REALM":   "tx-e2e", // explicit, non-empty -> keep
+						"CLIENT_AUTH_TYPE": "",       // empty -> should be filled
+					},
+				},
+			},
+			check: func(t *testing.T, c client.Client) {
+				cm := getCM(t, c)
+				if got := cm.Data["KEYCLOAK_REALM"]; got != "tx-e2e" {
+					t.Fatalf("KEYCLOAK_REALM = %q, want %q (preserved)", got, "tx-e2e")
+				}
+				if got := cm.Data["KEYCLOAK_URL"]; got == "" {
+					t.Fatalf("KEYCLOAK_URL (missing key) should be filled with default, got empty")
+				}
+				if got := cm.Data["CLIENT_AUTH_TYPE"]; got != "client-secret" {
+					t.Fatalf("CLIENT_AUTH_TYPE = %q, want empty value filled with default %q", got, "client-secret")
+				}
+			},
+		},
+		{
+			name: "stamps ownership labels on an externally-created ConfigMap",
+			objs: []client.Object{
+				kagentiEnabledNamespace(authbridgeConfigTestNamespace),
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      authbridgeConfigCM,
+						Namespace: authbridgeConfigTestNamespace,
+					},
+					Data: map[string]string{"KEYCLOAK_REALM": "tx-e2e"},
+				},
+			},
+			check: func(t *testing.T, c client.Client) {
+				cm := getCM(t, c)
+				if cm.Labels["app.kubernetes.io/managed-by"] != "kagenti-operator" {
+					t.Fatalf("missing managed-by label, got %v", cm.Labels)
+				}
+				if cm.Labels[LabelNamespaceDefaults] != "true" {
+					t.Fatalf("missing %s label, got %v", LabelNamespaceDefaults, cm.Labels)
+				}
+			},
+		},
+		{
+			name: "skips namespace without kagenti-enabled label",
+			objs: []client.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: authbridgeConfigTestNamespace}},
+			},
+			check: func(t *testing.T, c client.Client) {
+				cm := &corev1.ConfigMap{}
+				err := c.Get(ctx, client.ObjectKey{Namespace: authbridgeConfigTestNamespace, Name: authbridgeConfigCM}, cm)
+				if err == nil {
+					t.Fatalf("expected no authbridge-config to be created for non-kagenti-enabled namespace")
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := clientRegistrationTestScheme(t)
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.objs...).Build()
+			r := &AuthbridgeConfigReconciler{
+				Client:   c,
+				Platform: authbridgeTestPlatform(),
+			}
+			if _, err := r.Reconcile(ctx, req); err != nil {
+				t.Fatalf("Reconcile: %v", err)
+			}
+			tc.check(t, c)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`AuthbridgeConfigReconciler` unconditionally overwrote every key of an existing `authbridge-config` ConfigMap with platform-global defaults on each reconcile, silently discarding any explicitly-set per-namespace value such as `KEYCLOAK_REALM`. A workload in a namespace using a non-default realm had its realm reset to `kagenti` within one reconcile cycle, so the client-registration controller registered the client in the wrong realm and `client_credentials` grants returned `invalid_client` (401). Regression introduced in `cdbed3b`.

Fixes #433.

## Root cause

In the update path of `authbridgeconfig_controller.go`:

```go
for k, v := range desired {
    cm.Data[k] = v   // clobbers KEYCLOAK_REALM (and every other key)
}
```

## Fix

`authbridge-config` is a **namespace-defaults** source (labeled `kagenti.io/defaults=true`, consumed by `defaults_config_reconciler.go` / `agentruntime_controller.go`), and `cdbed3b` introduced it purely as operator-driven *defaulting*. Defaults should fill gaps, not override explicit values. On the update path the reconciler now only fills keys that are **missing or empty**, preserving any existing non-empty value:

```go
for k, v := range desired {
    if existing, ok := cm.Data[k]; ok && existing != "" {
        continue // preserve explicitly-set per-namespace value
    }
    cm.Data[k] = v
}
```

Unchanged: the **create** path (a fresh `kagenti-enabled` namespace still receives full operator-provided defaults) and the ownership/defaults **label stamping**. So the `cdbed3b` defaulting behavior is preserved for namespaces that have no config yet.

## Tests

The controller previously had **no test**. Adds `authbridgeconfig_controller_test.go` (plain `testing` + fake client, matching `clientregistration_controller_test.go`) covering:

| Case | Asserts |
|------|---------|
| Per-namespace realm preserved | existing `KEYCLOAK_REALM=tx-e2e` survives reconcile (the regression) |
| Create path | no CM → created with full platform defaults + labels |
| Missing/empty-key fill | present non-empty key kept; missing & empty keys filled from defaults |
| Label stamping | externally-created CM gets `managed-by` + `kagenti.io/defaults` |
| Skip | non-`kagenti-enabled` namespace → no CM created |

The first two/three cases were written failing first (clobber reproduced), then made green by the fix.

```
ok  github.com/kagenti/operator/internal/controller  (5/5 subtests pass)
```

`gofmt`, `go vet`, and `go build ./...` clean.

## Cross-refs

- Interim mitigation in kagenti made the token-exchange E2E step non-fatal (kagenti/kagenti #1982); this PR restores the underlying behavior so that suite can go green again.

_Assisted-By: Claude Code_
