### PR TITLE
Fix: add list/watch RBAC verbs for ServiceAccounts 

### DIFF
--- a/charts/kagenti-operator/templates/rbac/role.yaml
+++ b/charts/kagenti-operator/templates/rbac/role.yaml
@@ -62,7 +62,9 @@ rules:
   verbs:
   - create
   - get
+  - list
   - update
+  - watch
 - apiGroups:
   - cert-manager.io
   resources:

--- a/kagenti-operator/config/rbac/role.yaml
+++ b/kagenti-operator/config/rbac/role.yaml
@@ -54,7 +54,9 @@ rules:
   verbs:
   - create
   - get
+  - list
   - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -96,6 +96,7 @@ func NewPodMutator(
 }
 
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=create;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=create;get;list;update;watch
 
 // InjectAuthBridge evaluates the multi-layer precedence chain and conditionally injects sidecars.
 //


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary
The Helm chart's ClusterRole (`kagenti-manager-role`) only grants `create`, `get`, `update` for ServiceAccounts,
  missing `list` and `watch`. The webhook's `ensureServiceAccount` uses controller-runtime's cached client, which
  requires `list` + `watch` for its informer cache. Without them, the informer can't sync, `Get` calls hang until
  timeout, and pod creation is rejected.

  Changes:
  - Added `list` and `watch` verbs to ServiceAccount RBAC rule in Helm chart
  (`charts/kagenti-operator/templates/rbac/role.yaml`)
  - Same change in kustomize config (`kagenti-operator/config/rbac/role.yaml`)
  - Added kubebuilder RBAC marker for ServiceAccounts in `pod_mutator.go`

## Related issue(s)
https://github.com/kagenti/kagenti-operator/issues/426

## (Optional) Testing Instructions
Deploy the operator to a Kind cluster via Helm and verify that pods with SPIRE-enabled agents can be created without
  RBAC errors in the operator logs.

Fixes #426 