### PR TITLE
Fix(e2e): remove hardcoded runAsUser from test fixtures

### DIFF
--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -233,7 +233,6 @@ var _ = Describe("Manager", Ordered, func() {
 										"drop": ["ALL"]
 									},
 									"runAsNonRoot": true,
-									"runAsUser": 1000,
 									"seccompProfile": {
 										"type": "RuntimeDefault"
 									}

--- a/kagenti-operator/test/e2e/fixtures.go
+++ b/kagenti-operator/test/e2e/fixtures.go
@@ -77,7 +77,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -154,7 +154,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -223,7 +223,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -378,7 +378,7 @@ spec:
       serviceAccountName: signed-agent-sa
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+
         seccompProfile:
           type: RuntimeDefault
       initContainers:
@@ -532,7 +532,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -600,7 +600,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -693,7 +693,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -745,7 +745,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -797,7 +797,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -944,7 +944,7 @@ spec:
       serviceAccountName: authbridge-agent
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -1012,7 +1012,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -1099,7 +1099,7 @@ spec:
       serviceAccountName: combined-agent
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -1264,7 +1264,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -1322,7 +1322,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -1376,7 +1376,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -1460,7 +1460,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -1511,7 +1511,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/kagenti-operator/test/e2e/sharedtrust_test.go
+++ b/kagenti-operator/test/e2e/sharedtrust_test.go
@@ -371,7 +371,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
+
       containers:
       - name: discovery
         image: registry.k8s.io/pause:3.9
@@ -401,7 +401,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
+
       containers:
       - name: ztunnel
         image: registry.k8s.io/pause:3.9


### PR DESCRIPTION
## Summary

All E2E test fixtures hardcode `runAsUser: 1000` or `runAsUser: 65534` in pod security contexts. This is unnecessarily prescriptive — the actual security intent is `runAsNonRoot: true`, which is already set on every fixture. The hardcoded UIDs break on any platform with UID range enforcement (e.g. OpenShift SCCs assign UIDs from the namespace's allocated range, and a fixed UID outside that range causes pod admission failures).

Removing them has no effect on Kind, where any non-root UID is accepted.

## Changes

- Remove `runAsUser: 1000` from `fixtures.go` (17 occurrences), `e2e_test.go` (1 occurrence)
- Remove `runAsUser: 65534` from `sharedtrust_test.go` (2 occurrences)
- Preserve `runAsNonRoot: true` and `seccompProfile` on all pod specs (21 total, unchanged)

## Test Plan

- [ ] \`go build ./test/e2e/\` compiles cleanly
- [ ] \`grep -r runAsUser test/e2e/\` returns no results
- [ ] \`grep -c runAsNonRoot test/e2e/fixtures.go test/e2e/e2e_test.go test/e2e/sharedtrust_test.go\` confirms all security contexts preserved
- [ ] All 41 E2E specs pass on Kind (no regression)