### PR TITLE
Fix: 🐛 Use upstream ghcr.io/spiffe/spiffe-helper image for operator sidecar

### DIFF
--- a/charts/operator/templates/manager/manager.yaml
+++ b/charts/operator/templates/manager/manager.yaml
@@ -193,7 +193,7 @@ spec:
             {{- end }}
         {{- if and .Values.spiffe .Values.spiffe.enabled .Values.spiffe.operatorAuth .Values.spiffe.operatorAuth.enabled }}
         - name: spiffe-helper
-          image: ghcr.io/spiffe/spiffe-helper:latest
+          image: ghcr.io/spiffe/spiffe-helper:0.11.0
           imagePullPolicy: IfNotPresent
           args:
             - "-config"

--- a/charts/operator/templates/manager/manager.yaml
+++ b/charts/operator/templates/manager/manager.yaml
@@ -193,7 +193,7 @@ spec:
             {{- end }}
         {{- if and .Values.spiffe .Values.spiffe.enabled .Values.spiffe.operatorAuth .Values.spiffe.operatorAuth.enabled }}
         - name: spiffe-helper
-          image: ghcr.io/rossoctl/cortex/spiffe-helper:latest
+          image: ghcr.io/spiffe/spiffe-helper:latest
           imagePullPolicy: IfNotPresent
           args:
             - "-config"


### PR DESCRIPTION
## Summary

The operator's own `spiffe-helper` sidecar (injected into `rossoctl-controller-manager` when `spiffe.operatorAuth.enabled=true`) points at `ghcr.io/rossoctl/cortex/spiffe-helper:latest`, which was never published (`403 Forbidden` on pull). The operator pod gets stuck at `1/2 Ready` and never obtains a JWT-SVID, so operator SPIFFE auth never actually authenticates at runtime — even though the bootstrap Job (separately, in rossoctl/rossoctl) successfully registers the Keycloak client.

The container's CLI args (`-config /etc/spiffe-helper/config.hcl`) match the real upstream SPIFFE project tool exactly, and an earlier branch already used `ghcr.io/spiffe/spiffe-helper:0.11.0` before this regressed to the broken `rossoctl/cortex` path.

Key changes:
- `charts/operator/templates/manager/manager.yaml:196` — swap `ghcr.io/rossoctl/cortex/spiffe-helper:latest` → `ghcr.io/spiffe/spiffe-helper:0.11.0`.

Pinned to a specific version rather than `:latest`: unlike `authbridge`/`envoyProxy`/`authbridgeLite`/`proxyInit` (rossoctl-built images that default to `:latest` at this chart level and get pinned downstream by the `rossoctl/rossoctl` consumer chart), `spiffe-helper` is a genuine third-party upstream dependency with no downstream pin step — so it's tagged directly here to the current latest stable release (`0.11.0`, confirmed via `docker manifest inspect`).

Verified via `helm template` that the rendered `spiffe-helper` container now uses the correct pinned image, and confirmed on a live Kind cluster (loading a substitute image manually) that the operator comes up `2/2 Ready` and logs `"SPIFFE ID authentication enabled: using JWT-SVID for client registration"` once this image is resolvable.

## Related issue(s)

Fixes rossoctl/rossoctl#2334