### PR TITLE
docs: Fix broken discussions link in developer guide

### DIFF
--- a/operator/docs/dev.md
+++ b/operator/docs/dev.md
@@ -589,7 +589,7 @@ kubectl delete agentcard my-agent-deployment-card --grace-period=0 --force
 ## Getting Help
 
 - **GitHub Issues**: [Report bugs or request features](https://github.com/rossoctl/operator/issues)
-- **Discussions**: [Ask questions](https://github.com/rossoctl/operator/discussions)
+- **Discussions**: [Ask questions](https://github.com/rossoctl/rossoctl/discussions)
 - **Contributing**: See [CONTRIBUTING.md](../CONTRIBUTING.md)
 
 ---


### PR DESCRIPTION
Fix the broken **Discussions** link in the developer guide's *Getting Help* section.

`operator/docs/dev.md` linked to `https://github.com/rossoctl/operator/discussions`, but Discussions are disabled on `rossoctl/operator`, so that link 404s (the original report in #494). This repoints it to the umbrella project's Discussions page, `https://github.com/rossoctl/rossoctl/discussions`, which is enabled and is the correct home for project-wide questions.

Single-file, single-line change:

| File | Old URL | New URL |
|------|---------|---------|
| `operator/docs/dev.md` | `https://github.com/rossoctl/operator/discussions` | `https://github.com/rossoctl/rossoctl/discussions` |

Supersedes #498, which was generated against a stale pre-rename base and inadvertently bundled an org-rename revert and pinned-action downgrades across 13 files. This PR is the genuine 1-file fix from current `main`, with the link pointing at the current `rossoctl` org.

Fixes #494
