### PR TITLE
Feat: add MTLSReady condition to AgentRuntime status

### DIFF
--- a/kagenti-operator/config/rbac/role.yaml
+++ b/kagenti-operator/config/rbac/role.yaml
@@ -41,15 +41,6 @@ rules:
   - ""
   resources:
   - serviceaccounts
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - services
   verbs:
   - create
@@ -169,17 +160,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - k8s.keycloak.org
-  resources:
-  - keycloakrealmimports
-  - keycloaks
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
   - datasciencecluster.opendatahub.io
   resources:
   - datascienceclusters
@@ -195,6 +175,17 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - k8s.keycloak.org
+  resources:
+  - keycloakrealmimports
+  - keycloaks
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
 - apiGroups:
   - kuadrant.io
   resources:

--- a/kagenti-operator/internal/controller/agentruntime_controller.go
+++ b/kagenti-operator/internal/controller/agentruntime_controller.go
@@ -88,6 +88,10 @@ const (
 
 	// AnnotationRestartPendingValue is the value set on AnnotationRestartPending.
 	AnnotationRestartPendingValue = "true"
+
+	// SPIRE volume names injected by the webhook when mTLS is enabled.
+	VolumeSpireAgentSocket = "spire-agent-socket"
+	VolumeSVIDOutput       = "svid-output"
 )
 
 var sandboxGVK = schema.GroupVersionKind{
@@ -212,7 +216,10 @@ func (r *AgentRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			fmt.Sprintf("Namespace %s opted out of Istio mesh enrollment", rt.Namespace))
 	}
 
-	// 4.7. Ensure SCC RoleBinding exists in the namespace.
+	// 4.7. Evaluate MTLSReady condition based on resolved mTLSMode and SPIRE availability.
+	r.evaluateMTLSReady(ctx, rt)
+
+	// 4.8. Ensure SCC RoleBinding exists in the namespace.
 	// Creates a RoleBinding granting all ServiceAccounts in the namespace
 	// access to the kagenti-authbridge SCC. No-op on non-OpenShift clusters.
 	// On OpenShift, a transient failure is retried via requeue to prevent
@@ -761,6 +768,72 @@ func (r *AgentRuntimeReconciler) handleDeletion(ctx context.Context, rt *agentv1
 
 	logger.Info("Removed finalizer from AgentRuntime", "name", rt.Name)
 	return ctrl.Result{}, nil
+}
+
+// evaluateMTLSReady sets the MTLSReady condition based on the resolved
+// mTLSMode and whether SPIRE infrastructure is available on the workload.
+// This is informational — MTLSReady=False does NOT block Ready=True.
+func (r *AgentRuntimeReconciler) evaluateMTLSReady(ctx context.Context, rt *agentv1alpha1.AgentRuntime) {
+	logger := log.FromContext(ctx)
+
+	mtlsMode := rt.Spec.MTLSMode
+	if mtlsMode == "" {
+		mtlsMode = "permissive"
+	}
+
+	if mtlsMode == "disabled" {
+		r.setCondition(rt, ConditionTypeMTLSReady, metav1.ConditionTrue, "MTLSDisabled",
+			"mTLS explicitly disabled on this AgentRuntime")
+		return
+	}
+
+	// Check if workload has SPIRE infrastructure by looking for
+	// spire-agent-socket or svid-output volumes in the pod template.
+	acc, ok := newRuntimePodTemplateAccessor(rt.Spec.TargetRef.Kind)
+	if !ok {
+		r.setCondition(rt, ConditionTypeMTLSReady, metav1.ConditionFalse, "UnsupportedKind",
+			fmt.Sprintf("Cannot check SPIRE availability for workload kind %s", rt.Spec.TargetRef.Kind))
+		return
+	}
+
+	key := types.NamespacedName{Name: rt.Spec.TargetRef.Name, Namespace: rt.Namespace}
+	if err := r.Get(ctx, key, acc.obj); err != nil {
+		logger.V(1).Info("Cannot read workload for SPIRE check", "error", err)
+		r.setCondition(rt, ConditionTypeMTLSReady, metav1.ConditionFalse, "WorkloadNotFound",
+			fmt.Sprintf("Cannot verify SPIRE availability: %v", err))
+		return
+	}
+
+	podSpec := acc.getPodSpec(acc.obj)
+	if podSpec == nil {
+		// Sandbox workloads don't expose a typed PodSpec; assume SPIRE
+		// is available since the webhook handles injection at pod CREATE.
+		r.setCondition(rt, ConditionTypeMTLSReady, metav1.ConditionTrue, "SPIREAssumed",
+			"Sandbox workload; SPIRE availability assumed (webhook handles injection)")
+		return
+	}
+
+	spireDetected := false
+	for _, v := range podSpec.Volumes {
+		if v.Name == VolumeSpireAgentSocket || v.Name == VolumeSVIDOutput {
+			spireDetected = true
+			break
+		}
+	}
+
+	if spireDetected {
+		r.setCondition(rt, ConditionTypeMTLSReady, metav1.ConditionTrue, "SPIREAvailable",
+			fmt.Sprintf("SPIRE volumes detected on workload %s; mTLS mode: %s", rt.Spec.TargetRef.Name, mtlsMode))
+	} else {
+		msg := "mTLS requires SPIRE; either deploy SPIRE or set mTLSMode: disabled"
+		r.setCondition(rt, ConditionTypeMTLSReady, metav1.ConditionFalse, "SPIREUnavailable", msg)
+		if r.Recorder != nil {
+			r.Recorder.Eventf(rt, nil, corev1.EventTypeWarning, "SPIREUnavailable",
+				"MTLSReadyCheck", msg)
+		}
+		logger.Info("SPIRE not detected for mTLS-enabled workload",
+			"workload", rt.Spec.TargetRef.Name, "mtlsMode", mtlsMode)
+	}
 }
 
 func (r *AgentRuntimeReconciler) setCondition(rt *agentv1alpha1.AgentRuntime, condType string, status metav1.ConditionStatus, reason, message string) {


### PR DESCRIPTION
## Summary

- Add `MTLSReady` condition logic to the AgentRuntime reconciler (T006 from mTLS spec)
- Controller evaluates SPIRE availability on each reconcile by checking for `spire-agent-socket` or `svid-output` volumes in the workload's pod template
- Emits Warning Event with actionable guidance when SPIRE is missing but mTLS is enabled

## Condition States

| Reason | Status | When |
|--------|--------|------|
| `SPIREAvailable` | True | SPIRE volumes detected in workload pod template |
| `SPIREUnavailable` | False | mTLS mode is permissive/strict but no SPIRE volumes found |
| `MTLSDisabled` | True | mTLSMode explicitly set to `disabled` |
| `SPIREAssumed` | True | Sandbox workloads (webhook handles injection at pod CREATE) |

## Key Design Decisions

- `MTLSReady=False` does **NOT** block `Ready=True` — it's informational for fleet-wide mTLS rollout tracking
- SPIRE detection checks pod template volumes, not running pod state — this is the right layer since the webhook injects volumes at admission time
- Sandbox workloads assume SPIRE is available since typed PodSpec is not accessible from unstructured objects

## Test plan

- [x] All unit tests pass (`make test`)
- [ ] Deploy agent with SPIRE → verify `MTLSReady=True/SPIREAvailable`
- [ ] Deploy agent without SPIRE → verify `MTLSReady=False/SPIREUnavailable` + Warning Event
- [ ] Deploy agent with `mTLSMode: disabled` → verify `MTLSReady=True/MTLSDisabled`

Jira: RHAIENG-4928
Spec: specs/003-mtls-transport-security (PR #401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)