### PR TITLE
Refactor: Rename rossocortex → cortex + clean residual kagenti refs

### DIFF
--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -63,15 +63,15 @@ What was provided?
 
 ### Route logic
 
-1. **`/orchestrate <repo-path>`** -- If the path points to a git repository, derive the target name from the directory basename. Check `/tmp/kagenti/orchestrate/<target>/` for existing state. If no scan report exists, invoke `orchestrate:scan`. If scan exists but no plan, invoke `orchestrate:plan`. If both exist, determine the next incomplete phase and invoke it.
+1. **`/orchestrate <repo-path>`** -- If the path points to a git repository, derive the target name from the directory basename. Check `/tmp/rossoctl/orchestrate/<target>/` for existing state. If no scan report exists, invoke `orchestrate:scan`. If scan exists but no plan, invoke `orchestrate:plan`. If both exist, determine the next incomplete phase and invoke it.
 
 2. **`/orchestrate <phase>`** -- Validate that `scan-report.md` and `plan.md` exist for the current target. If missing, instruct the user to run `/orchestrate <repo-path>` first. Otherwise invoke the requested phase skill directly (e.g., `orchestrate:precommit`).
 
-3. **`/orchestrate status`** -- List all directories under `/tmp/kagenti/orchestrate/`, read each target's `phase-status.md`, and display a summary table showing target name, current phase, and completion percentage.
+3. **`/orchestrate status`** -- List all directories under `/tmp/rossoctl/orchestrate/`, read each target's `phase-status.md`, and display a summary table showing target name, current phase, and completion percentage.
 
 ## Phase Status Tracking
 
-All orchestration state is persisted under `/tmp/kagenti/orchestrate/<target>/`:
+All orchestration state is persisted under `/tmp/rossoctl/orchestrate/<target>/`:
 
 | File | Purpose |
 |------|---------|
@@ -154,5 +154,5 @@ git clone git@github.com:org/repo.git .repos/repo-name
 
 | Skill | Description |
 |-------|-------------|
-| `onboard:link` | Link a newly-orchestrated repo to Kagenti |
+| `onboard:link` | Link a newly-orchestrated repo to Rossoctl |
 | `onboard:standards` | Apply organizational standards and conventions |

--- a/.claude/skills/orchestrate:ci/SKILL.md
+++ b/.claude/skills/orchestrate:ci/SKILL.md
@@ -39,8 +39,8 @@ security scanning, dependency management, and supply chain hardening.
 
 ## Prerequisites
 
-- Plan exists at `/tmp/kagenti/orchestrate/<target>/plan.md`
-- Scan report at `/tmp/kagenti/orchestrate/<target>/scan-report.md`
+- Plan exists at `/tmp/rossoctl/orchestrate/<target>/plan.md`
+- Scan report at `/tmp/rossoctl/orchestrate/<target>/scan-report.md`
 - Target repo in `.repos/<target>/`
 
 ## Read Scan Report First
@@ -402,7 +402,7 @@ gh pr create --repo org/repo --title "Add comprehensive CI workflows" --body "Ph
 
 ## Update Phase Status
 
-Set ci to `complete` in `/tmp/kagenti/orchestrate/<target>/phase-status.md`.
+Set ci to `complete` in `/tmp/rossoctl/orchestrate/<target>/phase-status.md`.
 
 ## Related Skills
 

--- a/.claude/skills/orchestrate:plan/SKILL.md
+++ b/.claude/skills/orchestrate:plan/SKILL.md
@@ -33,7 +33,7 @@ is Phase 1 — interactive brainstorming with the developer, no PRs.
 Scan report must exist:
 
 ```bash
-cat /tmp/kagenti/orchestrate/<target>/scan-report.md
+cat /tmp/rossoctl/orchestrate/<target>/scan-report.md
 ```
 
 ## Planning Process
@@ -78,7 +78,7 @@ Target 600-700 lines per PR. For each phase:
 
 ## Plan Output
 
-Save to `/tmp/kagenti/orchestrate/<target>/plan.md`:
+Save to `/tmp/rossoctl/orchestrate/<target>/plan.md`:
 
 ```markdown
 # Enhancement Plan: <target>
@@ -128,7 +128,7 @@ Save to `/tmp/kagenti/orchestrate/<target>/plan.md`:
 Initialize phase tracking:
 
 ```bash
-cat > /tmp/kagenti/orchestrate/<target>/phase-status.md << 'EOF'
+cat > /tmp/rossoctl/orchestrate/<target>/phase-status.md << 'EOF'
 # Phase Status: <target>
 
 | Phase | Status | PR | Date |

--- a/.claude/skills/orchestrate:precommit/SKILL.md
+++ b/.claude/skills/orchestrate:precommit/SKILL.md
@@ -35,7 +35,7 @@ produces PR #1 — the foundation that validates all subsequent PRs.
 
 ## Prerequisites
 
-- Plan exists at `/tmp/kagenti/orchestrate/<target>/plan.md`
+- Plan exists at `/tmp/rossoctl/orchestrate/<target>/plan.md`
 - Target repo cloned in `.repos/<target>/`
 
 ## Step 1: Detect Language
@@ -212,7 +212,7 @@ gh pr create --repo org/repo --title "Add pre-commit hooks and code quality base
 
 ## Update Phase Status
 
-Update `/tmp/kagenti/orchestrate/<target>/phase-status.md`:
+Update `/tmp/rossoctl/orchestrate/<target>/phase-status.md`:
 - Set precommit to `complete`
 - Record PR number and date
 

--- a/.claude/skills/orchestrate:review/SKILL.md
+++ b/.claude/skills/orchestrate:review/SKILL.md
@@ -37,7 +37,7 @@ submits reviews after user approval.
 
 ## Prerequisites
 
-- `scan-report.md` and `plan.md` exist in `/tmp/kagenti/orchestrate/<target>/`
+- `scan-report.md` and `plan.md` exist in `/tmp/rossoctl/orchestrate/<target>/`
 - Phases 2-6 are complete (or at least the phases that were planned)
 - PRs are open on the target repo
 
@@ -210,7 +210,7 @@ Update `phase-status.md` when complete:
 
 ```bash
 # Update phase-status.md
-sed -i '' 's/| review .*/| review | complete | -- | YYYY-MM-DD |/' /tmp/kagenti/orchestrate/<target>/phase-status.md
+sed -i '' 's/| review .*/| review | complete | -- | YYYY-MM-DD |/' /tmp/rossoctl/orchestrate/<target>/phase-status.md
 ```
 
 ## Related Skills

--- a/.claude/skills/orchestrate:scan/SKILL.md
+++ b/.claude/skills/orchestrate:scan/SKILL.md
@@ -277,7 +277,7 @@ Then follow the `cve:scan` skill workflow:
    Advisory Database
 4. **Classify** — confirmed / suspected / false positive
 
-Write CVE findings to `/tmp/kagenti/cve/<target>/scan-report.json` (never to
+Write CVE findings to `/tmp/rossoctl/cve/<target>/scan-report.json` (never to
 git-tracked files). Include a summary in the scan report.
 
 Key areas to focus on:
@@ -326,10 +326,10 @@ git -C .repos/<target> remote -v
 
 ## Output Format
 
-Save scan report to `/tmp/kagenti/orchestrate/<target>/scan-report.md`:
+Save scan report to `/tmp/rossoctl/orchestrate/<target>/scan-report.md`:
 
 ```bash
-mkdir -p /tmp/kagenti/orchestrate/<target>
+mkdir -p /tmp/rossoctl/orchestrate/<target>
 ```
 
 Report template:
@@ -439,7 +439,7 @@ Report template:
 
 ## Dependency Vulnerabilities (cve:scan)
 - Scan method: [Trivy + LLM + WebSearch / LLM + WebSearch / LLM only]
-- Full report: `/tmp/kagenti/cve/<target>/scan-report.json`
+- Full report: `/tmp/rossoctl/cve/<target>/scan-report.json`
 
 | Severity | Count |
 |----------|-------|
@@ -458,7 +458,7 @@ Report template:
 |---------|----------|---------|
 | [e.g., insecure port, no input validation] | HIGH/MEDIUM | [brief description] |
 
-> **Note:** CVE IDs and detailed descriptions are in `/tmp/kagenti/cve/<target>/scan-report.json` only.
+> **Note:** CVE IDs and detailed descriptions are in `/tmp/rossoctl/cve/<target>/scan-report.json` only.
 > Do NOT copy CVE IDs into git-tracked files, PRs, or issues.
 
 ## Gap Summary

--- a/.claude/skills/skills:scan/SKILL.md
+++ b/.claude/skills/skills:scan/SKILL.md
@@ -180,10 +180,10 @@ Rate each skill 1-5:
 
 ### Phase 6: Generate Report
 
-Save to `/tmp/kagenti/skills-scan/`:
+Save to `/tmp/rossoctl/skills-scan/`:
 
 ```bash
-mkdir -p /tmp/kagenti/skills-scan
+mkdir -p /tmp/rossoctl/skills-scan
 ```
 
 Output a structured report:

--- a/.claude/skills/skills:validate/SKILL.md
+++ b/.claude/skills/skills:validate/SKILL.md
@@ -60,18 +60,18 @@ Commands target local Kind clusters or test environments.
 
 Check pod status:
 ```bash
-kubectl get pods -n kagenti-system
+kubectl get pods -n rossoctl-system
 ```
 
 Check logs:
 ```bash
-kubectl logs -n kagenti-system deployment/kagenti-operator-controller-manager
+kubectl logs -n rossoctl-system deployment/rossoctl-operator-controller-manager
 ```
 
 ## BAD (chained commands won't match auto-approve patterns)
 
 ```bash
-kubectl get pods -n kagenti-system && kubectl logs -n kagenti-system deployment/kagenti-operator-controller-manager
+kubectl get pods -n rossoctl-system && kubectl logs -n rossoctl-system deployment/rossoctl-operator-controller-manager
 ```
 ```
 

--- a/.claude/skills/skills:write/SKILL.md
+++ b/.claude/skills/skills:write/SKILL.md
@@ -100,12 +100,12 @@ Claude Code auto-approves commands by matching the first token against `.claude/
 ```markdown
 Check pod status:
 ```bash
-kubectl get pods -n kagenti-system
+kubectl get pods -n rossoctl-system
 ```
 
 Check logs:
 ```bash
-kubectl logs -n kagenti-system deployment/kagenti-operator-controller-manager
+kubectl logs -n rossoctl-system deployment/rossoctl-operator-controller-manager
 ```
 ```
 
@@ -117,10 +117,10 @@ Commands targeting management clusters or AWS need user approval anyway, so mult
 
 ### Temporary Files
 
-Skills that download logs, artifacts, or save analysis output should use `/tmp/kagenti-operator/<skill-category>/` as the working directory:
+Skills that download logs, artifacts, or save analysis output should use `/tmp/operator/<skill-category>/` as the working directory:
 
 ```bash
-mkdir -p /tmp/kagenti-operator/rca
+mkdir -p /tmp/operator/rca
 ```
 
 ### Update settings.json

--- a/charts/operator/templates/manager/manager.yaml
+++ b/charts/operator/templates/manager/manager.yaml
@@ -193,7 +193,7 @@ spec:
             {{- end }}
         {{- if and .Values.spiffe .Values.spiffe.enabled .Values.spiffe.operatorAuth .Values.spiffe.operatorAuth.enabled }}
         - name: spiffe-helper
-          image: ghcr.io/rossoctl/rossocortex/spiffe-helper:latest
+          image: ghcr.io/rossoctl/cortex/spiffe-helper:latest
           imagePullPolicy: IfNotPresent
           args:
             - "-config"

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -246,10 +246,10 @@ featureGates:
 # proxy-sidecar / lite mode (always-on enforce-redirect egress capture).
 defaults:
   images:
-    envoyProxy: ghcr.io/rossoctl/rossocortex/authbridge-envoy:latest
-    authbridge: ghcr.io/rossoctl/rossocortex/authbridge:latest
-    authbridgeLite: ghcr.io/rossoctl/rossocortex/authbridge-lite:latest
-    proxyInit: ghcr.io/rossoctl/rossocortex/proxy-init:latest
+    envoyProxy: ghcr.io/rossoctl/cortex/authbridge-envoy:latest
+    authbridge: ghcr.io/rossoctl/cortex/authbridge:latest
+    authbridgeLite: ghcr.io/rossoctl/cortex/authbridge-lite:latest
+    proxyInit: ghcr.io/rossoctl/cortex/proxy-init:latest
     pullPolicy: IfNotPresent
 
   # Proxy settings

--- a/docs/superpowers/plans/2026-06-18-authbridge-tlsbridge-phase2-operator.md
+++ b/docs/superpowers/plans/2026-06-18-authbridge-tlsbridge-phase2-operator.md
@@ -4,17 +4,17 @@
 
 **Goal:** Make the AuthBridge TLS bridge work end-to-end on operator-deployed agents — the operator provisions a per-agent cert-manager CA, mounts the signing key into the sidecar and the trust cert + trust env into the agent, and renders the `tls_bridge:` config block — so a real agent's outbound HTTPS is decrypted into the pipeline, gated behind an off-by-default `tlsBridgeMode`.
 
-**Architecture:** A new `tlsBridgeMode: disabled|enabled` field on the `AgentRuntime` CRD, resolved CR→namespace→default exactly like `mtlsMode`. When `enabled` (and feature-gated on, and cert-manager present, and `authBridgeMode ∈ {proxy-sidecar, lite}`), a new per-agent CA reconciler creates a SelfSigned `Issuer` + a CA `Certificate` (`isCA: true`, **no Name Constraints**) → a Secret. The mutating webhook hard-mounts `tls.crt`/`tls.key` into the sidecar (mode `0440`) and `ca.crt` + trust env into the agent, and renders `tls_bridge: {mode: enabled, ca_dir: /etc/authbridge/tls-bridge-ca}` into the per-agent config (consolidated schema, rossocortex#522 — no scope/ca_source/cert-paths). The `:9094` session-API localhost-bind (it now carries decrypted bodies) already shipped authbridge-side in #522, so the operator PR carries no extensions work; raw-body redaction is a deferred follow-up.
+**Architecture:** A new `tlsBridgeMode: disabled|enabled` field on the `AgentRuntime` CRD, resolved CR→namespace→default exactly like `mtlsMode`. When `enabled` (and feature-gated on, and cert-manager present, and `authBridgeMode ∈ {proxy-sidecar, lite}`), a new per-agent CA reconciler creates a SelfSigned `Issuer` + a CA `Certificate` (`isCA: true`, **no Name Constraints**) → a Secret. The mutating webhook hard-mounts `tls.crt`/`tls.key` into the sidecar (mode `0440`) and `ca.crt` + trust env into the agent, and renders `tls_bridge: {mode: enabled, ca_dir: /etc/authbridge/tls-bridge-ca}` into the per-agent config (consolidated schema, cortex#522 — no scope/ca_source/cert-paths). The `:9094` session-API localhost-bind (it now carries decrypted bodies) already shipped authbridge-side in #522, so the operator PR carries no extensions work; raw-body redaction is a deferred follow-up.
 
-**Tech Stack:** Go 1.x (rossoctl-operator, kubebuilder/controller-runtime), cert-manager Go API `github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1` (v1.20.2, already vendored + scheme-registered), `k8s.io/utils/ptr`. Phase-1 AuthBridge code (rossocortex PR #522) is the **prerequisite** — the rendered `tls_bridge:` block is only understood by the post-#522 authbridge image.
+**Tech Stack:** Go 1.x (rossoctl-operator, kubebuilder/controller-runtime), cert-manager Go API `github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1` (v1.20.2, already vendored + scheme-registered), `k8s.io/utils/ptr`. Phase-1 AuthBridge code (cortex PR #522) is the **prerequisite** — the rendered `tls_bridge:` block is only understood by the post-#522 authbridge image.
 
 **Locked decisions (from brainstorming):**
 1. CRD `tlsBridgeMode: disabled|enabled` maps 1:1 to `tls_bridge.mode`; `envoy-sidecar` + `enabled` ⇒ validating-webhook reject. (The authbridge schema was consolidated in #522: no scope/external — `enabled` intercepts all eligible on the configured ports.)
 2. **Unconstrained** per-agent CA (no X.509 Name Constraints). Containment = per-agent isolation + sidecar-only `0440` key + rotation. (Avoids the cert-manager `NameConstraints` feature-gate dependency entirely.)
 3. Fully **decoupled** from SPIRE/mTLS. Hard deps only: `authBridgeMode ∈ {proxy-sidecar, lite}` + cert-manager installed.
-   - **Cross-repo dependency for true SPIRE-free operation (added post-implementation, verified e2e):** the operator alone does not achieve this. The rossoctl chart renders an empty `spiffe: {}` into every agent's base config, and the pre-fix authbridge binary built the SPIFFE provider on mere presence of that block → `NewX509Source` blocked forever when no SPIRE socket was mounted. SPIRE-free boot therefore requires **rossocortex #523** (need-driven SPIFFE provider: build only when mTLS or a `identity.type=spiffe` plugin consumes it). On the operator side, `applyTLSBridgeMounts` now calls `ensureFSGroup` **unconditionally** (not only under `spireEnabled`) so the non-root sidecar can read the `0440` CA Secret without SPIRE — see the `0440`/`FSGroup=0` note below, which previously held only on the SPIRE path.
+   - **Cross-repo dependency for true SPIRE-free operation (added post-implementation, verified e2e):** the operator alone does not achieve this. The rossoctl chart renders an empty `spiffe: {}` into every agent's base config, and the pre-fix authbridge binary built the SPIFFE provider on mere presence of that block → `NewX509Source` blocked forever when no SPIRE socket was mounted. SPIRE-free boot therefore requires **cortex #523** (need-driven SPIFFE provider: build only when mTLS or a `identity.type=spiffe` plugin consumes it). On the operator side, `applyTLSBridgeMounts` now calls `ensureFSGroup` **unconditionally** (not only under `spireEnabled`) so the non-root sidecar can read the `0440` CA Secret without SPIRE — see the `0440`/`FSGroup=0` note below, which previously held only on the SPIRE path.
 
-**Spec:** `rossocortex/authbridge/docs/superpowers/specs/2026-06-12-authbridge-tlsbridge-design.md` (Phase 2 section). **Phase 1 plan:** `rossocortex/authbridge/docs/superpowers/plans/2026-06-17-authbridge-tlsbridge-phase1.md`.
+**Spec:** `cortex/authbridge/docs/superpowers/specs/2026-06-12-authbridge-tlsbridge-design.md` (Phase 2 section). **Phase 1 plan:** `cortex/authbridge/docs/superpowers/plans/2026-06-17-authbridge-tlsbridge-phase1.md`.
 
 ---
 
@@ -56,7 +56,7 @@ All operator paths under `operator/operator/` unless noted. Verified 2026-06-18.
 - `cmd/main.go` — register the reconciler (gated).
 - RBAC marker on the new reconciler + `config/rbac/role.yaml` + `charts/operator/templates/rbac/role.yaml`.
 
-**rossocortex:** none required for this PR. The `:9094` localhost-bind already
+**cortex:** none required for this PR. The `:9094` localhost-bind already
 shipped in #522 (`config.Load` rewrites `session_api_addr` to loopback when
 `tls_bridge.mode=enabled`). Raw-body redaction is a deferred follow-up, not a Phase-2 blocker.
 
@@ -78,7 +78,7 @@ git fetch origin main   # or upstream main, per your remote
 git checkout -b feat/tlsbridge-phase2 origin/main
 ```
 
-(All operator work happens here. No rossocortex changes are needed — the `:9094` localhost-bind already landed in #522.)
+(All operator work happens here. No cortex changes are needed — the `:9094` localhost-bind already landed in #522.)
 
 ---
 
@@ -338,7 +338,7 @@ git commit -s -m "feat(tlsbridge): reject tlsBridgeMode=enabled with envoy-sidec
 
 This reconciler watches `AgentRuntime`. When the resolved mode is `enabled` AND the feature gate is on AND cert-manager is present, it ensures (per agent): a namespace SelfSigned `Issuer` (shared, name `authbridge-tls-bridge-selfsigned`) and a CA `Certificate` (`isCA: true`, `secretName: <agent>-tls-bridge-ca`, **no nameConstraints**) owned by the AgentRuntime. cert-manager then issues the Secret (`tls.crt`/`tls.key`/`ca.crt`). The hard pod-mount (Task 7) blocks pod start until that Secret exists — solving the ordering race.
 
-> **Contract with authbridge `FileSource` (rossocortex#522).** The bridge's
+> **Contract with authbridge `FileSource` (cortex#522).** The bridge's
 > `NewFileSource` now *validates* the mounted Secret at boot and **fails loud** if the
 > cert is not a CA (`IsCA=false` / missing `KeyUsageCertSign`) or if cert/key don't match.
 > So the `Certificate` below MUST keep `IsCA: true` **and** `Usages` including
@@ -550,7 +550,7 @@ Run: `cd rossoctl-operator && go test ./internal/webhook/injector/ -run TestEnsu
 
 ```go
 	if tlsBridgeMode == TLSBridgeModeEnabled {
-		// Consolidated schema (rossocortex#522): mode + ca_dir only.
+		// Consolidated schema (cortex#522): mode + ca_dir only.
 		// ca_dir = the mounted cert-manager Secret (tls.crt/tls.key/ca.crt by
 		// convention). No scope/ca_source/cert+key paths.
 		cfg["tls_bridge"] = map[string]interface{}{
@@ -785,7 +785,7 @@ git commit -s -m "test(tlsbridge): e2e — operator-provisioned CA decrypts agen
 
 The operator renders a `tls_bridge:` block only the post-#522 authbridge image understands (the `:9094` localhost-bind + `FileSource` validation are already in #522). So:
 
-1. **rossocortex**: merge PR #522 → tag a new `v0.x.0-alpha.N` authbridge/proxy-init image.
+1. **cortex**: merge PR #522 → tag a new `v0.x.0-alpha.N` authbridge/proxy-init image.
 2. **rossoctl-operator**: merge this Phase-2 PR → tag `v0.x.0-alpha.M`.
 3. **rossoctl**: bump the chart pins (operator image + authbridge sidecar images) to the new tags; this is where it becomes installable. Same operator→extensions→rossoctl order as the alpha.9 release.
 

--- a/operator/docs/operator-managed-client-registration.md
+++ b/operator/docs/operator-managed-client-registration.md
@@ -144,7 +144,7 @@ That shape is intentional for this controller:
 1. **Upgrade rossoctl-operator** to a version that includes the AuthBridge webhook and ClientRegistration controller.
 2. **Enable the webhook** via Helm values (`webhook.enable: true`) and optionally `--enable-operator-client-registration`.
 3. **Configure** `--spire-trust-domain` if agent namespaces use SPIRE.
-4. **Remove the rossocortex webhook** chart dependency from the umbrella chart once the operator webhook is verified.
+4. **Remove the cortex webhook** chart dependency from the umbrella chart once the operator webhook is verified.
 
 Since both the webhook and controller ship in the same binary, there is no ordering concern between them.
 
@@ -173,7 +173,7 @@ Switching from **sidecar** to **operator** registration may change the **client 
 
 The webhook and operator now live in one repository (`rossoctl-operator`). This document is the single **source of truth** for the contract. Constants are co-located in the `internal/webhook/injector` package to avoid drift between annotation/label keys.
 
-The webhook was previously part of `rossocortex`; migration tracking is in [rossocortex#266](https://github.com/rossoctl/rossocortex/issues/266).
+The webhook was previously part of `cortex`; migration tracking is in [cortex#266](https://github.com/rossoctl/cortex/issues/266).
 
 ---
 

--- a/operator/internal/webhook/config/defaults.go
+++ b/operator/internal/webhook/config/defaults.go
@@ -31,18 +31,18 @@ func CompiledDefaults() *PlatformConfig {
 		Images: ImageConfig{
 			// authbridge-envoy: combined image for envoy-sidecar mode
 			// (Envoy + ext_proc authbridge + spiffe-helper bundled).
-			EnvoyProxy: "ghcr.io/rossoctl/rossocortex/authbridge-envoy:latest",
+			EnvoyProxy: "ghcr.io/rossoctl/cortex/authbridge-envoy:latest",
 			// authbridge: combined image for proxy-sidecar mode (default
 			// deployment shape) — authbridge-proxy + spiffe-helper
 			// bundled, no Envoy, no gRPC.
-			AuthBridge: "ghcr.io/rossoctl/rossocortex/authbridge:latest",
+			AuthBridge: "ghcr.io/rossoctl/cortex/authbridge:latest",
 			// authbridge-lite: size-optimized variant for the "lite"
 			// mode. Same listener layout as AuthBridge but parsers
 			// (a2a/mcp/inference) are dropped.
-			AuthBridgeLite: "ghcr.io/rossoctl/rossocortex/authbridge-lite:latest",
+			AuthBridgeLite: "ghcr.io/rossoctl/cortex/authbridge-lite:latest",
 			// proxy-init: iptables init container, used by
 			// envoy-sidecar mode only.
-			ProxyInit:  "ghcr.io/rossoctl/rossocortex/proxy-init:latest",
+			ProxyInit:  "ghcr.io/rossoctl/cortex/proxy-init:latest",
 			PullPolicy: corev1.PullIfNotPresent,
 		},
 		Proxy: ProxyConfig{

--- a/operator/internal/webhook/injector/pod_mutator.go
+++ b/operator/internal/webhook/injector/pod_mutator.go
@@ -810,7 +810,7 @@ func perAgentEnvoyConfigMapName(crName string) string {
 //     also passed through so the plugin can derive jwks_url from the
 //     INTERNAL URL — the sidecar actually GETs this URL from inside
 //     the cluster, and the public hostname typically won't resolve
-//     from inside the mesh. See rossocortex#383 for why the
+//     from inside the mesh. See cortex#383 for why the
 //     jwt-validation plugin needs its own copy of these fields.
 //     Other plugin settings fall back to their own defaults —
 //     audience_file=/shared/client-id.txt, bypass_paths=standard

--- a/operator/internal/webhook/injector/pod_mutator_test.go
+++ b/operator/internal/webhook/injector/pod_mutator_test.go
@@ -1314,7 +1314,7 @@ func TestEnsurePerAgentConfigMap_EmptyBaseYAML_FallbackFromNsConfig(t *testing.T
 	// keycloak_url + keycloak_realm are passed to jwt-validation so the
 	// plugin derives jwks_url from the internal URL. Required for
 	// split-horizon deployments where `issuer` (public) isn't reachable
-	// from inside the pod. See rossocortex#383.
+	// from inside the pod. See cortex#383.
 	if got, want := jwtCfg["keycloak_url"], "http://keycloak:8080"; got != want {
 		t.Errorf("jwt-validation.config.keycloak_url = %v, want %v", got, want)
 	}

--- a/operator/scripts/operator-rollout.sh
+++ b/operator/scripts/operator-rollout.sh
@@ -7,7 +7,7 @@
 # with webhook, cert-manager, and metrics enabled. It:
 #   1. Detects container runtime (docker/podman)
 #   2. Builds the operator image with ko and loads into Kind
-#   3. Disables the old rossoctl-webhook MWC from rossocortex
+#   3. Disables the old rossoctl-webhook MWC from cortex
 #   4. Ensures CRDs are installed (Helm skips crds/ on upgrade)
 #   5. Cleans up immutable RBAC resources (roleRef conflicts)
 #   6. Deploys the operator via Helm with webhook enabled
@@ -487,5 +487,5 @@ echo "    3. Check: kubectl get pod <name> -o jsonpath='{.spec.containers[*].nam
 echo ""
 echo "  To revert to old webhook:"
 echo "    1. Delete operator MWC: kubectl delete mutatingwebhookconfiguration <name>"
-echo "    2. Re-deploy rossocortex chart (restores old MWC)"
+echo "    2. Re-deploy cortex chart (restores old MWC)"
 echo "============================================="

--- a/operator/test/e2e/README.md
+++ b/operator/test/e2e/README.md
@@ -15,7 +15,7 @@ End-to-end tests for the rossoctl-operator. The suite runs 25 specs:
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) — `brew install kubectl`
 - Container runtime: **Docker** or **Podman**
 
-The test suite auto-detects Docker vs Podman. No env vars needed. AuthBridge sidecar images (`authbridge-envoy`, `proxy-init`, `spiffe-helper`) are pulled from `ghcr.io/rossoctl/rossocortex` and loaded into Kind during setup.
+The test suite auto-detects Docker vs Podman. No env vars needed. AuthBridge sidecar images (`authbridge-envoy`, `proxy-init`, `spiffe-helper`) are pulled from `ghcr.io/rossoctl/cortex` and loaded into Kind during setup.
 
 ## Run
 

--- a/operator/test/e2e/e2e_suite_test.go
+++ b/operator/test/e2e/e2e_suite_test.go
@@ -57,15 +57,15 @@ var (
 	signerImage = "ghcr.io/rossoctl/operator/agentcard-signer:e2e-test"
 
 	// sidecarImages are the AuthBridge sidecar images to pull and load into Kind.
-	// rossocortex ships two combined images plus proxy-init:
+	// cortex ships two combined images plus proxy-init:
 	//   * authbridge-envoy: envoy-sidecar mode (Envoy + ext_proc + bundled spiffe-helper)
 	//   * authbridge:       proxy-sidecar mode (authbridge-proxy + bundled spiffe-helper)
 	//   * proxy-init:       iptables init container, envoy-sidecar mode only
 	// Spiffe-helper and client-registration are no longer separate images.
 	sidecarImages = []string{
-		"ghcr.io/rossoctl/rossocortex/authbridge-envoy:latest",
-		"ghcr.io/rossoctl/rossocortex/authbridge:latest",
-		"ghcr.io/rossoctl/rossocortex/proxy-init:latest",
+		"ghcr.io/rossoctl/cortex/authbridge-envoy:latest",
+		"ghcr.io/rossoctl/cortex/authbridge:latest",
+		"ghcr.io/rossoctl/cortex/proxy-init:latest",
 	}
 )
 

--- a/specs/003-mtls-transport-security/REVIEWERS.md
+++ b/specs/003-mtls-transport-security/REVIEWERS.md
@@ -20,7 +20,7 @@ No breaking changes. Existing deployments without SPIRE get a clear `MTLSReady=F
 
 The implementation leverages heavily what's already built:
 
-- **Authbridge** (rossocortex): mTLS is fully implemented across all proxy modes. No changes needed, only verification.
+- **Authbridge** (cortex): mTLS is fully implemented across all proxy modes. No changes needed, only verification.
 - **Operator**: The main work is (a) changing the `mTLSMode` kubebuilder default to `permissive`, (b) setting `rossoctl.io/mtls-mode` annotation on the pod template, (c) adding `MTLSReady` condition logic, (d) flipping flag defaults, and (e) webhook sets `MTLS_MODE` env var on authbridge container.
 - **SPIRE detection**: The controller checks whether spiffe-helper volume mounts exist in the workload's pod template. If absent while mTLS is enabled, `MTLSReady=False/SPIREUnavailable`.
 - **Rolling restart**: When `mTLSMode` changes, the `rossoctl.io/mtls-mode` annotation on the pod template changes, triggering a Kubernetes rolling restart. This is independent of the platform config hash (per PR #405).

--- a/specs/003-mtls-transport-security/brainstorm.md
+++ b/specs/003-mtls-transport-security/brainstorm.md
@@ -58,15 +58,15 @@ Istio, user-supplied certificates, and cert-manager are explicitly out of scope.
 
 **Answer: spiffe-helper sidecar (file-based, option a).** A spiffe-helper container fetches SVIDs from SPIRE and writes them as PEM files (`svid.pem`, `svid_key.pem`, `bundle.pem`) to a shared volume. The proxy reads these files and reloads on change. This is already implemented and deployed.
 
-**Why not go-spiffe SDK directly in the proxy (option b)?** Option (b) eliminates the spiffe-helper container and keeps certs in memory, but it ties the proxy to SPIRE's Workload API. Option (a) keeps the proxy certificate-source-agnostic — it reads PEM files regardless of where they came from. This preserves the sidecar-agnostic constraint and works across all authbridge modes. Option (b) is the long-term direction per `rossocortex#332` but is deferred.
+**Why not go-spiffe SDK directly in the proxy (option b)?** Option (b) eliminates the spiffe-helper container and keeps certs in memory, but it ties the proxy to SPIRE's Workload API. Option (a) keeps the proxy certificate-source-agnostic — it reads PEM files regardless of where they came from. This preserves the sidecar-agnostic constraint and works across all authbridge modes. Option (b) is the long-term direction per `cortex#332` but is deferred.
 
 ### Q7: What happens when mTLS is enabled but SPIRE is not deployed?
 
 **Answer: Fail clearly (option b).** If mTLS is the default and SPIRE isn't available, set the AgentRuntime to an error state with a clear condition. The operator must either deploy SPIRE or explicitly set `mTLSMode: disabled`. No silent fallback to plain HTTP — that would mask a real security gap.
 
-### Q8: Should this spec cover authbridge code changes in rossocortex?
+### Q8: Should this spec cover authbridge code changes in cortex?
 
-**Answer: Yes — cover both repos.** This spec defines the work required in both `rossoctl-operator` (controller, CRD, webhook) and `rossocortex` (authbridge proxy TLS contexts). The spec captures what needs to change in authbridge to enable mTLS (DownstreamTlsContext, UpstreamTlsContext, certificate loading). Downstreaming logistics (how to bring authbridge code into the product build) are explicitly out of scope — that's a separate spike.
+**Answer: Yes — cover both repos.** This spec defines the work required in both `rossoctl-operator` (controller, CRD, webhook) and `cortex` (authbridge proxy TLS contexts). The spec captures what needs to change in authbridge to enable mTLS (DownstreamTlsContext, UpstreamTlsContext, certificate loading). Downstreaming logistics (how to bring authbridge code into the product build) are explicitly out of scope — that's a separate spike.
 
 ### Q5: Istio integration?
 
@@ -144,9 +144,9 @@ Istio, user-supplied certificates, and cert-manager are explicitly out of scope.
 - **AgentCardReconciler**: has `EnableVerifiedFetch`, `AuthenticatedFetcher`, SVID expiry grace period, signature verification
 - **AgentCardNetworkPolicyReconciler**: creates NetworkPolicies based on signature verification (to be replaced by policy enforcement from AgentRuntime)
 
-## Authbridge (rossocortex) Current State
+## Authbridge (cortex) Current State
 
-The authbridge in `rossocortex` already has significant mTLS infrastructure:
+The authbridge in `cortex` already has significant mTLS infrastructure:
 
 ### Existing mTLS Code
 

--- a/specs/003-mtls-transport-security/plan.md
+++ b/specs/003-mtls-transport-security/plan.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-Enable mTLS as the default transport security for controller-to-agent and agent-to-agent communication. Authbridge mTLS is already implemented in rossocortex across all proxy modes (envoy, proxy-sidecar, lite). The remaining work is operator-side: the controller sets a `rossoctl.io/mtls-mode` annotation on the pod template (triggering rolling restart on change), the webhook reads `mTLSMode` from the AgentRuntime CR and sets `MTLS_MODE` env var on the authbridge container, defaulting `mTLSMode` to `permissive`, wiring `SpiffeFetcher` as the default card fetcher, adding `MTLSReady` status conditions, and deprecating the JWS signing pipeline flags. SPIRE is the sole certificate provider; Istio is out of scope.
+Enable mTLS as the default transport security for controller-to-agent and agent-to-agent communication. Authbridge mTLS is already implemented in cortex across all proxy modes (envoy, proxy-sidecar, lite). The remaining work is operator-side: the controller sets a `rossoctl.io/mtls-mode` annotation on the pod template (triggering rolling restart on change), the webhook reads `mTLSMode` from the AgentRuntime CR and sets `MTLS_MODE` env var on the authbridge container, defaulting `mTLSMode` to `permissive`, wiring `SpiffeFetcher` as the default card fetcher, adding `MTLSReady` status conditions, and deprecating the JWS signing pipeline flags. SPIRE is the sole certificate provider; Istio is out of scope.
 
 ## Technical Context
 
@@ -79,10 +79,10 @@ operator/
     └── integration/                # MODIFY: mTLS integration test
 ```
 
-### Source Code (rossocortex — verification only)
+### Source Code (cortex — verification only)
 
 ```text
-rossocortex/authbridge/
+cortex/authbridge/
 ├── cmd/
 │   ├── authbridge-envoy/main.go    # VERIFY: mTLS wiring exists
 │   ├── authbridge-proxy/main.go    # VERIFIED: mTLS wiring complete

--- a/specs/003-mtls-transport-security/spec.md
+++ b/specs/003-mtls-transport-security/spec.md
@@ -26,7 +26,7 @@ All status updates (transport security, attested SPIFFE ID, mTLS readiness condi
 - AgentCard CRD removal — separate migration spec
 - Cross-cluster agent federation — future work
 - Bearer token / OAuth2 authorization — handled by authbridge, orthogonal to mTLS
-- Downstreaming logistics for rossocortex — separate spike
+- Downstreaming logistics for cortex — separate spike
 - Webhook injector changes — existing spiffe-helper injection is sufficient
 
 ## Clarifications
@@ -42,7 +42,7 @@ All status updates (transport security, attested SPIFFE ID, mTLS readiness condi
 
 ## Current State — What Already Exists
 
-### Authbridge (rossocortex) — DONE
+### Authbridge (cortex) — DONE
 
 mTLS is fully implemented in authbridge across all three proxy modes on main:
 
@@ -206,7 +206,7 @@ The controller detects SPIRE availability by checking for the spiffe-helper init
 ## Assumptions
 
 - SPIRE is deployed in the cluster and the SPIRE agent socket is accessible to both the controller pod and agent workload pods.
-- The authbridge mTLS implementation in rossocortex (on main) is stable and tested.
+- The authbridge mTLS implementation in cortex (on main) is stable and tested.
 - Each agent workload has exactly one Pod (one-agent-per-pod model), so pod identity equals agent identity (SPIFFE ID).
 - The spiffe-helper sidecar is already injected by the webhook when `mTLSMode` is non-disabled — no changes to injection logic are needed.
 - The authbridge sidecar supports an `MTLS_MODE` environment variable to configure TLS listener mode at startup.
@@ -224,7 +224,7 @@ The controller detects SPIRE availability by checking for the spiffe-helper init
 | `cmd/main.go` | Default `--enable-verified-fetch` to `true`; default signing flags to `false`; add deprecation log warnings |
 | `config/crd/bases/` | Regenerate CRD manifests if type changes |
 
-### rossocortex (verification + testing)
+### cortex (verification + testing)
 
 | File | Change |
 |------|--------|

--- a/specs/003-mtls-transport-security/tasks.md
+++ b/specs/003-mtls-transport-security/tasks.md
@@ -146,12 +146,12 @@ The following are already implemented and do NOT need new code:
 
 ---
 
-## Phase 7: Authbridge Verification (rossocortex)
+## Phase 7: Authbridge Verification (cortex)
 
 **Purpose**: Verify authbridge mTLS is complete and matches operator expectations
 
 - [x] T019 [DONE] Envoy mTLS wiring confirmed — webhook injector has `MTLSEnabled`, `MTLSPermissive`, `MTLSStrict` template fields driving envoy TLS contexts.
-- [ ] T020 [P] Verify the `cfg.MTLS` config schema in `authbridge/authlib/config/config.go` matches what the operator generates. Specifically: does the authbridge expect `mtls:\n  mode: permissive` or a different shape? Clone `rossocortex` and check.
+- [ ] T020 [P] Verify the `cfg.MTLS` config schema in `authbridge/authlib/config/config.go` matches what the operator generates. Specifically: does the authbridge expect `mtls:\n  mode: permissive` or a different shape? Clone `cortex` and check.
 - [ ] T021 Add mTLS integration tests (if not already present in authbridge). Test: (a) permissive accepts TLS + plaintext; (b) strict rejects plaintext; (c) cert rotation.
 
 **Checkpoint**: Authbridge config contract verified.

--- a/token-broker/cmd/main.go
+++ b/token-broker/cmd/main.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/jwtvalidation/validation"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/jwtvalidation/validation"
 	"github.com/rossoctl/token-broker/internal/api"
 	"github.com/rossoctl/token-broker/internal/cache"
 	"github.com/rossoctl/token-broker/internal/core"

--- a/token-broker/docs/API_SPECIFICATION.md
+++ b/token-broker/docs/API_SPECIFICATION.md
@@ -71,7 +71,7 @@ The AuthBridge Sidecar calls the Token Broker to obtain OAuth tokens for resourc
 
 **Purpose**: Request an OAuth token for a specific resource server using JWT-based authentication. This call blocks until the token is available or the request times out.
 
-**Called By**: AuthBridge Sidecar (from rossocortex/authbridge)
+**Called By**: AuthBridge Sidecar (from cortex/authbridge)
 
 **Authentication**: JWT Bearer token containing user ID and session key
 

--- a/token-broker/go.mod
+++ b/token-broker/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/google/uuid v1.6.0
-	github.com/rossoctl/rossocortex/authbridge/authlib v0.0.0-20260619001334-ce3417655ee8
+	github.com/rossoctl/cortex/authbridge/authlib v0.0.0-20260619001334-ce3417655ee8
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/token-broker/internal/api/handlers.go
+++ b/token-broker/internal/api/handlers.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/jwtvalidation/validation"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/jwtvalidation/validation"
 	"github.com/rossoctl/token-broker/internal/auth"
 	"github.com/rossoctl/token-broker/internal/core"
 )


### PR DESCRIPTION
## Summary
Follow-up to the Rossoctl rename. #485 merged the rename + go.sum fixes, but **not** the later rossocortex→cortex change; separately, `.claude/skills` files that landed on `main` after the branch still referenced `kagenti`.

- **rossocortex → cortex** (19 files): token-broker require `github.com/rossoctl/rossocortex/authbridge/authlib` → `.../cortex/...`; webhook image defaults + e2e `ghcr.io/rossoctl/rossocortex/*` → `ghcr.io/rossoctl/cortex/*`
- **Residual `kagenti → rossoctl`** in `.claude/skills` (9 files): `/tmp/kagenti/*` → `/tmp/rossoctl/*`, `kagenti-operator-controller-manager` → `rossoctl-operator-controller-manager`, brand

## Verification
- `go build` ✅, `go vet` ✅, `internal/webhook/config` test ✅
- `git grep` clean of `kagenti` and `rossocortex`

## Known cross-repo dependency
`token-broker` depends on `github.com/rossoctl/cortex/authbridge/authlib`, which resolves once cortex #680 merges and its authlib module publishes under the `cortex` path.

## Related issue(s)
Related to #1972