### PR TITLE
Fix: add retry logic to metrics E2E curl pod to prevent flaky timeouts

### DIFF
--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -214,7 +214,7 @@ var _ = Describe("Manager", Ordered, func() {
 								"name": "curl",
 								"image": "curlimages/curl:latest",
 								"command": ["/bin/sh", "-c"],
-								"args": ["curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics"],
+								"args": ["for i in 1 2 3 4 5; do curl -v -k --connect-timeout 15 --max-time 30 -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics && exit 0; echo \"Attempt $i failed, retrying in 5s...\"; sleep 5; done; exit 1"],
 								"securityContext": {
 									"allowPrivilegeEscalation": false,
 									"capabilities": {

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -203,6 +203,18 @@ var _ = Describe("Manager", Ordered, func() {
 			Eventually(verifyWebhookEndpointReady).Should(Succeed())
 
 			By("creating the curl-metrics pod to access the metrics endpoint")
+			metricsURL := fmt.Sprintf(
+				"https://%s.%s.svc.cluster.local:8443/metrics",
+				metricsServiceName, namespace,
+			)
+			curlCmd := fmt.Sprintf(
+				"for i in 1 2 3 4 5; do "+
+					"curl -v -k --connect-timeout 15 --max-time 30 "+
+					"-H 'Authorization: Bearer %s' %s "+
+					"&& exit 0; echo \"Attempt $i failed, retrying in 5s...\"; "+
+					"sleep 5; done; exit 1",
+				token, metricsURL,
+			)
 			Eventually(func() error {
 				cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
 					"--namespace", namespace,
@@ -214,7 +226,7 @@ var _ = Describe("Manager", Ordered, func() {
 								"name": "curl",
 								"image": "curlimages/curl:latest",
 								"command": ["/bin/sh", "-c"],
-								"args": ["for i in 1 2 3 4 5; do curl -v -k --connect-timeout 15 --max-time 30 -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics && exit 0; echo \"Attempt $i failed, retrying in 5s...\"; sleep 5; done; exit 1"],
+								"args": [%q],
 								"securityContext": {
 									"allowPrivilegeEscalation": false,
 									"capabilities": {
@@ -229,7 +241,7 @@ var _ = Describe("Manager", Ordered, func() {
 							}],
 							"serviceAccountName": "%s"
 						}
-					}`, token, metricsServiceName, namespace, serviceAccountName))
+					}`, curlCmd, serviceAccountName))
 				_, runErr := utils.Run(cmd)
 				if runErr != nil && strings.Contains(runErr.Error(), "already exists") {
 					return nil

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -209,7 +209,7 @@ var _ = Describe("Manager", Ordered, func() {
 			)
 			curlCmd := fmt.Sprintf(
 				"for i in 1 2 3 4 5; do "+
-					"curl -v -k --connect-timeout 15 --max-time 30 "+
+					"curl -v -f -k --connect-timeout 15 --max-time 30 "+
 					"-H 'Authorization: Bearer %s' %s "+
 					"&& exit 0; echo \"Attempt $i failed, retrying in 5s...\"; "+
 					"sleep 5; done; exit 1",
@@ -258,7 +258,7 @@ var _ = Describe("Manager", Ordered, func() {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(output).To(Equal("Succeeded"), "curl pod in wrong status")
 			}
-			Eventually(verifyCurlUp, 5*time.Minute).Should(Succeed())
+			Eventually(verifyCurlUp, 3*time.Minute).Should(Succeed())
 
 			By("getting the metrics by checking curl-metrics logs")
 			metricsOutput := getMetricsOutput()


### PR DESCRIPTION
## Summary
- The `curl-metrics` pod in the metrics E2E test had no connect timeout or retry logic
- A single TCP timeout from delayed KinD service routing caused the pod to fail, then the test polled for 5 minutes before giving up
- Added a retry loop (5 attempts, `--connect-timeout 15`, `--max-time 30`, 5s sleep between) so transient networking delays in KinD are handled gracefully

## Test plan
- [x] CI E2E tests pass (metrics test specifically)
- [x] Verify retry loop handles transient connection failures in KinD
- [x] Confirm no regression in other E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)