### PR TITLE
Feat(e2e): make tests configurable for pre-installed operator environments

### DIFF
--- a/kagenti-operator/test/e2e/e2e_suite_test.go
+++ b/kagenti-operator/test/e2e/e2e_suite_test.go
@@ -31,11 +31,14 @@ import (
 
 var (
 	// Optional Environment Variables:
+	// - E2E_BUILD_SKIP=true: Skips all image builds, Kind image loading, and infrastructure
+	//   installs/teardown. Use when running against a pre-installed operator on an existing cluster.
 	// - PROMETHEUS_INSTALL_SKIP=true: Skips Prometheus Operator installation during test setup.
 	// - CERT_MANAGER_INSTALL_SKIP=true: Skips CertManager installation during test setup.
 	// - SPIRE_INSTALL_SKIP=true: Skips SPIRE installation during test setup.
 	// These variables are useful if Prometheus, CertManager, or SPIRE is already installed,
 	// avoiding re-installation and conflicts.
+	skipBuild              = os.Getenv("E2E_BUILD_SKIP") == "true"
 	skipPrometheusInstall  = os.Getenv("PROMETHEUS_INSTALL_SKIP") == "true"
 	skipCertManagerInstall = os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true"
 	skipSpireInstall       = os.Getenv("SPIRE_INSTALL_SKIP") == "true"
@@ -77,6 +80,11 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	if skipBuild {
+		_, _ = fmt.Fprintf(GinkgoWriter, "E2E_BUILD_SKIP=true — skipping all image builds and infrastructure installs\n")
+		return
+	}
+
 	By("Ensure that Prometheus is enabled")
 	_ = utils.UncommentCode("config/default/kustomization.yaml", "#- ../prometheus", "#")
 
@@ -144,6 +152,11 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
+	if skipBuild {
+		_, _ = fmt.Fprintf(GinkgoWriter, "E2E_BUILD_SKIP=true — skipping infrastructure teardown\n")
+		return
+	}
+
 	// Teardown Prometheus, CertManager, and SPIRE after the suite if not skipped
 	// and if they were not already installed
 	if !skipPrometheusInstall && !isPrometheusOperatorAlreadyInstalled {

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -31,8 +31,29 @@ import (
 	"github.com/kagenti/operator/test/utils"
 )
 
+func controllerNS() string {
+	if v := os.Getenv("E2E_CONTROLLER_NAMESPACE"); v != "" {
+		return v
+	}
+	return "kagenti-operator-system"
+}
+
+func controllerDeploy() string {
+	if v := os.Getenv("E2E_CONTROLLER_DEPLOYMENT"); v != "" {
+		return v
+	}
+	return "kagenti-operator-controller-manager"
+}
+
+func webhookServiceName() string {
+	if v := os.Getenv("E2E_WEBHOOK_SERVICE"); v != "" {
+		return v
+	}
+	return "kagenti-operator-webhook-service"
+}
+
 // namespace where the project is deployed in
-const namespace = "kagenti-operator-system"
+var namespace = controllerNS()
 
 // serviceAccountName created for the project
 const serviceAccountName = "kagenti-operator-controller-manager"
@@ -194,7 +215,7 @@ var _ = Describe("Manager", Ordered, func() {
 			By("waiting for the webhook endpoint to be ready")
 			verifyWebhookEndpointReady := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "endpoints",
-					"kagenti-operator-webhook-service", "-n", namespace,
+					webhookServiceName(), "-n", namespace,
 					"-o", "jsonpath={.subsets[0].addresses[0].ip}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -218,13 +239,13 @@ var _ = Describe("Manager", Ordered, func() {
 			Eventually(func() error {
 				cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
 					"--namespace", namespace,
-					"--image=curlimages/curl:latest",
+					"--image="+curlImage(),
 					"--overrides",
 					fmt.Sprintf(`{
 						"spec": {
 							"containers": [{
 								"name": "curl",
-								"image": "curlimages/curl:latest",
+								"image": %q,
 								"command": ["/bin/sh", "-c"],
 								"args": [%q],
 								"securityContext": {
@@ -233,7 +254,6 @@ var _ = Describe("Manager", Ordered, func() {
 										"drop": ["ALL"]
 									},
 									"runAsNonRoot": true,
-									"runAsUser": 1000,
 									"seccompProfile": {
 										"type": "RuntimeDefault"
 									}
@@ -241,7 +261,7 @@ var _ = Describe("Manager", Ordered, func() {
 							}],
 							"serviceAccountName": "%s"
 						}
-					}`, curlCmd, serviceAccountName))
+					}`, curlImage(), curlCmd, serviceAccountName))
 				_, runErr := utils.Run(cmd)
 				if runErr != nil && strings.Contains(runErr.Error(), "already exists") {
 					return nil
@@ -331,7 +351,7 @@ type tokenRequest struct {
 }
 
 var _ = Describe("AuthBridge Injection E2E", Ordered, func() {
-	const controllerNamespace = "kagenti-operator-system"
+	controllerNamespace := controllerNS()
 
 	BeforeAll(func() {
 		Expect(utils.DeployController(controllerNamespace, projectImage)).To(Succeed(), "Failed to deploy controller")
@@ -349,7 +369,7 @@ var _ = Describe("AuthBridge Injection E2E", Ordered, func() {
 		By("waiting for webhook endpoint to be ready")
 		Eventually(func(g Gomega) {
 			cmd := exec.Command("kubectl", "get", "endpoints",
-				"kagenti-operator-webhook-service", "-n", controllerNamespace,
+				webhookServiceName(), "-n", controllerNamespace,
 				"-o", "jsonpath={.subsets[0].addresses[0].ip}")
 			output, err := utils.Run(cmd)
 			g.Expect(err).NotTo(HaveOccurred())
@@ -672,7 +692,7 @@ var _ = Describe("AuthBridge Injection E2E", Ordered, func() {
 			cmd = exec.Command("kubectl", "run", curlPodName,
 				"--restart=Never",
 				"--namespace", authBridgeTestNamespace,
-				"--image=curlimages/curl:latest",
+				"--image="+curlImage(),
 				"--command", "--",
 				"curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
 				fmt.Sprintf("http://authbridge-agent.%s.svc:8080/", authBridgeTestNamespace))
@@ -700,8 +720,8 @@ var _ = Describe("AuthBridge Injection E2E", Ordered, func() {
 })
 
 var _ = Describe("AgentCard E2E", Ordered, func() {
-	const controllerNamespace = "kagenti-operator-system"
-	const controllerDeployment = "kagenti-operator-controller-manager"
+	controllerNamespace := controllerNS()
+	controllerDeployment := controllerDeploy()
 
 	BeforeAll(func() {
 		Expect(utils.DeployController(controllerNamespace, projectImage)).To(Succeed(), "Failed to deploy controller")
@@ -719,7 +739,7 @@ var _ = Describe("AgentCard E2E", Ordered, func() {
 		By("waiting for webhook endpoint to be ready")
 		Eventually(func(g Gomega) {
 			cmd := exec.Command("kubectl", "get", "endpoints",
-				"kagenti-operator-webhook-service", "-n", controllerNamespace,
+				webhookServiceName(), "-n", controllerNamespace,
 				"-o", "jsonpath={.subsets[0].addresses[0].ip}")
 			output, err := utils.Run(cmd)
 			g.Expect(err).NotTo(HaveOccurred())
@@ -1036,7 +1056,7 @@ var _ = Describe("AgentCard E2E", Ordered, func() {
 })
 
 var _ = Describe("AgentRuntime E2E", Ordered, func() {
-	const controllerNamespace = "kagenti-operator-system"
+	controllerNamespace := controllerNS()
 
 	BeforeAll(func() {
 		By("ensuring mlflow-operator ClusterRole exists for ServiceAccount informer")
@@ -1067,7 +1087,7 @@ rules:
 		By("waiting for webhook endpoint to be ready")
 		Eventually(func(g Gomega) {
 			cmd := exec.Command("kubectl", "get", "endpoints",
-				"kagenti-operator-webhook-service", "-n", controllerNamespace,
+				webhookServiceName(), "-n", controllerNamespace,
 				"-o", "jsonpath={.subsets[0].addresses[0].ip}")
 			output, err := utils.Run(cmd)
 			g.Expect(err).NotTo(HaveOccurred())
@@ -1504,8 +1524,8 @@ rules:
 })
 
 var _ = Describe("Combined AgentRuntime + AgentCard + Auth Bridge E2E", Ordered, func() {
-	const controllerNamespace = "kagenti-operator-system"
-	const controllerDeployment = "kagenti-operator-controller-manager"
+	controllerNamespace := controllerNS()
+	controllerDeployment := controllerDeploy()
 
 	var origArgs []string
 
@@ -1538,7 +1558,7 @@ rules:
 		By("waiting for webhook endpoint to be ready")
 		Eventually(func(g Gomega) {
 			cmd := exec.Command("kubectl", "get", "endpoints",
-				"kagenti-operator-webhook-service", "-n", controllerNamespace,
+				webhookServiceName(), "-n", controllerNamespace,
 				"-o", "jsonpath={.subsets[0].addresses[0].ip}")
 			output, err := utils.Run(cmd)
 			g.Expect(err).NotTo(HaveOccurred())
@@ -1977,8 +1997,8 @@ rules:
 })
 
 var _ = Describe("Skill Discovery E2E", Ordered, func() {
-	const controllerNamespace = "kagenti-operator-system"
-	const controllerDeployment = "kagenti-operator-controller-manager"
+	controllerNamespace := controllerNS()
+	controllerDeployment := controllerDeploy()
 
 	BeforeAll(func() {
 		By("ensuring mlflow-operator ClusterRole exists for ServiceAccount informer")
@@ -2017,7 +2037,7 @@ rules:
 		By("waiting for webhook endpoint to be ready")
 		Eventually(func(g Gomega) {
 			cmd := exec.Command("kubectl", "get", "endpoints",
-				"kagenti-operator-webhook-service", "-n", controllerNamespace,
+				webhookServiceName(), "-n", controllerNamespace,
 				"-o", "jsonpath={.subsets[0].addresses[0].ip}")
 			output, err := utils.Run(cmd)
 			g.Expect(err).NotTo(HaveOccurred())
@@ -2181,7 +2201,7 @@ rules:
 			By("waiting for webhook endpoint to be ready after restart")
 			Eventually(func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "endpoints",
-					"kagenti-operator-webhook-service", "-n", controllerNamespace,
+					webhookServiceName(), "-n", controllerNamespace,
 					"-o", "jsonpath={.subsets[0].addresses[0].ip}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -2422,7 +2442,7 @@ rules:
 })
 
 var _ = Describe("Istio Mesh Enrollment E2E", Ordered, func() {
-	const controllerNamespace = "kagenti-operator-system"
+	controllerNamespace := controllerNS()
 
 	BeforeAll(func() {
 		Expect(utils.DeployController(controllerNamespace, projectImage)).To(Succeed(), "Failed to deploy controller")
@@ -2440,7 +2460,7 @@ var _ = Describe("Istio Mesh Enrollment E2E", Ordered, func() {
 		By("waiting for webhook endpoint to be ready")
 		Eventually(func(g Gomega) {
 			cmd := exec.Command("kubectl", "get", "endpoints",
-				"kagenti-operator-webhook-service", "-n", controllerNamespace,
+				webhookServiceName(), "-n", controllerNamespace,
 				"-o", "jsonpath={.subsets[0].addresses[0].ip}")
 			output, err := utils.Run(cmd)
 			g.Expect(err).NotTo(HaveOccurred())

--- a/kagenti-operator/test/e2e/e2e_test.go
+++ b/kagenti-operator/test/e2e/e2e_test.go
@@ -52,7 +52,6 @@ func webhookServiceName() string {
 	return "kagenti-operator-webhook-service"
 }
 
-// namespace where the project is deployed in
 var namespace = controllerNS()
 
 // serviceAccountName created for the project
@@ -253,7 +252,7 @@ var _ = Describe("Manager", Ordered, func() {
 									"capabilities": {
 										"drop": ["ALL"]
 									},
-									"runAsNonRoot": true,
+									"runAsNonRoot": true%s,
 									"seccompProfile": {
 										"type": "RuntimeDefault"
 									}
@@ -261,7 +260,7 @@ var _ = Describe("Manager", Ordered, func() {
 							}],
 							"serviceAccountName": "%s"
 						}
-					}`, curlImage(), curlCmd, serviceAccountName))
+					}`, curlImage(), curlCmd, runAsUserJSON("1000"), serviceAccountName))
 				_, runErr := utils.Run(cmd)
 				if runErr != nil && strings.Contains(runErr.Error(), "already exists") {
 					return nil

--- a/kagenti-operator/test/e2e/fixtures.go
+++ b/kagenti-operator/test/e2e/fixtures.go
@@ -19,9 +19,28 @@ package e2e
 import (
 	"encoding/base64"
 	"fmt"
+	"os"
 
 	"github.com/kagenti/operator/internal/clientreg"
 )
+
+// curlImage returns the container image used for curl-based test pods.
+// Override with E2E_CURL_IMAGE for environments where Docker Hub is unavailable.
+func curlImage() string {
+	if v := os.Getenv("E2E_CURL_IMAGE"); v != "" {
+		return v
+	}
+	return "curlimages/curl:latest"
+}
+
+// pythonImage returns the container image used for Python-based test workloads.
+// Override with E2E_PYTHON_IMAGE for environments that need a different registry.
+func pythonImage() string {
+	if v := os.Getenv("E2E_PYTHON_IMAGE"); v != "" {
+		return v
+	}
+	return "docker.io/python:3.11-slim"
+}
 
 const testNamespace = "e2e-agentcard-test"
 const authBridgeTestNamespace = "e2e-authbridge-test"
@@ -82,7 +101,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: echo
-          image: docker.io/python:3.11-slim
+          image: ` + pythonImage() + `
           imagePullPolicy: IfNotPresent
           command:
             - python3
@@ -228,7 +247,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: echo
-          image: docker.io/python:3.11-slim
+          image: ` + pythonImage() + `
           imagePullPolicy: IfNotPresent
           command:
             - python3
@@ -425,7 +444,7 @@ spec:
               memory: 32Mi
       containers:
         - name: agent
-          image: docker.io/python:3.11-slim
+          image: ` + pythonImage() + `
           imagePullPolicy: IfNotPresent
           command: ["python3", "-m", "http.server", "8080", "--directory", "/app"]
           ports:
@@ -949,7 +968,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: echo
-          image: docker.io/python:3.11-slim
+          image: ` + pythonImage() + `
           imagePullPolicy: IfNotPresent
           command:
             - python3
@@ -1104,7 +1123,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: echo
-          image: docker.io/python:3.11-slim
+          image: ` + pythonImage() + `
           imagePullPolicy: IfNotPresent
           command:
             - python3

--- a/kagenti-operator/test/e2e/fixtures.go
+++ b/kagenti-operator/test/e2e/fixtures.go
@@ -42,6 +42,38 @@ func pythonImage() string {
 	return "docker.io/python:3.11-slim"
 }
 
+// runAsUserYAML returns a YAML line setting runAsUser for pod security contexts.
+// The default images (curlimages/curl, python:3.11-slim) need an explicit numeric
+// UID because they either use a non-numeric user or run as root, which fails the
+// runAsNonRoot check without it.
+// Set E2E_RUN_AS_USER=none to omit the line entirely (e.g. OpenShift assigns UIDs
+// via SCC), or E2E_RUN_AS_USER=<uid> to override the value.
+func runAsUserYAML(defaultUID string) string {
+	v := os.Getenv("E2E_RUN_AS_USER")
+	if v == "none" {
+		return ""
+	}
+	uid := defaultUID
+	if v != "" {
+		uid = v
+	}
+	return fmt.Sprintf("\n        runAsUser: %s", uid)
+}
+
+// runAsUserJSON returns a JSON fragment for runAsUser inside a securityContext.
+// Returns empty string when E2E_RUN_AS_USER=none.
+func runAsUserJSON(defaultUID string) string {
+	v := os.Getenv("E2E_RUN_AS_USER")
+	if v == "none" {
+		return ""
+	}
+	uid := defaultUID
+	if v != "" {
+		uid = v
+	}
+	return fmt.Sprintf(`, "runAsUser": %s`, uid)
+}
+
 const testNamespace = "e2e-agentcard-test"
 const authBridgeTestNamespace = "e2e-authbridge-test"
 const authBridgeAgentName = "authbridge-agent"
@@ -95,8 +127,7 @@ spec:
         protocol.kagenti.io/a2a: ""
     spec:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        runAsNonRoot: true` + runAsUserYAML("1000") + `
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -172,8 +203,7 @@ spec:
         kagenti.io/inject: disabled
     spec:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        runAsNonRoot: true` + runAsUserYAML("1000") + `
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -241,8 +271,7 @@ spec:
         protocol.kagenti.io/a2a: ""
     spec:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        runAsNonRoot: true` + runAsUserYAML("1000") + `
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -396,8 +425,7 @@ spec:
     spec:
       serviceAccountName: signed-agent-sa
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        runAsNonRoot: true` + runAsUserYAML("1000") + `
         seccompProfile:
           type: RuntimeDefault
       initContainers:
@@ -550,8 +578,7 @@ spec:
         app.kubernetes.io/name: runtime-agent-target
     spec:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        runAsNonRoot: true` + runAsUserYAML("1000") + `
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -618,8 +645,7 @@ spec:
         app.kubernetes.io/name: runtime-tool-target
     spec:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        runAsNonRoot: true` + runAsUserYAML("1000") + `
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -711,8 +737,7 @@ spec:
         app.kubernetes.io/name: runtime-sts-target
     spec:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        runAsNonRoot: true` + runAsUserYAML("1000") + `
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -763,8 +788,7 @@ spec:
         app.kubernetes.io/name: runtime-minimal-target
     spec:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        runAsNonRoot: true` + runAsUserYAML("1000") + `
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -815,8 +839,7 @@ spec:
         app.kubernetes.io/name: runtime-overrides-target
     spec:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        runAsNonRoot: true` + runAsUserYAML("1000") + `
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -962,8 +985,7 @@ spec:
     spec:
       serviceAccountName: authbridge-agent
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        runAsNonRoot: true` + runAsUserYAML("1000") + `
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -1030,8 +1052,7 @@ spec:
         kagenti.io/inject: disabled
     spec:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        runAsNonRoot: true` + runAsUserYAML("1000") + `
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -1117,8 +1138,7 @@ spec:
     spec:
       serviceAccountName: combined-agent
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        runAsNonRoot: true` + runAsUserYAML("1000") + `
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -1282,8 +1302,7 @@ spec:
         kagenti.io/inject: disabled
     spec:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        runAsNonRoot: true` + runAsUserYAML("1000") + `
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -1340,8 +1359,7 @@ spec:
         kagenti.io/inject: disabled
     spec:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        runAsNonRoot: true` + runAsUserYAML("1000") + `
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -1394,8 +1412,7 @@ spec:
         kagenti.io/inject: disabled
     spec:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        runAsNonRoot: true` + runAsUserYAML("1000") + `
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -1478,8 +1495,7 @@ spec:
         app.kubernetes.io/name: istio-mesh-agent
     spec:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        runAsNonRoot: true` + runAsUserYAML("1000") + `
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -1529,8 +1545,7 @@ spec:
         app.kubernetes.io/name: istio-mesh-optout-agent
     spec:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        runAsNonRoot: true` + runAsUserYAML("1000") + `
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/kagenti-operator/test/e2e/sharedtrust_test.go
+++ b/kagenti-operator/test/e2e/sharedtrust_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var _ = Describe("SharedTrust E2E", Ordered, func() {
-	const controllerNamespace = "kagenti-operator-system"
+	controllerNamespace := controllerNS()
 
 	BeforeAll(func() {
 		Expect(utils.DeployController(controllerNamespace, projectImage)).To(Succeed(), "Failed to deploy controller")

--- a/kagenti-operator/test/e2e/sharedtrust_test.go
+++ b/kagenti-operator/test/e2e/sharedtrust_test.go
@@ -370,8 +370,7 @@ spec:
         app: istiod
     spec:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
+        runAsNonRoot: true` + runAsUserYAML("65534") + `
       containers:
       - name: discovery
         image: registry.k8s.io/pause:3.9
@@ -400,8 +399,7 @@ spec:
         app: ztunnel
     spec:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
+        runAsNonRoot: true` + runAsUserYAML("65534") + `
       containers:
       - name: ztunnel
         image: registry.k8s.io/pause:3.9

--- a/kagenti-operator/test/utils/utils.go
+++ b/kagenti-operator/test/utils/utils.go
@@ -508,7 +508,13 @@ func RestoreControllerArgs(namespace, deploy string, origArgs []string) error {
 }
 
 // DeployController installs CRDs and deploys the controller-manager.
+// Set E2E_CONTROLLER_DEPLOY_SKIP=true to skip when running against a pre-installed operator.
 func DeployController(namespace, img string) error {
+	if os.Getenv("E2E_CONTROLLER_DEPLOY_SKIP") == "true" {
+		By("skipping controller deployment (E2E_CONTROLLER_DEPLOY_SKIP=true)")
+		return nil
+	}
+
 	By("creating manager namespace")
 	if err := ensureNamespaceReady(namespace, 120*time.Second); err != nil {
 		return fmt.Errorf("namespace %s not ready: %w", namespace, err)
@@ -689,7 +695,14 @@ data:
 }
 
 // UndeployController undeploys the controller-manager and uninstalls CRDs.
+// UndeployController undeploys the controller-manager and uninstalls CRDs.
+// Set E2E_CONTROLLER_DEPLOY_SKIP=true to skip when running against a pre-installed operator.
 func UndeployController() {
+	if os.Getenv("E2E_CONTROLLER_DEPLOY_SKIP") == "true" {
+		By("skipping controller undeployment (E2E_CONTROLLER_DEPLOY_SKIP=true)")
+		return
+	}
+
 	By("undeploying the controller-manager")
 	cmd := exec.Command("make", "undeploy")
 	if _, err := Run(cmd); err != nil {

--- a/kagenti-operator/test/utils/utils.go
+++ b/kagenti-operator/test/utils/utils.go
@@ -695,7 +695,6 @@ data:
 }
 
 // UndeployController undeploys the controller-manager and uninstalls CRDs.
-// UndeployController undeploys the controller-manager and uninstalls CRDs.
 // Set E2E_CONTROLLER_DEPLOY_SKIP=true to skip when running against a pre-installed operator.
 func UndeployController() {
 	if os.Getenv("E2E_CONTROLLER_DEPLOY_SKIP") == "true" {


### PR DESCRIPTION
## Summary
Add environment variable overrides so the E2E test suite can target a pre-installed operator (e.g. Helm-deployed on OpenShift) without requiring Kind, local image builds, or infrastructure bootstrapping. All variables are optional and default to the current upstream values, so existing CI behaviour is unchanged.

## Changes
- **`e2e_suite_test.go`** — `E2E_BUILD_SKIP=true` short-circuits `BeforeSuite`/`AfterSuite`, skipping image builds, Kind loading, and Prometheus/CertManager/SPIRE installs.
- **`test/utils/utils.go`** — `E2E_CONTROLLER_DEPLOY_SKIP=true` makes `DeployController`/`UndeployController` no-ops when the operator is already running.
- **`e2e_test.go`** — Replace `const` namespace/deployment/webhook-service strings with `controllerNS()`, `controllerDeploy()`, `webhookServiceName()` helpers reading `E2E_CONTROLLER_NAMESPACE`, `E2E_CONTROLLER_DEPLOYMENT`, `E2E_WEBHOOK_SERVICE`.
- **`fixtures.go`** — Add `curlImage()` and `pythonImage()` helpers reading `E2E_CURL_IMAGE` and `E2E_PYTHON_IMAGE`, defaulting to `curlimages/curl:latest` and `docker.io/python:3.11-slim`. Add `runAsUserYAML()`/`runAsUserJSON()` helpers reading `E2E_RUN_AS_USER` to make `runAsUser` configurable.
- **`sharedtrust_test.go`** — Use `controllerNS()` and configurable `runAsUser`.

## Environment Variables

| Variable | Default | Purpose |
|---|---|---|
| `E2E_BUILD_SKIP` | `false` | Skip image builds and infra installs |
| `E2E_CONTROLLER_DEPLOY_SKIP` | `false` | Skip controller deploy/undeploy |
| `E2E_CONTROLLER_NAMESPACE` | `kagenti-operator-system` | Operator namespace |
| `E2E_CONTROLLER_DEPLOYMENT` | `kagenti-operator-controller-manager` | Deployment name |
| `E2E_WEBHOOK_SERVICE` | `kagenti-operator-webhook-service` | Webhook service name |
| `E2E_CURL_IMAGE` | `curlimages/curl:latest` | Curl pod image |
| `E2E_PYTHON_IMAGE` | `docker.io/python:3.11-slim` | Python workload image |
| `E2E_RUN_AS_USER` | `1000` (or `65534`) | Pod runAsUser UID; set to `none` to omit |

## Test Plan
- [ ] Default behaviour: `go test -tags integration ./test/e2e/` with no env vars runs identically to before (Kind CI unaffected)
- [ ] Pre-installed operator: set all `E2E_*` vars with `E2E_RUN_AS_USER=none`, run focused tests — suite skips builds and targets the correct namespace/images
- [ ] `go vet` and pre-commit hooks pass
- [ ] Verified on OpenShift: AgentRuntime E2E — 8/8 passed