### PR TITLE
docs: Fix 2 broken internal links in kagenti-operator

### DIFF
--- a/docs/migration/migrate-agent-crd-to-workloads.md
+++ b/docs/migration/migrate-agent-crd-to-workloads.md
@@ -276,5 +276,5 @@ The operator supports running in hybrid mode indefinitely, so you can migrate gr
 ## Support
 
 For questions or issues:
-- Open an issue at https://github.com/kagenti/operator/issues
+- Open an issue at https://github.com/kagenti/kagenti-operator/issues
 - Refer to the full migration plan in the project documentation.

--- a/kagenti-operator/docs/dev.md
+++ b/kagenti-operator/docs/dev.md
@@ -589,7 +589,7 @@ kubectl delete agentcard my-agent-deployment-card --grace-period=0 --force
 ## Getting Help
 
 - **GitHub Issues**: [Report bugs or request features](https://github.com/kagenti/kagenti-operator/issues)
-- **Discussions**: [Ask questions](https://github.com/kagenti/kagenti-operator/discussions)
+- **Issues**: [Ask questions or report bugs](https://github.com/kagenti/kagenti-operator/issues)
 - **Contributing**: See [CONTRIBUTING.md](../CONTRIBUTING.md)
 
 ---


### PR DESCRIPTION
Automated fix by OpenClaw Link Health Fixer.
Broken internal links updated to point to current locations.

| File | Old URL | New URL |
|------|---------|---------|
| `docs/migration/migrate-agent-crd-to-workloads.md` | `github.com/kagenti/operator/issues` (repo does not exist) | `github.com/kagenti/kagenti-operator/issues` |
| `kagenti-operator/docs/dev.md` | `github.com/kagenti/kagenti-operator/discussions` (disabled) | `github.com/kagenti/kagenti-operator/issues` |

Detected in scan 2026-07-10-001.