### PR TITLE
Fix: stop rendering duplicate rossoctl-authbridge SCC (rossoctl#2354)

### DIFF
--- a/charts/operator/templates/rbac/authbridge-scc.yaml
+++ b/charts/operator/templates/rbac/authbridge-scc.yaml
@@ -1,62 +1,12 @@
 {{- if and .Values.rbac.enable (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
-# SCC for AuthBridge proxy-sidecar containers in agent namespaces.
-# Custom SCC needed because restricted-v2 does not permit CSI volumes
-# (csi.spiffe.io for SPIRE workload API).
-# groups is empty -- the operator creates per-namespace RoleBindings at runtime.
-apiVersion: security.openshift.io/v1
-kind: SecurityContextConstraints
-metadata:
-  name: rossoctl-authbridge
-  labels:
-    {{- include "chart.labels" . | nindent 4 }}
-    app.kubernetes.io/component: authbridge
-groups: []
-allowHostDirVolumePlugin: false
-allowHostIPC: false
-allowHostNetwork: false
-allowHostPID: false
-allowHostPorts: false
-allowPrivilegedContainer: false
-allowPrivilegeEscalation: false
-allowedCapabilities: []
-defaultAddCapabilities: []
-requiredDropCapabilities:
-  - ALL
-fsGroup:
-  type: RunAsAny
-runAsUser:
-  type: MustRunAsNonRoot
-seLinuxContext:
-  type: MustRunAs
-supplementalGroups:
-  type: RunAsAny
-seccompProfiles:
-  - runtime/default
-volumes:
-  - configMap
-  - csi
-  - downwardAPI
-  - emptyDir
-  - ephemeral
-  - persistentVolumeClaim
-  - projected
-  - secret
----
-# ClusterRole granting "use" on the rossoctl-authbridge SCC.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: system:openshift:scc:rossoctl-authbridge
-  labels:
-    {{- include "chart.labels" . | nindent 4 }}
-    app.kubernetes.io/component: authbridge
-rules:
-  - apiGroups: ["security.openshift.io"]
-    resources: ["securitycontextconstraints"]
-    resourceNames: ["rossoctl-authbridge"]
-    verbs: ["use"]
----
-# Grants the operator SA "use" on the SCC so it can delegate via RoleBindings.
+# The AuthBridge SecurityContextConstraints and its "use" ClusterRole are owned by the
+# rossoctl platform chart (charts/rossoctl/templates/rossoctl-authbridge-scc.yaml), which
+# ships a permissive superset spec. Rendering them here too produced a second, conflicting
+# SCC in a combined install and blocked OpenShift install (rossoctl#2354). This chart keeps
+# only the binding that grants the operator SA "use" of that SCC, so the controller
+# (ensureNamespaceSCCBinding) can delegate via per-namespace RoleBindings without an RBAC
+# privilege-escalation error. The roleRef resolves to the platform-provided ClusterRole of
+# the same name.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
## Summary

Fixes the OpenShift install-blocker **rossoctl/rossoctl#2354**.

This chart rendered a second `rossoctl-authbridge` SCC (+ its `use` ClusterRole) that **duplicates and conflicts** with the ones the rossoctl **platform chart** has shipped since 2026-03-27. In a combined rossoctl install (this chart is pulled as a subchart), two docs declare the same cluster-scoped SCC → Helm merge-patch adoption fails on OpenShift → **install hard-blocks**. Even when de-duped to *this* chart's spec, agent pods then fail admission because this spec is restrictive (`MustRunAsNonRoot`, `allowedCapabilities:[]`, drop `ALL`) and can't admit the injected `proxy-init` (NET_ADMIN/NET_RAW, root).

The platform chart's SCC is a **strict superset** — identical `volumes` (incl. `csi` for SPIRE), and more permissive only where `proxy-init` requires it — so dropping this chart's copy loses nothing and also fixes the admission failure.

## Change

`charts/operator/templates/rbac/authbridge-scc.yaml`:
- **Remove** the `SecurityContextConstraints` and the `system:openshift:scc:rossoctl-authbridge` ClusterRole (both owned by the platform chart).
- **Keep** the `ClusterRoleBinding` granting the operator SA `use` of the SCC — its `roleRef` resolves to the platform-provided ClusterRole of the same name, so `ensureNamespaceSCCBinding`'s per-namespace delegation keeps working without an RBAC privilege-escalation error.

Net in a combined install: exactly one (permissive, platform) SCC + one ClusterRole; operator retains delegation. No new permissions vs v0.6.1.

## Standalone note (maintainer decision)

If this chart is meant to be installed **standalone on OpenShift** (without the platform chart), it still needs its own SCC. In that case, prefer gating the removed objects behind a `scc.create` value (default `true`) that rossoctl sets `false`, and make the standalone SCC spec permissive — rather than deleting outright. Happy to switch to that approach if standalone-via-Helm on OCP is a supported path. (The kustomize `config/security/rossoctl-authbridge-scc.yaml` path is unaffected.)

## Rollout

After merge: cut a new operator-chart release → re-pin `operator-chart` in `rossoctl` `charts/rossoctl/Chart.yaml` + `helm dependency update`.

Refs rossoctl/rossoctl#2354. Context (regression trace + field-by-field SCC comparison) in that issue.

Assisted-By: Claude Code