### PR TITLE
Chore: sunset client-registration sidecar — remove legacy opt-in label

### DIFF
--- a/kagenti-operator/internal/clientreg/names.go
+++ b/kagenti-operator/internal/clientreg/names.go
@@ -19,10 +19,6 @@ import (
 )
 
 const (
-	// LabelClientRegistrationInject: when "true", the workload opts into the legacy
-	// client-registration sidecar and operator-managed registration is skipped.
-	LabelClientRegistrationInject = "kagenti.io/client-registration-inject"
-
 	// LabelAgentType distinguishes agents from tools; operator-managed registration runs for
 	// agents unconditionally and for tools only when the injectTools feature gate is on.
 	LabelAgentType  = "kagenti.io/type"
@@ -54,9 +50,6 @@ func KeycloakClientCredentialsSecretName(namespace, workload string) string {
 func SkipReason(labels map[string]string, injectTools bool) string {
 	if labels == nil {
 		return "pod template has no labels"
-	}
-	if labels[LabelClientRegistrationInject] == "true" {
-		return fmt.Sprintf("%s is \"true\" (legacy webhook client-registration sidecar; operator-managed registration disabled for this workload)", LabelClientRegistrationInject)
 	}
 	switch labels[LabelAgentType] {
 	case LabelValueAgent:

--- a/kagenti-operator/internal/clientreg/names_test.go
+++ b/kagenti-operator/internal/clientreg/names_test.go
@@ -46,7 +46,6 @@ func TestSkipReason(t *testing.T) {
 	}{
 		{"nil labels", nil, true, true},
 		{"empty labels", map[string]string{}, true, true},
-		{"legacy sidecar opt-in", map[string]string{LabelClientRegistrationInject: "true", LabelAgentType: LabelValueAgent}, true, true},
 		{"agent proceeds", map[string]string{LabelAgentType: LabelValueAgent}, false, false},
 		{"tool with gate on proceeds", map[string]string{LabelAgentType: LabelValueTool}, true, false},
 		{"tool with gate off skipped", map[string]string{LabelAgentType: LabelValueTool}, false, true},

--- a/kagenti-operator/internal/controller/clientregistration_controller.go
+++ b/kagenti-operator/internal/controller/clientregistration_controller.go
@@ -45,12 +45,6 @@ const (
 	// keycloakInitialAdminSecret is the RHBK-managed secret with keys "username"/"password".
 	keycloakInitialAdminSecret = "keycloak-initial-admin"
 
-	// LabelClientRegistrationInject: when not "true", the operator registers the OAuth client and sets
-	// AnnotationKeycloakClientSecretName. Value "true" opts the workload into the legacy webhook
-	// client-registration sidecar; the operator skips registration for that workload.
-	// Re-exported from internal/clientreg so existing callers keep working.
-	LabelClientRegistrationInject = clientreg.LabelClientRegistrationInject
-
 	// AnnotationKeycloakClientSecretName must match kagenti-webhook injector.AnnotationKeycloakClientSecretName.
 	// Re-exported from internal/clientreg to give both the controller and the webhook one source of truth.
 	AnnotationKeycloakClientSecretName = clientreg.AnnotationKeycloakClientSecretName

--- a/kagenti-operator/internal/controller/clientregistration_controller_test.go
+++ b/kagenti-operator/internal/controller/clientregistration_controller_test.go
@@ -45,22 +45,6 @@ func TestWorkloadWantsOperatorClientReg(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "agent with legacy sidecar opt-in — operator skips",
-			labels: map[string]string{
-				LabelAgentType:                LabelValueAgent,
-				LabelClientRegistrationInject: "true",
-			},
-			want: false,
-		},
-		{
-			name: "agent explicit false — same as default (operator-managed)",
-			labels: map[string]string{
-				LabelAgentType:                LabelValueAgent,
-				LabelClientRegistrationInject: "false",
-			},
-			want: true,
-		},
-		{
 			name: "tool default with injectTools",
 			labels: map[string]string{
 				LabelAgentType: string(agentv1alpha1.RuntimeTypeTool),
@@ -74,15 +58,6 @@ func TestWorkloadWantsOperatorClientReg(t *testing.T) {
 				LabelAgentType: string(agentv1alpha1.RuntimeTypeTool),
 			},
 			injectTools: false,
-			want:        false,
-		},
-		{
-			name: "tool with legacy opt-in — operator skips regardless of injectTools",
-			labels: map[string]string{
-				LabelAgentType:                string(agentv1alpha1.RuntimeTypeTool),
-				LabelClientRegistrationInject: "true",
-			},
-			injectTools: true,
 			want:        false,
 		},
 	}

--- a/kagenti-operator/internal/webhook/injector/constants.go
+++ b/kagenti-operator/internal/webhook/injector/constants.go
@@ -5,10 +5,6 @@ const (
 	// Per-sidecar workload labels — set value to "false" to disable injection
 	LabelEnvoyProxyInject   = "kagenti.io/envoy-proxy-inject"
 	LabelSpiffeHelperInject = "kagenti.io/spiffe-helper-inject"
-
-	// LabelClientRegistrationInject — legacy sidecar opt-in: set to "true" to inject;
-	// default is operator-managed Keycloak credentials (no sidecar).
-	LabelClientRegistrationInject = "kagenti.io/client-registration-inject"
 )
 
 // AuthBridge deployment modes. Selected via the namespace

--- a/kagenti-operator/internal/webhook/v1alpha1/authbridge_webhook_test.go
+++ b/kagenti-operator/internal/webhook/v1alpha1/authbridge_webhook_test.go
@@ -309,23 +309,6 @@ var _ = Describe("AuthBridge Pod Webhook", func() {
 			Expect(pod.Annotations).NotTo(HaveKey(injector.AnnotationKeycloakClientSecretName))
 		})
 
-		It("skips workloads opted into the legacy client-registration sidecar", func() {
-			createAgentRuntime(testNamespace, "prepop-legacy")
-
-			pod := newTestPod("prepop-legacy", map[string]string{
-				"kagenti.io/type":                       "agent",
-				"kagenti.io/inject":                     "enabled",
-				"kagenti.io/client-registration-inject": "true",
-			})
-
-			err := k8sClient.Create(ctx, pod)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(pod.Annotations).NotTo(HaveKey(injector.AnnotationKeycloakClientSecretName))
-		})
 	})
 })
 


### PR DESCRIPTION
## Summary

Closes kagenti/kagenti#1913. Removes the last remnant of the legacy in-pod client-registration sidecar: the `kagenti.io/client-registration-inject` opt-in label.

## Background

The client-registration sidecar itself was removed in kagenti/kagenti#1422 (merged 2026-05-12). What remained was the `kagenti.io/client-registration-inject=true` label that workloads could set to opt out of operator-managed registration — effectively saying "use the in-pod sidecar instead." With the sidecar gone, the label has no meaningful effect and only creates confusion for anyone who sets it expecting the old behavior.

## Changes

- `internal/clientreg/names.go`: remove `LabelClientRegistrationInject` constant and the `SkipReason` case that checked for it
- `internal/webhook/injector/constants.go`: remove duplicate constant definition
- `internal/controller/clientregistration_controller.go`: remove re-export alias
- `internal/clientreg/names_test.go`: remove test case covering the legacy label

**Behavior change**: `kagenti.io/client-registration-inject=true` is now silently ignored. Operator-managed registration runs for all eligible agent/tool workloads unconditionally.

## Checklist

- [x] All commits signed-off (DCO)
- [x] Tests pass (`internal/clientreg` ✅, all others ✅)
- [x] No install path sets this label (confirmed in #1422)

Assisted-By: Claude Code