### PR TITLE
Fix(controller,webhook): write client-id.txt in federated-jwt mode for inbound JWT validation

### DIFF
--- a/kagenti-operator/internal/controller/clientregistration_controller.go
+++ b/kagenti-operator/internal/controller/clientregistration_controller.go
@@ -364,28 +364,22 @@ func (r *ClientRegistrationReconciler) reconcileOne(
 			"clientId", clientID)
 	}
 
-	// In federated-jwt mode, agents authenticate using their SPIFFE identity directly.
-	// No credential secret is needed — AuthBridge reads JWT-SVIDs from the workload
-	// API socket, not from a mounted secret. Skipping secret creation avoids leaving
-	// unused Keycloak client secrets in agent namespaces.
+	// In federated-jwt mode pass an empty clientSecret so ensureClientCredentialsSecret
+	// writes only client-id.txt (not client-secret.txt). The inbound jwt-validation
+	// plugin in AuthBridge reads client-id.txt to determine the expected audience; without
+	// it, all inbound requests to the agent are rejected with 503 indefinitely.
 	secretName := keycloakClientCredentialsSecretName(ns, workloadName)
-	if authType != "federated-jwt" {
-		if err := r.ensureClientCredentialsSecret(ctx, owner, secretName, clientID, clientSecret); err != nil {
-			logger.Error(err, "ensure client credentials secret")
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-		}
-		// Annotate the pod template with the secret name so the webhook mounts it.
-		if err := patchTemplate(ctx); err != nil {
-			logger.Error(err, "patch workload pod template")
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-		}
-	} else {
-		// In federated-jwt mode, AuthBridge reads JWT-SVIDs directly from the SPIFFE
-		// workload API socket — no credential secret is needed or created. Skip both the
-		// secret and the pod template annotation so the webhook does not try to mount a
-		// non-existent secret.
-		logger.V(1).Info("skipping credential secret and template patch (federated-jwt — AuthBridge uses SPIFFE identity directly)",
-			"workload", workloadName, "namespace", ns)
+	credSecret := clientSecret
+	if authType == "federated-jwt" {
+		credSecret = ""
+	}
+	if err := r.ensureClientCredentialsSecret(ctx, owner, secretName, clientID, credSecret); err != nil {
+		logger.Error(err, "ensure client credentials secret")
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+	if err := patchTemplate(ctx); err != nil {
+		logger.Error(err, "patch workload pod template")
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
 	logger.Info("operator client registration applied",
@@ -571,7 +565,11 @@ func (r *ClientRegistrationReconciler) ensureClientCredentialsSecret(ctx context
 		if sec.StringData == nil {
 			sec.StringData = map[string]string{}
 		}
-		sec.StringData["client-secret.txt"] = clientSecret
+		// client-secret.txt is omitted in federated-jwt mode (empty string) — agents
+		// authenticate via JWT-SVID and have no Keycloak client secret to store.
+		if clientSecret != "" {
+			sec.StringData["client-secret.txt"] = clientSecret
+		}
 		sec.StringData["client-id.txt"] = clientID
 		return controllerutil.SetControllerReference(owner, sec, r.Scheme)
 	})

--- a/kagenti-operator/internal/controller/clientregistration_controller.go
+++ b/kagenti-operator/internal/controller/clientregistration_controller.go
@@ -565,11 +565,11 @@ func (r *ClientRegistrationReconciler) ensureClientCredentialsSecret(ctx context
 		if sec.StringData == nil {
 			sec.StringData = map[string]string{}
 		}
-		// client-secret.txt is omitted in federated-jwt mode (empty string) — agents
-		// authenticate via JWT-SVID and have no Keycloak client secret to store.
-		if clientSecret != "" {
-			sec.StringData["client-secret.txt"] = clientSecret
-		}
+		// In federated-jwt mode clientSecret is empty — agents authenticate via JWT-SVID.
+		// We still write client-secret.txt (as an empty string) so the webhook's subPath
+		// mount produces a file rather than a directory (Kubernetes creates a directory
+		// when a subPath key is absent from the Secret).
+		sec.StringData["client-secret.txt"] = clientSecret
 		sec.StringData["client-id.txt"] = clientID
 		return controllerutil.SetControllerReference(owner, sec, r.Scheme)
 	})

--- a/kagenti-operator/internal/webhook/v1alpha1/authbridge_webhook.go
+++ b/kagenti-operator/internal/webhook/v1alpha1/authbridge_webhook.go
@@ -97,22 +97,20 @@ func (w *AuthBridgeWebhook) Handle(ctx context.Context, req admission.Request) a
 	// Without this, the first pod comes up with an empty /shared/ and envoy returns 503
 	// "identity not yet configured (credentials pending)" until the user deletes the pod.
 	//
-	// Skip in federated-jwt mode: AuthBridge reads JWT-SVIDs from the SPIFFE workload API
-	// socket directly and no credential Secret is created or needed. Injecting the volume
-	// mount for a non-existent Secret would leave pods stuck in Init.
+	// In federated-jwt mode the Secret still exists (written by the operator with only
+	// client-id.txt, no client-secret.txt) so the volume mount is still needed. The
+	// inbound jwt-validation plugin reads client-id.txt to determine the expected audience;
+	// without the mount the plugin polls forever and rejects all inbound traffic with 503.
 	if pod.Annotations[injector.AnnotationKeycloakClientSecretName] == "" &&
 		clientreg.WorkloadWantsOperatorClientReg(pod.Labels, w.Mutator.GetFeatureGates().InjectTools) {
-		nsConfig, _ := injector.ReadNamespaceConfig(ctx, w.Mutator.APIReader, req.Namespace)
-		if nsConfig == nil || nsConfig.ClientAuthType != injector.ClientAuthTypeFederatedJWT {
-			if pod.Annotations == nil {
-				pod.Annotations = map[string]string{}
-			}
-			pod.Annotations[injector.AnnotationKeycloakClientSecretName] =
-				clientreg.KeycloakClientCredentialsSecretName(req.Namespace, resourceName)
-			authbridgelog.Info("pre-populated Keycloak client credentials annotation",
-				"namespace", req.Namespace, "name", resourceName,
-				"secret", pod.Annotations[injector.AnnotationKeycloakClientSecretName])
+		if pod.Annotations == nil {
+			pod.Annotations = map[string]string{}
 		}
+		pod.Annotations[injector.AnnotationKeycloakClientSecretName] =
+			clientreg.KeycloakClientCredentialsSecretName(req.Namespace, resourceName)
+		authbridgelog.Info("pre-populated Keycloak client credentials annotation",
+			"namespace", req.Namespace, "name", resourceName,
+			"secret", pod.Annotations[injector.AnnotationKeycloakClientSecretName])
 	}
 
 	// Check if already injected (idempotency / reinvocation)


### PR DESCRIPTION
## Problem

In `federated-jwt` mode, agent pods reject all inbound authenticated requests with HTTP 503:

```
identity not yet configured (credentials pending)
```

The `authbridge-proxy` sidecar polls indefinitely for `/shared/client-id.txt` — the file the inbound `jwt-validation` plugin reads to determine the expected audience when validating incoming JWTs.

## Root cause

PR #476 correctly intended to skip writing `client-secret.txt` in federated-jwt mode. However it skipped the entire `ensureClientCredentialsSecret` call, which also skipped `client-id.txt`. It also skipped `patchTemplate`, so the Secret annotation was never set and the webhook never mounted the Secret into the pod at all. The broken chain:

1. `ensureClientCredentialsSecret` skipped → no Secret, no `client-id.txt`
2. `patchTemplate` skipped → no annotation on pod template → webhook doesn't mount Secret
3. Webhook separately skipped annotation pre-population → same result

## Fix

**Controller** — in federated-jwt mode, pass an empty `clientSecret` to `ensureClientCredentialsSecret` instead of skipping the call. The Secret is always written with both keys: `client-id.txt` (the agent's SPIFFE ID) and `client-secret.txt` (empty string in federated-jwt mode). Writing an empty `client-secret.txt` rather than omitting the key avoids a Kubernetes quirk where a subPath mount for an absent Secret key creates a directory at the mount path instead of a file. Remove the `authType` guard so `patchTemplate` also runs in federated-jwt mode.

**Webhook** — remove the federated-jwt guard on annotation pre-population. The Secret now exists in this mode, so the volume mount annotation is needed for the first pod to start without a pod recreate.

In federated-jwt mode AuthBridge uses `identity.type=spiffe` for outbound token exchange and never reads `client-secret.txt`, so the empty value is harmless.

## Testing

- `go build ./...` clean
- `go vet ./internal/controller/... ./internal/webhook/...` clean

Fixes #482

Assisted-By: Claude Code