### PR TITLE
CI: Increase E2E test timeout from 30m to 45m

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,7 @@ jobs:
   test-e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6

--- a/kagenti-operator/Makefile
+++ b/kagenti-operator/Makefile
@@ -112,7 +112,7 @@ test-e2e: manifests generate fmt vet ## Run the e2e tests. Expected an isolated 
 		echo "No Kind cluster is running. Please start a Kind cluster before running the e2e tests."; \
 		exit 1; \
 	}
-	go test ./test/e2e/ -v -ginkgo.v -timeout 30m
+	go test ./test/e2e/ -v -ginkgo.v -timeout 45m
 
 .PHONY: test-integration
 test-integration: manifests generate fmt vet ## Run integration tests (requires Kind cluster)


### PR DESCRIPTION
The E2E suite has grown to 41 specs across 8 Describe blocks with per-block controller redeploys. The 30-minute Go test timeout is no longer sufficient on CI runners. Bump to 45m and add a 75-minute job-level timeout as a safety net.

## Summary

- Increase Go test timeout from `30m` to `45m` in `kagenti-operator/Makefile`
- Add `timeout-minutes: 75` to the `test-e2e` job in `.github/workflows/ci.yaml` as a safety net to prevent runaway jobs

## Related issue(s)

Fixes #445

## (Optional) Testing Instructions

1. Open any PR against `main` and verify the E2E Tests job no longer times out at 30 minutes
2. Verify the job-level timeout of 75 minutes appears in the Actions UI