### PR TITLE
Fix(charts): correct operator controller image to rossoctl-operator

### DIFF
--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -3,7 +3,7 @@ controllerManager:
   replicas: 1
   container:
     image:
-      repository: ghcr.io/rossoctl/operator/operator
+      repository: ghcr.io/rossoctl/operator/rossoctl-operator
       tag: __PLACEHOLDER__
       pullPolicy: IfNotPresent
     args:


### PR DESCRIPTION
## Summary

Fix the operator-chart controller image reference left inconsistent by the
`kagenti → rossoctl` rename.

The rename renamed the **repo** to `operator` and the **controller image** to
`rossoctl-operator`, but `charts/operator/values.yaml` set
`controllerManager.container.image.repository` to the **repo** name
(`ghcr.io/rossoctl/operator/operator`) — which does not exist.

## Impact

`rossoctl-controller-manager` hits `ImagePullBackOff` (403 — image not found)
on platform install, failing the Kind e2e on **both `main` and the
`v0.7.0-alpha.6` PR**. The real image `ghcr.io/rossoctl/operator/rossoctl-operator`
publishes correctly; only the chart reference was wrong.

## Fix

Point `image.repository` at the actual published image:
`ghcr.io/rossoctl/operator/rossoctl-operator`.

## After merge

Re-cut operator `v0.3.0-alpha.10`, then re-pin the platform (`rossoctl/rossoctl`)
to `alpha.10` — the Kind e2e should then install cleanly.

Assisted-By: Claude Code
