### PR TITLE
Feat: add Kuadrant operand controller

### DIFF
--- a/charts/kagenti-operator/templates/manager/manager.yaml
+++ b/charts/kagenti-operator/templates/manager/manager.yaml
@@ -31,6 +31,9 @@ spec:
             {{- range .Values.controllerManager.container.args }}
             - {{ . }}
             {{- end }}
+            {{- if .Values.kuadrant.enable }}
+            - "--enable-kuadrant=true"
+            {{- end }}
             {{- if .Values.mlflow.enable }}
             - "--enable-mlflow=true"
             {{- end }}

--- a/charts/kagenti-operator/templates/rbac/role.yaml
+++ b/charts/kagenti-operator/templates/rbac/role.yaml
@@ -23,6 +23,7 @@ rules:
   - namespaces
   - services
   verbs:
+  - create
   - get
   - list
   - watch
@@ -142,6 +143,17 @@ rules:
   - statefulsets/finalizers
   verbs:
   - update
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - kuadrants
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - discovery.k8s.io
   resources:

--- a/charts/kagenti-operator/templates/rbac/role.yaml
+++ b/charts/kagenti-operator/templates/rbac/role.yaml
@@ -20,12 +20,20 @@ rules:
   - ""
   resources:
   - endpoints
-  - namespaces
   - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
   verbs:
   - create
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - ""

--- a/charts/kagenti-operator/values.yaml
+++ b/charts/kagenti-operator/values.yaml
@@ -110,6 +110,13 @@ authbridgeConfig:
   # How long AuthBridge waits for Keycloak credentials (increase for slow Keycloak startup)
   # credentialWaitTimeout: "120s"
 
+# [KUADRANT]: Kuadrant operand controller — reconciles Kuadrant CR in kuadrant-system.
+# When enabled, the operator creates and drift-reconciles the Kuadrant CR that
+# setup-kagenti.sh currently applies manually. Requires the Kuadrant CRD to be
+# installed (controller is a no-op otherwise).
+kuadrant:
+  enable: false
+
 # [MLFLOW]: MLflow experiment tracking integration
 mlflow:
   enable: false

--- a/kagenti-operator/cmd/main.go
+++ b/kagenti-operator/cmd/main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/kagenti/operator/internal/controller"
 	"github.com/kagenti/operator/internal/discovery"
 	"github.com/kagenti/operator/internal/keycloak"
+	"github.com/kagenti/operator/internal/kuadrant"
 	"github.com/kagenti/operator/internal/mlflow"
 	"github.com/kagenti/operator/internal/signature"
 	"github.com/kagenti/operator/internal/tekton"
@@ -72,6 +73,7 @@ func init() {
 	utilruntime.Must(agentv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(mlflow.AddToScheme(scheme))
 	utilruntime.Must(tekton.AddToScheme(scheme))
+	utilruntime.Must(kuadrant.AddToScheme(scheme))
 	utilruntime.Must(cmv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
@@ -111,6 +113,7 @@ func main() {
 	var mlflowWorkspace string
 	var mlflowExperimentName string
 	var mlflowCAFile string
+	var enableKuadrant bool
 
 	var enableCardDiscovery bool
 
@@ -170,6 +173,8 @@ func main() {
 		"MLflow experiment name; created automatically if it doesn't exist")
 	flag.StringVar(&mlflowCAFile, "mlflow-ca-file", "",
 		"Path to PEM-encoded CA bundle for MLflow TLS verification (appended to system pool)")
+	flag.BoolVar(&enableKuadrant, "enable-kuadrant", false,
+		"Enable Kuadrant operand controller (reconciles Kuadrant CR in kuadrant-system)")
 
 	flag.BoolVar(&enableCardDiscovery, "enable-card-discovery", true,
 		"Enable automatic agent card discovery from AgentRuntime workloads into status.card (set to false to disable)")
@@ -703,6 +708,18 @@ func main() {
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "TektonConfig")
 			os.Exit(1)
+		}
+	}
+
+	if enableKuadrant {
+		if controller.KuadrantCRDExists(mgr.GetConfig()) {
+			if err = (&controller.KuadrantReconciler{
+				Client: mgr.GetClient(),
+			}).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create controller", "controller", "Kuadrant")
+				os.Exit(1)
+			}
+			setupLog.Info("Kuadrant operand controller enabled")
 		}
 	}
 

--- a/kagenti-operator/cmd/main.go
+++ b/kagenti-operator/cmd/main.go
@@ -720,6 +720,8 @@ func main() {
 				os.Exit(1)
 			}
 			setupLog.Info("Kuadrant operand controller enabled")
+		} else {
+			setupLog.Info("Kuadrant enabled but CRD not found; controller not started")
 		}
 	}
 

--- a/kagenti-operator/config/rbac/role.yaml
+++ b/kagenti-operator/config/rbac/role.yaml
@@ -22,6 +22,7 @@ rules:
   resources:
   - namespaces
   verbs:
+  - create
   - get
   - list
   - patch
@@ -90,22 +91,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - agent.kagenti.dev
-  resources:
-  - authorizationpolicies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - agent.kagenti.dev
-  resources:
-  - authorizationpolicies/status
-  verbs:
-  - get
-  - update
-  - patch
-- apiGroups:
   - agents.x-k8s.io
   resources:
   - sandboxes
@@ -172,6 +157,17 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - kuadrants
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - mlflow.kubeflow.org

--- a/kagenti-operator/internal/controller/kuadrant_controller.go
+++ b/kagenti-operator/internal/controller/kuadrant_controller.go
@@ -143,6 +143,8 @@ type kuadrantBootstrap struct {
 	reconciler *KuadrantReconciler
 }
 
+func (b *kuadrantBootstrap) NeedLeaderElection() bool { return true }
+
 func (b *kuadrantBootstrap) Start(ctx context.Context) error {
 	kuadrantLogger.Info("Bootstrap: triggering initial Kuadrant reconcile")
 	req := ctrl.Request{

--- a/kagenti-operator/internal/controller/kuadrant_controller.go
+++ b/kagenti-operator/internal/controller/kuadrant_controller.go
@@ -145,15 +145,28 @@ type kuadrantBootstrap struct {
 
 func (b *kuadrantBootstrap) Start(ctx context.Context) error {
 	kuadrantLogger.Info("Bootstrap: triggering initial Kuadrant reconcile")
-	_, err := b.reconciler.Reconcile(ctx, ctrl.Request{
+	req := ctrl.Request{
 		NamespacedName: types.NamespacedName{
 			Name:      kuadrantCRName,
 			Namespace: kuadrantNamespace,
 		},
-	})
-	if err != nil {
-		kuadrantLogger.Error(err, "Bootstrap reconcile failed — controller watch will retry on next event")
 	}
+
+	const maxAttempts = 5
+	for attempt := range maxAttempts {
+		_, err := b.reconciler.Reconcile(ctx, req)
+		if err == nil {
+			return nil
+		}
+		kuadrantLogger.Error(err, "Bootstrap reconcile attempt failed", "attempt", attempt+1, "maxAttempts", maxAttempts)
+		delay := time.Duration(attempt+1) * 5 * time.Second
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(delay):
+		}
+	}
+	kuadrantLogger.Info("Bootstrap reconcile exhausted retries — CR will be created on the next watch event or operator restart")
 	return nil
 }
 

--- a/kagenti-operator/internal/controller/kuadrant_controller.go
+++ b/kagenti-operator/internal/controller/kuadrant_controller.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/kagenti/operator/internal/kuadrant"
+)
+
+const (
+	kuadrantNamespace = "kuadrant-system"
+	kuadrantCRName    = "kuadrant"
+)
+
+var kuadrantLogger = ctrl.Log.WithName("controller").WithName("Kuadrant")
+
+// KuadrantReconciler ensures a Kuadrant CR exists in kuadrant-system.
+// It replaces the manual `kubectl apply` in setup-kagenti.sh, providing
+// drift reconciliation and idempotent creation.
+type KuadrantReconciler struct {
+	client.Client
+}
+
+// +kubebuilder:rbac:groups=kuadrant.io,resources=kuadrants,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create
+
+func (r *KuadrantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.V(1).Info("Reconciling Kuadrant", "name", req.Name, "namespace", req.Namespace)
+
+	// Ensure kuadrant-system namespace exists.
+	ns := &corev1.Namespace{}
+	if err := r.Get(ctx, types.NamespacedName{Name: kuadrantNamespace}, ns); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: kuadrantNamespace,
+			},
+		}
+		if err := r.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+			logger.Error(err, "Failed to create kuadrant-system namespace")
+			return ctrl.Result{}, err
+		}
+		logger.Info("Created kuadrant-system namespace")
+	}
+
+	// Get or create the Kuadrant CR.
+	kq := &kuadrant.Kuadrant{}
+	err := r.Get(ctx, types.NamespacedName{Name: kuadrantCRName, Namespace: kuadrantNamespace}, kq)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+
+		kq = &kuadrant.Kuadrant{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "kuadrant.io/v1beta1",
+				Kind:       "Kuadrant",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kuadrantCRName,
+				Namespace: kuadrantNamespace,
+				Labels: map[string]string{
+					LabelManagedBy: LabelManagedByValue,
+				},
+			},
+		}
+		if err := r.Create(ctx, kq); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				logger.V(1).Info("Kuadrant CR already exists (concurrent create)")
+				return ctrl.Result{}, nil
+			}
+			logger.Error(err, "Failed to create Kuadrant CR")
+			return ctrl.Result{}, err
+		}
+		logger.Info("Created Kuadrant CR", "namespace", kuadrantNamespace, "name", kuadrantCRName)
+		return ctrl.Result{}, nil
+	}
+
+	// CR exists — ensure our managed-by label is present for drift detection.
+	if kq.Labels == nil || kq.Labels[LabelManagedBy] != LabelManagedByValue {
+		patch := kq.DeepCopy()
+		if patch.Labels == nil {
+			patch.Labels = make(map[string]string)
+		}
+		patch.Labels[LabelManagedBy] = LabelManagedByValue
+		if err := r.Patch(ctx, patch, client.MergeFrom(kq)); err != nil {
+			logger.Error(err, "Failed to patch Kuadrant CR labels")
+			return ctrl.Result{}, err
+		}
+		logger.Info("Patched Kuadrant CR with managed-by label")
+	}
+
+	logger.V(1).Info("Kuadrant CR is present and correct")
+	return ctrl.Result{}, nil
+}
+
+func (r *KuadrantReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&kuadrant.Kuadrant{}).
+		Named("Kuadrant").
+		Complete(r)
+}
+
+// KuadrantCRDExists checks whether the kuadrant.io/v1beta1 Kuadrant CRD is
+// registered on the cluster. Returns false if the CRD is not installed,
+// making the controller a no-op.
+func KuadrantCRDExists(cfg *rest.Config) bool {
+	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		kuadrantLogger.Error(err, "Failed to create discovery client for Kuadrant check - controller will not start")
+		return false
+	}
+
+	for attempt := range 3 {
+		if attempt > 0 {
+			delay := time.Duration(attempt) * 5 * time.Second
+			kuadrantLogger.Info("Retrying Kuadrant CRD discovery", "attempt", attempt+1, "delay", delay)
+			time.Sleep(delay)
+		}
+
+		resources, err := dc.ServerResourcesForGroupVersion("kuadrant.io/v1beta1")
+		if err != nil {
+			kuadrantLogger.Info("Kuadrant CRD not found", "attempt", attempt+1, "error", err)
+			continue
+		}
+
+		for _, r := range resources.APIResources {
+			if r.Kind == "Kuadrant" {
+				kuadrantLogger.Info("Kuadrant CRD detected: will manage Kuadrant operand CR")
+				return true
+			}
+		}
+
+		kuadrantLogger.Info("kuadrant.io/v1beta1 group exists but Kuadrant kind not found")
+		return false
+	}
+
+	kuadrantLogger.Info("Kuadrant CRD not found after retries: Kuadrant operator not installed")
+	return false
+}

--- a/kagenti-operator/internal/controller/kuadrant_controller.go
+++ b/kagenti-operator/internal/controller/kuadrant_controller.go
@@ -124,10 +124,37 @@ func (r *KuadrantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 }
 
 func (r *KuadrantReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&kuadrant.Kuadrant{}).
 		Named("Kuadrant").
-		Complete(r)
+		Complete(r); err != nil {
+		return err
+	}
+
+	// Bootstrap: the For() watch only fires on existing CR events, so we
+	// need an initial reconcile to create the CR when none exists yet.
+	return mgr.Add(&kuadrantBootstrap{reconciler: r})
+}
+
+// kuadrantBootstrap is a manager.Runnable that triggers one reconcile after
+// the manager cache is synced, ensuring the Kuadrant CR is created on first
+// startup even when no CR exists to generate watch events.
+type kuadrantBootstrap struct {
+	reconciler *KuadrantReconciler
+}
+
+func (b *kuadrantBootstrap) Start(ctx context.Context) error {
+	kuadrantLogger.Info("Bootstrap: triggering initial Kuadrant reconcile")
+	_, err := b.reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      kuadrantCRName,
+			Namespace: kuadrantNamespace,
+		},
+	})
+	if err != nil {
+		kuadrantLogger.Error(err, "Bootstrap reconcile failed — controller watch will retry on next event")
+	}
+	return nil
 }
 
 // KuadrantCRDExists checks whether the kuadrant.io/v1beta1 Kuadrant CRD is

--- a/kagenti-operator/internal/controller/kuadrant_controller_test.go
+++ b/kagenti-operator/internal/controller/kuadrant_controller_test.go
@@ -176,20 +176,8 @@ var _ = Describe("KuadrantReconciler", func() {
 		Expect(after.ResourceVersion).To(Equal(rvBefore))
 	})
 
-	It("should handle not-found gracefully (CRD exists but no CR event)", func() {
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(scheme).
-			Build()
-
-		reconciler = &KuadrantReconciler{Client: fakeClient}
-
-		result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      kuadrantCRName,
-				Namespace: kuadrantNamespace,
-			},
-		})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(ctrl.Result{}))
+	It("should require leader election for the bootstrap runnable", func() {
+		b := &kuadrantBootstrap{reconciler: &KuadrantReconciler{}}
+		Expect(b.NeedLeaderElection()).To(BeTrue())
 	})
 })

--- a/kagenti-operator/internal/controller/kuadrant_controller_test.go
+++ b/kagenti-operator/internal/controller/kuadrant_controller_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kagenti/operator/internal/kuadrant"
+)
+
+var _ = Describe("KuadrantReconciler", func() {
+	var (
+		reconciler *KuadrantReconciler
+		scheme     *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(kuadrant.AddToScheme(scheme)).To(Succeed())
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	It("should create namespace and Kuadrant CR when neither exists", func() {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
+
+		reconciler = &KuadrantReconciler{Client: fakeClient}
+
+		result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      kuadrantCRName,
+				Namespace: kuadrantNamespace,
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}))
+
+		ns := &corev1.Namespace{}
+		Expect(fakeClient.Get(context.Background(),
+			types.NamespacedName{Name: kuadrantNamespace}, ns)).To(Succeed())
+
+		kq := &kuadrant.Kuadrant{}
+		Expect(fakeClient.Get(context.Background(),
+			types.NamespacedName{Name: kuadrantCRName, Namespace: kuadrantNamespace}, kq)).To(Succeed())
+		Expect(kq.Labels[LabelManagedBy]).To(Equal(LabelManagedByValue))
+	})
+
+	It("should create Kuadrant CR when namespace exists but CR does not", func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: kuadrantNamespace},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(ns).
+			Build()
+
+		reconciler = &KuadrantReconciler{Client: fakeClient}
+
+		result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      kuadrantCRName,
+				Namespace: kuadrantNamespace,
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}))
+
+		kq := &kuadrant.Kuadrant{}
+		Expect(fakeClient.Get(context.Background(),
+			types.NamespacedName{Name: kuadrantCRName, Namespace: kuadrantNamespace}, kq)).To(Succeed())
+		Expect(kq.Labels[LabelManagedBy]).To(Equal(LabelManagedByValue))
+	})
+
+	It("should add managed-by label when CR exists without it", func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: kuadrantNamespace},
+		}
+		kq := &kuadrant.Kuadrant{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "kuadrant.io/v1beta1",
+				Kind:       "Kuadrant",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kuadrantCRName,
+				Namespace: kuadrantNamespace,
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(ns, kq).
+			Build()
+
+		reconciler = &KuadrantReconciler{Client: fakeClient}
+
+		result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      kuadrantCRName,
+				Namespace: kuadrantNamespace,
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}))
+
+		patched := &kuadrant.Kuadrant{}
+		Expect(fakeClient.Get(context.Background(),
+			types.NamespacedName{Name: kuadrantCRName, Namespace: kuadrantNamespace}, patched)).To(Succeed())
+		Expect(patched.Labels[LabelManagedBy]).To(Equal(LabelManagedByValue))
+	})
+
+	It("should be a no-op when CR exists with correct labels", func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: kuadrantNamespace},
+		}
+		kq := &kuadrant.Kuadrant{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "kuadrant.io/v1beta1",
+				Kind:       "Kuadrant",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kuadrantCRName,
+				Namespace: kuadrantNamespace,
+				Labels: map[string]string{
+					LabelManagedBy: LabelManagedByValue,
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(ns, kq).
+			Build()
+
+		reconciler = &KuadrantReconciler{Client: fakeClient}
+
+		before := &kuadrant.Kuadrant{}
+		Expect(fakeClient.Get(context.Background(),
+			types.NamespacedName{Name: kuadrantCRName, Namespace: kuadrantNamespace}, before)).To(Succeed())
+		rvBefore := before.ResourceVersion
+
+		result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      kuadrantCRName,
+				Namespace: kuadrantNamespace,
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}))
+
+		after := &kuadrant.Kuadrant{}
+		Expect(fakeClient.Get(context.Background(),
+			types.NamespacedName{Name: kuadrantCRName, Namespace: kuadrantNamespace}, after)).To(Succeed())
+		Expect(after.ResourceVersion).To(Equal(rvBefore))
+	})
+
+	It("should handle not-found gracefully (CRD exists but no CR event)", func() {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
+
+		reconciler = &KuadrantReconciler{Client: fakeClient}
+
+		result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      kuadrantCRName,
+				Namespace: kuadrantNamespace,
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}))
+	})
+})

--- a/kagenti-operator/internal/kuadrant/types.go
+++ b/kagenti-operator/internal/kuadrant/types.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kuadrant defines a local subset of the Kuadrant API
+// (kuadrant.io/v1beta1) used by the Kuadrant operand controller.
+// These types are intentionally minimal to avoid importing the full
+// Kuadrant operator SDK. Only metadata is modeled because the setup
+// script creates a bare Kuadrant CR with no spec fields.
+package kuadrant
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	SchemeGroupVersion = schema.GroupVersion{Group: "kuadrant.io", Version: "v1beta1"}
+
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+
+	AddToScheme = SchemeBuilder.AddToScheme
+)
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&Kuadrant{},
+		&KuadrantList{},
+	)
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}
+
+// Kuadrant is a minimal representation of the kuadrant.io/v1beta1 Kuadrant CR.
+// The setup script creates this with no spec — just metadata in kuadrant-system.
+type Kuadrant struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}
+
+type KuadrantList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []Kuadrant `json:"items"`
+}
+
+func (in *Kuadrant) DeepCopyObject() runtime.Object {
+	return in.DeepCopy()
+}
+
+func (in *Kuadrant) DeepCopy() *Kuadrant {
+	if in == nil {
+		return nil
+	}
+	out := new(Kuadrant)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *Kuadrant) DeepCopyInto(out *Kuadrant) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+}
+
+func (in *KuadrantList) DeepCopyObject() runtime.Object {
+	return in.DeepCopy()
+}
+
+func (in *KuadrantList) DeepCopy() *KuadrantList {
+	if in == nil {
+		return nil
+	}
+	out := new(KuadrantList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *KuadrantList) DeepCopyInto(out *KuadrantList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		out.Items = make([]Kuadrant, len(in.Items))
+		for i := range in.Items {
+			in.Items[i].DeepCopyInto(&out.Items[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new operand controller to the kagenti-operator that reconciles a Kuadrant CR in `kuadrant-system`. This replaces the manual `kubectl apply` step in the setup scripts, providing idempotent creation and drift reconciliation.

## Changes

- `internal/controller/kuadrant_controller.go` — new `KuadrantReconciler` that ensures the `kuadrant-system` namespace and a bare Kuadrant CR exist, with `managed-by` label for drift detection. Includes a bootstrap `Runnable` to trigger initial reconcile (the `For()` watch alone cannot fire when no CR exists yet).
- `internal/controller/kuadrant_controller_test.go` — unit tests covering creation, label patching, no-op, and not-found scenarios
- `internal/kuadrant/types.go` — minimal Go types for `kuadrant.io/v1beta1` to avoid importing the full Kuadrant SDK
- `cmd/main.go` — conditional controller registration gated on `--enable-kuadrant` flag and `KuadrantCRDExists()` discovery check
- `charts/kagenti-operator/values.yaml` + `templates/manager/manager.yaml` — Helm values and template for the `kuadrant.enable` feature gate

## Test Plan

- [x] Deploy with Kuadrant CRD present and `--enable-kuadrant=true` — operator creates CR, Kuadrant operator reconciles to Ready
- [x] Verify `managed-by: kagenti-operator` label on created CR
- [x] Deploy without Kuadrant CRD and flag unset — operator starts cleanly, no Kuadrant activity
- [ ] Unit tests pass (`make test`)