### PR TITLE
Feat: Support Sandbox workloads in AuthBridge owner resolution + ConfigMap GC

### DIFF
--- a/kagenti-operator/internal/controller/agentruntime_controller.go
+++ b/kagenti-operator/internal/controller/agentruntime_controller.go
@@ -1331,6 +1331,12 @@ func newRuntimePodTemplateAccessor(kind string) (*runtimePodTemplateAccessor, bo
 				u := o.(*unstructured.Unstructured)
 				_ = unstructured.SetNestedStringMap(u.Object, a, "spec", "podTemplate", "metadata", "annotations")
 			},
+			// getPodSpec is not implemented for Sandbox: extracting a typed
+			// *corev1.PodSpec out of the unstructured podTemplate isn't needed
+			// today (the only former caller, OCI skill mounting, was removed).
+			// Return nil rather than leaving the func nil so a future caller hits
+			// a nil-check, not a nil-function-call panic.
+			getPodSpec: func(client.Object) *corev1.PodSpec { return nil },
 		}, true
 	default:
 		return nil, false

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -27,6 +27,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	applyconfigscorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	applyconfigsmetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1187,9 +1189,32 @@ func (m *PodMutator) buildOwnerReference(ctx context.Context, namespace, crName 
 			WithBlockOwnerDeletion(true)
 	}
 
+	// Try Sandbox (agents.x-k8s.io). The Sandbox CR name == the workload name,
+	// so the per-agent ConfigMap is garbage-collected with the Sandbox, matching
+	// Deployment/StatefulSet behavior.
+	sandbox := &unstructured.Unstructured{}
+	sandbox.SetGroupVersionKind(sandboxOwnerGVK)
+	if err := m.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: crName}, sandbox); err == nil {
+		return applyconfigsmetav1.OwnerReference().
+			WithAPIVersion(sandboxOwnerGVK.GroupVersion().String()).
+			WithKind(sandboxOwnerGVK.Kind).
+			WithName(sandbox.GetName()).
+			WithUID(sandbox.GetUID()).
+			WithController(true).
+			WithBlockOwnerDeletion(true)
+	}
+
 	mutatorLog.V(1).Info("Could not find owner workload for per-agent ConfigMap, skipping OwnerReference",
 		"namespace", namespace, "crName", crName)
 	return nil
+}
+
+// sandboxOwnerGVK is the agent-sandbox CR GVK used to look up the owning Sandbox
+// for per-agent ConfigMap garbage collection. Mirrors the controller's sandboxGVK.
+var sandboxOwnerGVK = schema.GroupVersionKind{
+	Group:   "agents.x-k8s.io",
+	Version: "v1alpha1",
+	Kind:    "Sandbox",
 }
 
 func containerExists(containers []corev1.Container, name string) bool {

--- a/kagenti-operator/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator.go
@@ -1156,8 +1156,8 @@ func (m *PodMutator) ensurePerAgentEnvoyConfigMap(
 	return cmName, nil
 }
 
-// buildOwnerReference looks up the Deployment or StatefulSet that owns the
-// pod being created and returns an OwnerReference apply configuration.
+// buildOwnerReference looks up the Deployment, StatefulSet, or Sandbox that
+// owns the pod being created and returns an OwnerReference apply configuration.
 // Returns nil if the workload cannot be found (best-effort).
 func (m *PodMutator) buildOwnerReference(ctx context.Context, namespace, crName string) *applyconfigsmetav1.OwnerReferenceApplyConfiguration {
 	// Uses the cached client (not APIReader) because Deployments/StatefulSets
@@ -1192,6 +1192,12 @@ func (m *PodMutator) buildOwnerReference(ctx context.Context, namespace, crName 
 	// Try Sandbox (agents.x-k8s.io). The Sandbox CR name == the workload name,
 	// so the per-agent ConfigMap is garbage-collected with the Sandbox, matching
 	// Deployment/StatefulSet behavior.
+	//
+	// This relies on the shared manager cache having a warm Sandbox informer,
+	// which the AgentRuntime controller keeps populated. If the webhook is ever
+	// split into its own cache/process, this Get may miss until that cache syncs;
+	// it degrades gracefully (any error → nil → no OwnerReference, the pre-Sandbox
+	// behavior), so it never blocks injection.
 	sandbox := &unstructured.Unstructured{}
 	sandbox.SetGroupVersionKind(sandboxOwnerGVK)
 	if err := m.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: crName}, sandbox); err == nil {

--- a/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
+++ b/kagenti-operator/internal/webhook/injector/pod_mutator_test.go
@@ -25,6 +25,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1624,6 +1625,47 @@ func TestEnsurePerAgentConfigMap_OwnerReference_SetFromStatefulSet(t *testing.T)
 	ref := cm.OwnerReferences[0]
 	if ref.Kind != "StatefulSet" || ref.Name != "my-stateful-agent" || ref.UID != "sts-uid-456" {
 		t.Errorf("OwnerReference = %+v, want StatefulSet/my-stateful-agent/sts-uid-456", ref)
+	}
+}
+
+func TestEnsurePerAgentConfigMap_OwnerReference_SetFromSandbox(t *testing.T) {
+	// Sandbox is an agents.x-k8s.io CR (unstructured). The per-agent ConfigMap
+	// should be owned by it so it's garbage-collected with the Sandbox, matching
+	// the Deployment/StatefulSet behavior.
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = agentv1alpha1.AddToScheme(scheme)
+	scheme.AddKnownTypeWithName(sandboxOwnerGVK, &unstructured.Unstructured{})
+
+	sandbox := &unstructured.Unstructured{}
+	sandbox.SetGroupVersionKind(sandboxOwnerGVK)
+	sandbox.SetNamespace("team1")
+	sandbox.SetName("my-sandbox-agent")
+	sandbox.SetUID(types.UID("sandbox-uid-789"))
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sandbox).Build()
+	m := &PodMutator{
+		Client:            fakeClient,
+		APIReader:         fakeClient,
+		GetPlatformConfig: config.CompiledDefaults,
+		GetFeatureGates:   config.DefaultFeatureGates,
+	}
+	ctx := context.Background()
+
+	cmName, err := m.ensurePerAgentConfigMap(ctx, "team1", "my-sandbox-agent",
+		ModeEnvoySidecar, "", &NamespaceConfig{ClientAuthType: "client-secret"}, nil, "", nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cm := fetchConfigMap(t, m, "team1", cmName)
+	if len(cm.OwnerReferences) == 0 {
+		t.Fatal("expected OwnerReference on ConfigMap")
+	}
+	ref := cm.OwnerReferences[0]
+	if ref.Kind != "Sandbox" || ref.Name != "my-sandbox-agent" || ref.UID != "sandbox-uid-789" {
+		t.Errorf("OwnerReference = %+v, want Sandbox/my-sandbox-agent/sandbox-uid-789", ref)
 	}
 }
 

--- a/kagenti-operator/internal/workload/owner.go
+++ b/kagenti-operator/internal/workload/owner.go
@@ -32,6 +32,11 @@ func ResolveOwner(pod *corev1.Pod) OwnerInfo {
 		switch ref.Kind {
 		case "StatefulSet":
 			return OwnerInfo{Name: ref.Name, Kind: "StatefulSet"}
+		case "Sandbox":
+			// agent-sandbox (agents.x-k8s.io) workloads. The Sandbox name is the
+			// workload name an AgentRuntime targetRef points at, so key off the
+			// ownerRef rather than the pod name. Mirrors IsPodOwnedBy below.
+			return OwnerInfo{Name: ref.Name, Kind: "Sandbox"}
 		case "ReplicaSet":
 			name := deploymentNameFromReplicaSet(ref.Name, pod.Labels)
 			if name != "" {

--- a/kagenti-operator/internal/workload/owner.go
+++ b/kagenti-operator/internal/workload/owner.go
@@ -9,18 +9,18 @@ import (
 // OwnerInfo describes the workload that owns a Pod.
 type OwnerInfo struct {
 	Name string
-	Kind string // "Deployment", "StatefulSet", or "" if unknown
+	Kind string // "Deployment", "StatefulSet", "Sandbox", or "" if unknown
 }
 
 // ResolveOwner determines which top-level workload (Deployment,
-// StatefulSet) owns a Pod by inspecting ownerReferences and labels.
+// StatefulSet, Sandbox) owns a Pod by inspecting ownerReferences and labels.
 //
 // For Deployment pods the chain is Pod → ReplicaSet → Deployment;
 // the Deployment name is recovered from the ReplicaSet name by
 // stripping the pod-template-hash suffix.
 //
-// For StatefulSet pods the ownerReference points directly to the
-// StatefulSet (only controller ownerReferences are considered).
+// For StatefulSet and Sandbox pods the ownerReference points directly to the
+// workload (only controller ownerReferences are considered).
 //
 // Returns empty OwnerInfo when ownership cannot be determined.
 func ResolveOwner(pod *corev1.Pod) OwnerInfo {

--- a/kagenti-operator/internal/workload/owner_test.go
+++ b/kagenti-operator/internal/workload/owner_test.go
@@ -24,6 +24,24 @@ func TestResolveOwner_StatefulSet(t *testing.T) {
 	}
 }
 
+func TestResolveOwner_Sandbox(t *testing.T) {
+	// A Sandbox pod's controller ownerRef carries the Sandbox (workload) name,
+	// which is what an AgentRuntime targetRef points at. Resolving Kind="Sandbox"
+	// makes override matching exact instead of relying on the pod-name fallback.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "weather-agent",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "Sandbox", Name: "weather-agent", Controller: boolPtr(true)},
+			},
+		},
+	}
+	info := ResolveOwner(pod)
+	if info.Name != "weather-agent" || info.Kind != "Sandbox" {
+		t.Errorf("expected (weather-agent, Sandbox), got (%s, %s)", info.Name, info.Kind)
+	}
+}
+
 func TestResolveOwner_StatefulSet_NonController_Ignored(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

Make the AuthBridge webhook + operator handle **`Sandbox`** (`agents.x-k8s.io`) workloads with the same robustness as Deployment/StatefulSet, so the kagenti backend can attach an `AgentRuntime` (`mtlsMode` / `authBridgeMode` / `tlsBridgeMode`, including the TLS bridge) to sandbox-workload agents.

Three additive, case-only changes:

- **`ResolveOwner` Sandbox case** (`internal/workload/owner.go`) — resolve a Sandbox pod's owner as `{Name: <sandbox>, Kind: "Sandbox"}` (mirrors the existing `IsPodOwnedBy`), so AuthBridge override matching is by exact kind+name instead of the pod-name fallback. Closes the edge case where two AgentRuntimes share a `targetRef.name` across different kinds.
- **`buildOwnerReference` Sandbox branch** (`internal/webhook/injector/pod_mutator.go`) — set an ownerRef to the Sandbox so the per-agent `authbridge-config-<name>` ConfigMap is garbage-collected with the Sandbox (parity with Deployment/StatefulSet; previously orphaned on delete).
- **`getPodSpec` nil-guard** (`internal/controller/agentruntime_controller.go`) — the Sandbox pod-template accessor left `getPodSpec` unset (dead code today); return nil from a real func so a future caller hits a nil-check rather than a nil-function-call panic.

The CA reconciler and validating webhook are already kind-agnostic, and the AgentRuntime controller already supports Sandbox targetRefs (two-phase scale-restart), so this PR is purely robustness + GC. **No change to Deployment/StatefulSet/Job paths.**

## Test plan

- `go test ./internal/workload/... ./internal/webhook/injector/...` — including new `TestResolveOwner_Sandbox` and `TestEnsurePerAgentConfigMap_OwnerReference_SetFromSandbox`.
- Verified end-to-end on Kind: a sandbox `weather-agent` with `tlsBridgeMode: enabled` gets the per-agent CA minted, the two-volume CA mount + `tls_bridge` config injected, forged-leaf TLS interception (`issuer=CN=authbridge-tls-bridge-ca-weather-agent`), and decrypted request payloads (LLM `/v1/chat/completions`, MCP `/mcp`) on the session API.

## Notes

Pairs with the kagenti backend change that creates the Sandbox-targetRef AgentRuntime (separate PR in `kagenti/kagenti`). This operator change is optional hardening — the released operator already handles sandbox via the pod-name fallback; this makes it exact and adds ConfigMap GC.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
